### PR TITLE
refactor: OAuth プロバイダ抽象化 — Provider IF 導入と GitHub 実装の分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+すべての変更は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に従い、
+バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に従う。
+
+## [Unreleased]
+
+### Changed
+
+- `internal/auth` を `Provider` インターフェースで抽象化。GitHub OAuth 通信ロジックを `internal/auth/provider/github.go` に分離した。外部 IF（環境変数・エンドポイント・OAuth フロー）は変更なし（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
+- リバースプロキシが上流 MCP サービスに送出するヘッダに `X-Authenticated-User` を追加。`X-GitHub-Login` も互換のため引き続き送出する（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
+
+### Internal
+
+- `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
+- `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 	"github.com/scottlz0310/mcp-gateway/internal/proxy"
 	"github.com/scottlz0310/mcp-gateway/internal/router"
@@ -54,15 +55,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	oauthHandler := auth.NewHandler(auth.Config{
-		GitHubClientID:     cfg.githubClientID,
-		GitHubClientSecret: cfg.githubClientSecret,
-		BaseURL:            cfg.baseURL,
-		Scopes:             cfg.oauthScopes,
-		SessionTTL:         time.Duration(cfg.sessionTTLMin) * time.Minute,
-		CacheTTL:           time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
-		ExpiresIn:          time.Duration(cfg.tokenExpiresInSec) * time.Second,
+	prov, err := provider.New(provider.Config{
+		Kind:         "github",
+		ClientID:     cfg.githubClientID,
+		ClientSecret: cfg.githubClientSecret,
+		RedirectURI:  strings.TrimRight(cfg.baseURL, "/") + "/callback",
+		Scopes:       cfg.oauthScopes,
 	})
+	if err != nil {
+		slog.Error("provider init failed", "err", err)
+		os.Exit(1)
+	}
+
+	oauthHandler := auth.NewHandler(auth.Config{
+		BaseURL:    cfg.baseURL,
+		SessionTTL: time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:   time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:  time.Duration(cfg.tokenExpiresInSec) * time.Second,
+	}, prov)
 
 	authMiddleware := middleware.Auth(oauthHandler)
 
@@ -97,6 +107,7 @@ func main() {
 	slog.Info("mcp-gateway starting",
 		"addr", addr,
 		"base_url", cfg.baseURL,
+		"provider", prov.Name(),
 		"routes", len(routes),
 	)
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,16 +11,15 @@ import (
 	"time"
 
 	"log/slog"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
 )
 
-var githubClient = &http.Client{Timeout: 15 * time.Second}
-
-// Config holds OAuth façade configuration.
+// Config holds OAuth façade configuration. Provider-specific fields (client
+// credentials, scope) live on the Provider implementation; this struct only
+// carries gateway-wide settings.
 type Config struct {
-	GitHubClientID       string
-	GitHubClientSecret   string
 	BaseURL              string
-	Scopes               string
 	SessionTTL           time.Duration
 	CacheTTL             time.Duration
 	AllowedRedirectHosts []string
@@ -31,23 +29,16 @@ type Config struct {
 	ExpiresIn time.Duration
 }
 
-// UpstreamError represents a failure contacting an upstream service.
-type UpstreamError struct {
-	err error
-}
-
-func (e *UpstreamError) Error() string         { return e.err.Error() }
-func (e *UpstreamError) Unwrap() error         { return e.err }
-func (e *UpstreamError) IsUpstreamError() bool { return true }
-
-// Handler implements the OAuth façade endpoints.
+// Handler implements the OAuth façade endpoints, delegating provider-specific
+// operations to a provider.Provider.
 type Handler struct {
-	cfg   Config
-	store *Store
+	cfg      Config
+	provider provider.Provider
+	store    *Store
 }
 
-// NewHandler creates a new OAuth Handler with the given configuration.
-func NewHandler(cfg Config) *Handler {
+// NewHandler creates a new OAuth Handler with the given configuration and provider.
+func NewHandler(cfg Config, p provider.Provider) *Handler {
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
@@ -56,8 +47,9 @@ func NewHandler(cfg Config) *Handler {
 		cfg.ExpiresIn = 90 * 24 * time.Hour
 	}
 	return &Handler{
-		cfg:   cfg,
-		store: NewStore(cfg.SessionTTL, cfg.CacheTTL),
+		cfg:      cfg,
+		provider: p,
+		store:    NewStore(cfg.SessionTTL, cfg.CacheTTL),
 	}
 }
 
@@ -77,7 +69,7 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 }
 
 // Register implements RFC 7591 Dynamic Client Registration (pseudo).
-// Always returns the pre-configured GitHub OAuth App client_id.
+// Always returns the configured upstream OAuth App client_id.
 func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 
@@ -94,7 +86,7 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"client_id":                  h.cfg.GitHubClientID,
+		"client_id":                  h.provider.ClientID(),
 		"client_id_issued_at":        time.Now().Unix(),
 		"client_secret_expires_at":   0,
 		"token_endpoint_auth_method": "none",
@@ -113,7 +105,7 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// Authorize redirects the MCP client to GitHub OAuth.
+// Authorize redirects the MCP client to the configured OAuth provider.
 func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	state := q.Get("state")
@@ -150,18 +142,11 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 
 	h.store.SaveSession(state, redirectURI, codeChallenge)
 
-	ghURL, _ := url.Parse("https://github.com/login/oauth/authorize")
-	ghq := ghURL.Query()
-	ghq.Set("client_id", h.cfg.GitHubClientID)
-	ghq.Set("redirect_uri", h.cfg.BaseURL+"/callback")
-	ghq.Set("state", state)
-	ghq.Set("scope", h.cfg.Scopes)
-	ghURL.RawQuery = ghq.Encode()
-
-	http.Redirect(w, r, ghURL.String(), http.StatusFound)
+	http.Redirect(w, r, h.provider.AuthorizeURL(state, codeChallenge), http.StatusFound)
 }
 
-// Callback receives GitHub's authorization code and exchanges it for an access token.
+// Callback receives the provider's authorization code and exchanges it for
+// an access token via the Provider implementation.
 func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	code := q.Get("code")
@@ -176,14 +161,14 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessToken, grantedScope, err := h.exchangeGitHubCode(r.Context(), code)
+	accessToken, scopes, err := h.provider.ExchangeCode(r.Context(), code)
 	if err != nil {
-		slog.Error("GitHub token exchange failed", "err", err)
+		slog.Error("OAuth token exchange failed", "provider", h.provider.Name(), "err", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
 
-	internalCode, err := h.store.CompleteCallback(state, accessToken, grantedScope)
+	internalCode, err := h.store.CompleteCallback(state, accessToken, joinScopes(scopes))
 	if err != nil {
 		slog.Error("session completion failed", "err", err)
 		http.Error(w, "invalid state", http.StatusBadRequest)
@@ -243,42 +228,18 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(tokenResp)
 }
 
-// ValidateToken checks the bearer token against GitHub API (with cache).
+// ValidateToken checks the bearer token via the provider (with cache).
+// The returned subject is the Identity.Subject from the provider.
 func (h *Handler) ValidateToken(ctx context.Context, token string) (string, error) {
-	if login, ok := h.store.LookupToken(token); ok {
-		return login, nil
+	if subject, ok := h.store.LookupToken(token); ok {
+		return subject, nil
 	}
-
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/user", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := githubClient.Do(req)
+	id, err := h.provider.ValidateToken(ctx, token)
 	if err != nil {
-		return "", &UpstreamError{err: fmt.Errorf("GitHub API unreachable: %w", err)}
+		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode >= 500 {
-			return "", &UpstreamError{err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
-		}
-		return "", fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", &UpstreamError{err: fmt.Errorf("reading GitHub user response: %w", err)}
-	}
-	var user struct {
-		Login string `json:"login"`
-	}
-	if err := json.Unmarshal(body, &user); err != nil || user.Login == "" {
-		return "", fmt.Errorf("unexpected GitHub user response")
-	}
-
-	h.store.CacheToken(token, user.Login)
-	return user.Login, nil
+	h.store.CacheToken(token, id.Subject)
+	return id.Subject, nil
 }
 
 // InvalidateCachedToken delegates cache invalidation to the underlying store.
@@ -286,50 +247,17 @@ func (h *Handler) InvalidateCachedToken(token string) {
 	h.store.InvalidateCachedToken(token)
 }
 
-func (h *Handler) exchangeGitHubCode(ctx context.Context, code string) (string, string, error) {
-	form := url.Values{
-		"client_id":     {h.cfg.GitHubClientID},
-		"client_secret": {h.cfg.GitHubClientSecret},
-		"code":          {code},
-		"redirect_uri":  {h.cfg.BaseURL + "/callback"},
-	}
-
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://github.com/login/oauth/access_token",
-		strings.NewReader(form.Encode()))
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := githubClient.Do(req)
-	if err != nil {
-		return "", "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return "", "", fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
-	}
-
-	var result struct {
-		AccessToken string `json:"access_token"`
-		Scope       string `json:"scope"`
-		Error       string `json:"error"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", "", fmt.Errorf("decoding GitHub OAuth response: %w", err)
-	}
-	if result.Error != "" {
-		return "", "", fmt.Errorf("GitHub OAuth error: %s", result.Error)
-	}
-	if result.AccessToken == "" {
-		return "", "", fmt.Errorf("empty access_token from GitHub")
-	}
-	return result.AccessToken, result.Scope, nil
-}
-
 func isAllowedRedirectHost(hostname string, allowed []string) bool {
 	return slices.Contains(allowed, hostname)
+}
+
+// joinScopes serializes the provider's scope slice for OAuth token responses.
+// The comma delimiter preserves backward compatibility with the previous
+// GitHub-coupled implementation, which forwarded GitHub's raw scope string.
+// RFC 6749 §3.3 specifies space delimiter; normalization to that form is
+// deferred to a separate change to keep this refactor non-breaking.
+func joinScopes(scopes []string) string {
+	return strings.Join(scopes, ",")
 }
 
 func oauthError(w http.ResponseWriter, code, description string, status int) {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -38,7 +38,11 @@ type Handler struct {
 }
 
 // NewHandler creates a new OAuth Handler with the given configuration and provider.
+// It panics if p is nil, because all handler methods dereference the provider.
 func NewHandler(cfg Config, p provider.Provider) *Handler {
+	if p == nil {
+		panic("auth.NewHandler: provider must not be nil")
+	}
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -7,18 +7,23 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
 )
 
 func newTestHandler() *Handler {
-	return NewHandler(Config{
-		GitHubClientID:     "test-client-id",
-		GitHubClientSecret: "test-client-secret",
-		BaseURL:            "http://localhost:8080",
-		Scopes:             "repo,user",
-		SessionTTL:         10 * time.Minute,
-		CacheTTL:           5 * time.Minute,
-		ExpiresIn:          90 * 24 * time.Hour,
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
 	})
+	return NewHandler(Config{
+		BaseURL:    "http://localhost:8080",
+		SessionTTL: 10 * time.Minute,
+		CacheTTL:   5 * time.Minute,
+		ExpiresIn:  90 * 24 * time.Hour,
+	}, p)
 }
 
 func TestDiscovery(t *testing.T) {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -125,6 +125,15 @@ func TestAuthorizeDisallowedRedirectHost(t *testing.T) {
 	}
 }
 
+func TestNewHandlerPanicsOnNilProvider(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for nil provider")
+		}
+	}()
+	NewHandler(Config{}, nil)
+}
+
 func TestAuthorizeRedirectsToGitHub(t *testing.T) {
 	h := newTestHandler()
 	r := httptest.NewRequest(http.MethodGet,

--- a/internal/auth/provider/errors.go
+++ b/internal/auth/provider/errors.go
@@ -1,0 +1,13 @@
+package provider
+
+// UpstreamError represents a transient failure contacting an OAuth provider's
+// API (network error, 5xx response). Callers (e.g. middleware) use this to
+// return 503 Service Unavailable instead of 401 Unauthorized so that clients
+// retry rather than treat the token as invalid.
+type UpstreamError struct {
+	Err error
+}
+
+func (e *UpstreamError) Error() string         { return e.Err.Error() }
+func (e *UpstreamError) Unwrap() error         { return e.Err }
+func (e *UpstreamError) IsUpstreamError() bool { return true }

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -28,8 +28,8 @@ func New(cfg Config) (Provider, error) {
 			return nil, fmt.Errorf("github provider requires RedirectURI")
 		}
 		u, err := url.Parse(cfg.RedirectURI)
-		if err != nil || !u.IsAbs() || (u.Scheme != "http" && u.Scheme != "https") {
-			return nil, fmt.Errorf("github provider requires an absolute http/https RedirectURI, got %q", cfg.RedirectURI)
+		if err != nil || !u.IsAbs() || u.Host == "" || u.Fragment != "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return nil, fmt.Errorf("github provider requires an absolute http/https RedirectURI with a host and no fragment, got %q", cfg.RedirectURI)
 		}
 		return NewGitHub(GitHubConfig{
 			ClientID:     cfg.ClientID,

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -1,6 +1,9 @@
 package provider
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
 // Config carries the provider-agnostic configuration consumed by New.
 // Provider-specific fields are added as additional providers are introduced.
@@ -20,6 +23,13 @@ func New(cfg Config) (Provider, error) {
 	case "github", "":
 		if cfg.ClientID == "" || cfg.ClientSecret == "" {
 			return nil, fmt.Errorf("github provider requires ClientID and ClientSecret")
+		}
+		if cfg.RedirectURI == "" {
+			return nil, fmt.Errorf("github provider requires RedirectURI")
+		}
+		u, err := url.Parse(cfg.RedirectURI)
+		if err != nil || !u.IsAbs() || (u.Scheme != "http" && u.Scheme != "https") {
+			return nil, fmt.Errorf("github provider requires an absolute http/https RedirectURI, got %q", cfg.RedirectURI)
 		}
 		return NewGitHub(GitHubConfig{
 			ClientID:     cfg.ClientID,

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -1,0 +1,33 @@
+package provider
+
+import "fmt"
+
+// Config carries the provider-agnostic configuration consumed by New.
+// Provider-specific fields are added as additional providers are introduced.
+type Config struct {
+	// Kind selects the provider implementation: "github".
+	Kind string
+
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	Scopes       string
+}
+
+// New instantiates the Provider implementation selected by cfg.Kind.
+func New(cfg Config) (Provider, error) {
+	switch cfg.Kind {
+	case "github", "":
+		if cfg.ClientID == "" || cfg.ClientSecret == "" {
+			return nil, fmt.Errorf("github provider requires ClientID and ClientSecret")
+		}
+		return NewGitHub(GitHubConfig{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURI:  cfg.RedirectURI,
+			Scopes:       cfg.Scopes,
+		}), nil
+	default:
+		return nil, fmt.Errorf("unsupported OAuth provider %q", cfg.Kind)
+	}
+}

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -56,6 +56,9 @@ func NewGitHub(cfg GitHubConfig) Provider {
 	if err != nil {
 		panic(fmt.Sprintf("provider.NewGitHub: invalid AuthorizeURL %q: %v", cfg.AuthorizeURL, err))
 	}
+	if !authorizeURL.IsAbs() || (authorizeURL.Scheme != "http" && authorizeURL.Scheme != "https") {
+		panic(fmt.Sprintf("provider.NewGitHub: AuthorizeURL %q must be an absolute http/https URL", cfg.AuthorizeURL))
+	}
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 15 * time.Second}

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -35,11 +35,13 @@ type GitHubConfig struct {
 }
 
 type githubProvider struct {
-	cfg    GitHubConfig
-	client *http.Client
+	cfg          GitHubConfig
+	client       *http.Client
+	authorizeURL *url.URL // pre-parsed at construction to catch misconfigurations early
 }
 
 // NewGitHub returns a Provider backed by GitHub OAuth 2.0.
+// It panics if AuthorizeURL is not a valid URL, to catch misconfigurations at startup.
 func NewGitHub(cfg GitHubConfig) Provider {
 	if cfg.AuthorizeURL == "" {
 		cfg.AuthorizeURL = githubAuthorizeURL
@@ -50,18 +52,22 @@ func NewGitHub(cfg GitHubConfig) Provider {
 	if cfg.UserAPI == "" {
 		cfg.UserAPI = githubUserAPI
 	}
+	authorizeURL, err := url.Parse(cfg.AuthorizeURL)
+	if err != nil {
+		panic(fmt.Sprintf("provider.NewGitHub: invalid AuthorizeURL %q: %v", cfg.AuthorizeURL, err))
+	}
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 15 * time.Second}
 	}
-	return &githubProvider{cfg: cfg, client: client}
+	return &githubProvider{cfg: cfg, client: client, authorizeURL: authorizeURL}
 }
 
 func (p *githubProvider) Name() string     { return "github" }
 func (p *githubProvider) ClientID() string { return p.cfg.ClientID }
 
 func (p *githubProvider) AuthorizeURL(state, codeChallenge string) string {
-	u, _ := url.Parse(p.cfg.AuthorizeURL)
+	u := *p.authorizeURL // shallow copy to avoid mutating the stored URL
 	q := u.Query()
 	q.Set("client_id", p.cfg.ClientID)
 	q.Set("redirect_uri", p.cfg.RedirectURI)
@@ -82,8 +88,11 @@ func (p *githubProvider) ExchangeCode(ctx context.Context, code string) (string,
 		"redirect_uri":  {p.cfg.RedirectURI},
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		p.cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", nil, &UpstreamError{Err: fmt.Errorf("building GitHub token request: %w", err)}
+	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -119,7 +128,10 @@ func (p *githubProvider) ExchangeCode(ctx context.Context, code string) (string,
 }
 
 func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Identity, error) {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.UserAPI, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.UserAPI, nil)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("building GitHub user request: %w", err)}
+	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
@@ -130,10 +142,17 @@ func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Ident
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode >= 500 {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+		case http.StatusForbidden, http.StatusTooManyRequests:
 			return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+		default:
+			if resp.StatusCode >= 500 {
+				return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+			}
+			return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
 		}
-		return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -144,8 +163,11 @@ func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Ident
 		Login string `json:"login"`
 		Name  string `json:"name"`
 	}
-	if err := json.Unmarshal(body, &user); err != nil || user.Login == "" {
-		return Identity{}, fmt.Errorf("unexpected GitHub user response")
+	if err := json.Unmarshal(body, &user); err != nil {
+		return Identity{}, fmt.Errorf("decoding GitHub user response: %w", err)
+	}
+	if user.Login == "" {
+		return Identity{}, fmt.Errorf("GitHub user response missing login")
 	}
 
 	return Identity{

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -1,0 +1,172 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	githubAuthorizeURL = "https://github.com/login/oauth/authorize"
+	githubTokenURL     = "https://github.com/login/oauth/access_token"
+	githubUserAPI      = "https://api.github.com/user"
+)
+
+// GitHubConfig configures the GitHub OAuth provider.
+type GitHubConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	Scopes       string
+
+	// AuthorizeURL / TokenURL / UserAPI are exposed for testing. When zero,
+	// the public github.com endpoints are used.
+	AuthorizeURL string
+	TokenURL     string
+	UserAPI      string
+
+	// HTTPClient overrides the default 15s-timeout client. For tests.
+	HTTPClient *http.Client
+}
+
+type githubProvider struct {
+	cfg    GitHubConfig
+	client *http.Client
+}
+
+// NewGitHub returns a Provider backed by GitHub OAuth 2.0.
+func NewGitHub(cfg GitHubConfig) Provider {
+	if cfg.AuthorizeURL == "" {
+		cfg.AuthorizeURL = githubAuthorizeURL
+	}
+	if cfg.TokenURL == "" {
+		cfg.TokenURL = githubTokenURL
+	}
+	if cfg.UserAPI == "" {
+		cfg.UserAPI = githubUserAPI
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &githubProvider{cfg: cfg, client: client}
+}
+
+func (p *githubProvider) Name() string     { return "github" }
+func (p *githubProvider) ClientID() string { return p.cfg.ClientID }
+
+func (p *githubProvider) AuthorizeURL(state, codeChallenge string) string {
+	u, _ := url.Parse(p.cfg.AuthorizeURL)
+	q := u.Query()
+	q.Set("client_id", p.cfg.ClientID)
+	q.Set("redirect_uri", p.cfg.RedirectURI)
+	q.Set("state", state)
+	q.Set("scope", p.cfg.Scopes)
+	// GitHub classic OAuth does not consume code_challenge; PKCE is enforced
+	// between the MCP client and this gateway in handler.Token, not upstream.
+	_ = codeChallenge
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (p *githubProvider) ExchangeCode(ctx context.Context, code string) (string, []string, error) {
+	form := url.Values{
+		"client_id":     {p.cfg.ClientID},
+		"client_secret": {p.cfg.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {p.cfg.RedirectURI},
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		p.cfg.TokenURL, strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", nil, &UpstreamError{Err: fmt.Errorf("GitHub token endpoint unreachable: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		if resp.StatusCode >= 500 {
+			return "", nil, &UpstreamError{Err: fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		}
+		return "", nil, fmt.Errorf("GitHub OAuth returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", nil, fmt.Errorf("decoding GitHub OAuth response: %w", err)
+	}
+	if result.Error != "" {
+		return "", nil, fmt.Errorf("GitHub OAuth error: %s", result.Error)
+	}
+	if result.AccessToken == "" {
+		return "", nil, fmt.Errorf("empty access_token from GitHub")
+	}
+	return result.AccessToken, splitScopes(result.Scope), nil
+}
+
+func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Identity, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, p.cfg.UserAPI, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API unreachable: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode >= 500 {
+			return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+		}
+		return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("reading GitHub user response: %w", err)}
+	}
+	var user struct {
+		Login string `json:"login"`
+		Name  string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil || user.Login == "" {
+		return Identity{}, fmt.Errorf("unexpected GitHub user response")
+	}
+
+	return Identity{
+		Provider:    "github",
+		Subject:     user.Login,
+		DisplayName: user.Name,
+	}, nil
+}
+
+// splitScopes normalizes GitHub's comma-delimited scope string into a slice.
+func splitScopes(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -163,6 +163,20 @@ func TestGitHubValidateToken(t *testing.T) {
 			wantUpstrm: true,
 		},
 		{
+			name:       "403 is upstream error",
+			status:     http.StatusForbidden,
+			body:       "",
+			wantErr:    true,
+			wantUpstrm: true,
+		},
+		{
+			name:       "429 is upstream error",
+			status:     http.StatusTooManyRequests,
+			body:       "",
+			wantErr:    true,
+			wantUpstrm: true,
+		},
+		{
 			name:    "empty login",
 			status:  http.StatusOK,
 			body:    `{"login":""}`,
@@ -230,6 +244,18 @@ func TestNewFactory(t *testing.T) {
 		_, err := New(Config{Kind: "github"})
 		if err == nil {
 			t.Fatal("expected error")
+		}
+	})
+	t.Run("missing redirect uri", func(t *testing.T) {
+		_, err := New(Config{Kind: "github", ClientID: "cid", ClientSecret: "secret"})
+		if err == nil {
+			t.Fatal("expected error for missing RedirectURI")
+		}
+	})
+	t.Run("invalid redirect uri", func(t *testing.T) {
+		_, err := New(Config{Kind: "github", ClientID: "cid", ClientSecret: "secret", RedirectURI: "not-a-url"})
+		if err == nil {
+			t.Fatal("expected error for non-absolute RedirectURI")
 		}
 	})
 	t.Run("unsupported kind", func(t *testing.T) {

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -24,6 +24,31 @@ func newGitHubFromServer(t *testing.T, srv *httptest.Server) Provider {
 	})
 }
 
+func TestNewGitHubPanicsOnInvalidAuthorizeURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		authorizeURL string
+	}{
+		{name: "relative URL", authorizeURL: "login/oauth/authorize"},
+		{name: "non-http scheme", authorizeURL: "ftp://github.com/login/oauth/authorize"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("expected panic but did not get one")
+				}
+			}()
+			NewGitHub(GitHubConfig{
+				ClientID:     "cid",
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/callback",
+				AuthorizeURL: tc.authorizeURL,
+			})
+		})
+	}
+}
+
 func TestGitHubAuthorizeURL(t *testing.T) {
 	p := NewGitHub(GitHubConfig{
 		ClientID:    "cid",

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -1,0 +1,241 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func newGitHubFromServer(t *testing.T, srv *httptest.Server) Provider {
+	t.Helper()
+	return NewGitHub(GitHubConfig{
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+		AuthorizeURL: srv.URL + "/login/oauth/authorize",
+		TokenURL:     srv.URL + "/login/oauth/access_token",
+		UserAPI:      srv.URL + "/user",
+		HTTPClient:   srv.Client(),
+	})
+}
+
+func TestGitHubAuthorizeURL(t *testing.T) {
+	p := NewGitHub(GitHubConfig{
+		ClientID:    "cid",
+		RedirectURI: "http://localhost:8080/callback",
+		Scopes:      "repo,user",
+	})
+	got, err := url.Parse(p.AuthorizeURL("state-abc", "challenge-ignored"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Host != "github.com" {
+		t.Errorf("host: got %q", got.Host)
+	}
+	q := got.Query()
+	if q.Get("client_id") != "cid" {
+		t.Errorf("client_id: got %q", q.Get("client_id"))
+	}
+	if q.Get("state") != "state-abc" {
+		t.Errorf("state: got %q", q.Get("state"))
+	}
+	if q.Get("redirect_uri") != "http://localhost:8080/callback" {
+		t.Errorf("redirect_uri: got %q", q.Get("redirect_uri"))
+	}
+	if q.Get("scope") != "repo,user" {
+		t.Errorf("scope: got %q", q.Get("scope"))
+	}
+}
+
+func TestGitHubExchangeCode(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		body        string
+		wantToken   string
+		wantScopes  []string
+		wantErr     bool
+		wantUpstrm  bool
+	}{
+		{
+			name:       "success",
+			status:     http.StatusOK,
+			body:       `{"access_token":"tok","scope":"repo,user"}`,
+			wantToken:  "tok",
+			wantScopes: []string{"repo", "user"},
+		},
+		{
+			name:    "oauth error",
+			status:  http.StatusOK,
+			body:    `{"error":"bad_verification_code"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty token",
+			status:  http.StatusOK,
+			body:    `{"access_token":""}`,
+			wantErr: true,
+		},
+		{
+			name:       "5xx is upstream error",
+			status:     http.StatusBadGateway,
+			body:       "upstream",
+			wantErr:    true,
+			wantUpstrm: true,
+		},
+		{
+			name:    "4xx is regular error",
+			status:  http.StatusBadRequest,
+			body:    "bad",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/login/oauth/access_token" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			p := newGitHubFromServer(t, srv)
+			tok, scopes, err := p.ExchangeCode(context.Background(), "code")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				var ue *UpstreamError
+				if tc.wantUpstrm && !errors.As(err, &ue) {
+					t.Errorf("expected UpstreamError, got %T: %v", err, err)
+				}
+				if !tc.wantUpstrm && errors.As(err, &ue) {
+					t.Errorf("did not expect UpstreamError, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok != tc.wantToken {
+				t.Errorf("token: got %q, want %q", tok, tc.wantToken)
+			}
+			if strings.Join(scopes, ",") != strings.Join(tc.wantScopes, ",") {
+				t.Errorf("scopes: got %v, want %v", scopes, tc.wantScopes)
+			}
+		})
+	}
+}
+
+func TestGitHubValidateToken(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantSub    string
+		wantErr    bool
+		wantUpstrm bool
+	}{
+		{
+			name:    "success",
+			status:  http.StatusOK,
+			body:    `{"login":"alice","name":"Alice"}`,
+			wantSub: "alice",
+		},
+		{
+			name:    "401 invalid token",
+			status:  http.StatusUnauthorized,
+			body:    "",
+			wantErr: true,
+		},
+		{
+			name:       "5xx upstream",
+			status:     http.StatusInternalServerError,
+			body:       "",
+			wantErr:    true,
+			wantUpstrm: true,
+		},
+		{
+			name:    "empty login",
+			status:  http.StatusOK,
+			body:    `{"login":""}`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/user" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer my-token" {
+					t.Errorf("Authorization: got %q", got)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			p := newGitHubFromServer(t, srv)
+			id, err := p.ValidateToken(context.Background(), "my-token")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				var ue *UpstreamError
+				if tc.wantUpstrm && !errors.As(err, &ue) {
+					t.Errorf("expected UpstreamError, got %T", err)
+				}
+				if !tc.wantUpstrm && errors.As(err, &ue) {
+					t.Errorf("did not expect UpstreamError, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id.Subject != tc.wantSub {
+				t.Errorf("subject: got %q, want %q", id.Subject, tc.wantSub)
+			}
+			if id.Provider != "github" {
+				t.Errorf("provider: got %q", id.Provider)
+			}
+		})
+	}
+}
+
+func TestNewFactory(t *testing.T) {
+	t.Run("github default", func(t *testing.T) {
+		p, err := New(Config{
+			ClientID:     "cid",
+			ClientSecret: "secret",
+			RedirectURI:  "http://localhost/callback",
+			Scopes:       "repo",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Name() != "github" {
+			t.Errorf("name: got %q", p.Name())
+		}
+	})
+	t.Run("missing credentials", func(t *testing.T) {
+		_, err := New(Config{Kind: "github"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("unsupported kind", func(t *testing.T) {
+		_, err := New(Config{Kind: "unknown", ClientID: "x", ClientSecret: "y"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -283,6 +283,18 @@ func TestNewFactory(t *testing.T) {
 			t.Fatal("expected error for non-absolute RedirectURI")
 		}
 	})
+	t.Run("redirect uri missing host", func(t *testing.T) {
+		_, err := New(Config{Kind: "github", ClientID: "cid", ClientSecret: "secret", RedirectURI: "https:///callback"})
+		if err == nil {
+			t.Fatal("expected error for RedirectURI with empty host")
+		}
+	})
+	t.Run("redirect uri with fragment", func(t *testing.T) {
+		_, err := New(Config{Kind: "github", ClientID: "cid", ClientSecret: "secret", RedirectURI: "https://example.com/callback#frag"})
+		if err == nil {
+			t.Fatal("expected error for RedirectURI with fragment")
+		}
+	})
 	t.Run("unsupported kind", func(t *testing.T) {
 		_, err := New(Config{Kind: "unknown", ClientID: "x", ClientSecret: "y"})
 		if err == nil {

--- a/internal/auth/provider/mock.go
+++ b/internal/auth/provider/mock.go
@@ -1,6 +1,9 @@
 package provider
 
-import "context"
+import (
+	"context"
+	"net/url"
+)
 
 // Mock is an in-memory Provider implementation for tests.
 //
@@ -27,7 +30,9 @@ func (m *Mock) AuthorizeURL(state, codeChallenge string) string {
 	if m.AuthorizeURLFunc != nil {
 		return m.AuthorizeURLFunc(state, codeChallenge)
 	}
-	return "https://mock.example.com/authorize?state=" + state
+	q := url.Values{}
+	q.Set("state", state)
+	return "https://mock.example.com/authorize?" + q.Encode()
 }
 
 func (m *Mock) ExchangeCode(ctx context.Context, code string) (string, []string, error) {

--- a/internal/auth/provider/mock.go
+++ b/internal/auth/provider/mock.go
@@ -1,0 +1,45 @@
+package provider
+
+import "context"
+
+// Mock is an in-memory Provider implementation for tests.
+//
+// Field-level overrides drive per-method behavior without requiring a fake
+// HTTP server.
+type Mock struct {
+	NameValue        string
+	ClientIDValue    string
+	AuthorizeURLFunc func(state, codeChallenge string) string
+	ExchangeCodeFunc func(ctx context.Context, code string) (string, []string, error)
+	ValidateFunc     func(ctx context.Context, token string) (Identity, error)
+}
+
+func (m *Mock) Name() string {
+	if m.NameValue == "" {
+		return "mock"
+	}
+	return m.NameValue
+}
+
+func (m *Mock) ClientID() string { return m.ClientIDValue }
+
+func (m *Mock) AuthorizeURL(state, codeChallenge string) string {
+	if m.AuthorizeURLFunc != nil {
+		return m.AuthorizeURLFunc(state, codeChallenge)
+	}
+	return "https://mock.example.com/authorize?state=" + state
+}
+
+func (m *Mock) ExchangeCode(ctx context.Context, code string) (string, []string, error) {
+	if m.ExchangeCodeFunc != nil {
+		return m.ExchangeCodeFunc(ctx, code)
+	}
+	return "mock-token-for-" + code, []string{"mock"}, nil
+}
+
+func (m *Mock) ValidateToken(ctx context.Context, token string) (Identity, error) {
+	if m.ValidateFunc != nil {
+		return m.ValidateFunc(ctx, token)
+	}
+	return Identity{Provider: m.Name(), Subject: "mock-user"}, nil
+}

--- a/internal/auth/provider/provider.go
+++ b/internal/auth/provider/provider.go
@@ -1,0 +1,44 @@
+// Package provider abstracts OAuth 2.0 provider-specific operations
+// (authorization endpoint, token exchange, token validation) so that the
+// gateway can be wired to GitHub, fly.io, OIDC, etc. via configuration.
+package provider
+
+import "context"
+
+// Provider abstracts OAuth 2.0 provider-specific operations.
+//
+// Implementations hold their own client credentials and fixed URLs internally;
+// callers do not pass them per request.
+type Provider interface {
+	// Name returns the provider identifier (e.g. "github").
+	Name() string
+
+	// ClientID returns the OAuth client identifier configured for this provider.
+	// Used by the pseudo dynamic client registration endpoint (RFC 7591).
+	ClientID() string
+
+	// AuthorizeURL builds the redirect URL to the provider's authorization
+	// endpoint. The state and (optional) PKCE code_challenge are forwarded.
+	AuthorizeURL(state, codeChallenge string) string
+
+	// ExchangeCode exchanges an authorization code for an access token.
+	// scopes is the granted scope list as reported by the provider; the
+	// concrete delimiter (comma / space) is normalized by the implementation.
+	ExchangeCode(ctx context.Context, code string) (token string, scopes []string, err error)
+
+	// ValidateToken validates a bearer token and returns the authenticated
+	// identity. Implementations should return UpstreamError for transient
+	// network/5xx failures so callers can distinguish them from auth failures.
+	ValidateToken(ctx context.Context, token string) (Identity, error)
+}
+
+// Identity represents the authenticated user across providers.
+//
+// Subject is the unique identifier used by the gateway (GitHub: login,
+// fly.io: user ID, OIDC: sub claim). DisplayName is optional and may be
+// surfaced to upstream services for human-readable logging.
+type Identity struct {
+	Provider    string
+	Subject     string
+	DisplayName string
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -12,8 +12,11 @@ import (
 
 type contextKey string
 
-const ContextKeyLogin contextKey = "github_login"
-const ContextKeyToken contextKey = "github_token"
+// ContextKeyIdentity carries the authenticated user identifier (provider's
+// Identity.Subject) injected by Auth middleware. Renamed from the previous
+// "github_login" — the value is now provider-agnostic.
+const ContextKeyIdentity contextKey = "authenticated_user"
+const ContextKeyToken contextKey = "auth_token"
 
 // TokenValidator is implemented by auth.Handler.
 type TokenValidator interface {
@@ -24,7 +27,8 @@ type upstreamErrorer interface {
 	IsUpstreamError() bool
 }
 
-// Auth returns a middleware that validates Bearer tokens via the GitHub API.
+// Auth returns a middleware that validates Bearer tokens via the configured
+// OAuth provider.
 func Auth(v TokenValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +38,7 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 				return
 			}
 
-			login, err := v.ValidateToken(r.Context(), token)
+			subject, err := v.ValidateToken(r.Context(), token)
 			if err != nil {
 				var ue upstreamErrorer
 				if errors.As(err, &ue) {
@@ -49,7 +53,7 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 				return
 			}
 
-			ctx := context.WithValue(r.Context(), ContextKeyLogin, login)
+			ctx := context.WithValue(r.Context(), ContextKeyIdentity, subject)
 			ctx = context.WithValue(ctx, ContextKeyToken, token)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -72,13 +76,14 @@ func extractBearer(r *http.Request) string {
 	return ""
 }
 
-// LoginFromContext retrieves the GitHub login injected by Auth middleware.
-func LoginFromContext(ctx context.Context) string {
-	v, _ := ctx.Value(ContextKeyLogin).(string)
+// IdentityFromContext retrieves the authenticated user identifier injected by
+// Auth middleware.
+func IdentityFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyIdentity).(string)
 	return v
 }
 
-// TokenFromContext retrieves the GitHub token injected by Auth middleware.
+// TokenFromContext retrieves the bearer token injected by Auth middleware.
 func TokenFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(ContextKeyToken).(string)
 	return v

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -72,9 +72,9 @@ func TestAuthUpstreamError(t *testing.T) {
 }
 
 func TestAuthValidToken(t *testing.T) {
-	var gotLogin, gotToken string
+	var gotIdentity, gotToken string
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotLogin = LoginFromContext(r.Context())
+		gotIdentity = IdentityFromContext(r.Context())
 		gotToken = TokenFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	})
@@ -89,8 +89,8 @@ func TestAuthValidToken(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("status: got %d, want %d", w.Code, http.StatusOK)
 	}
-	if gotLogin != "alice" {
-		t.Errorf("login in context: got %q, want %q", gotLogin, "alice")
+	if gotIdentity != "alice" {
+		t.Errorf("identity in context: got %q, want %q", gotIdentity, "alice")
 	}
 	if gotToken != "my-token" {
 		t.Errorf("token in context: got %q, want %q", gotToken, "my-token")

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
@@ -40,11 +41,11 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 			}
 
 			if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
-				pr.Out.Header.Set("X-Authenticated-User", subject)
+				pr.Out.Header.Set("X-Authenticated-User", sanitizeHeaderValue(subject))
 				// Legacy header retained during the migration window so that
 				// upstream MCP services (github-mcp, copilot-review-mcp) keep
 				// working until they migrate to X-Authenticated-User.
-				pr.Out.Header.Set("X-GitHub-Login", subject)
+				pr.Out.Header.Set("X-GitHub-Login", sanitizeHeaderValue(subject))
 			}
 
 			slog.Info("proxy request",
@@ -83,6 +84,11 @@ func extractBearer(req *http.Request) string {
 		return auth[len(prefix):]
 	}
 	return ""
+}
+
+// sanitizeHeaderValue strips CR and LF to prevent HTTP header injection.
+func sanitizeHeaderValue(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
 // tokenHash returns the first 8 hex characters of SHA-256(token) for log correlation.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -86,9 +86,12 @@ func extractBearer(req *http.Request) string {
 	return ""
 }
 
+// headerSanitizer is a package-level replacer reused on every proxied request.
+var headerSanitizer = strings.NewReplacer("\r", "", "\n", "")
+
 // sanitizeHeaderValue strips CR and LF to prevent HTTP header injection.
 func sanitizeHeaderValue(s string) string {
-	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+	return headerSanitizer.Replace(s)
 }
 
 // tokenHash returns the first 8 hex characters of SHA-256(token) for log correlation.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -16,10 +16,11 @@ type TokenInvalidator interface {
 	InvalidateCachedToken(token string)
 }
 
-// NewHandler returns an HTTP handler that reverse-proxies authenticated requests
-// to the upstream MCP server. It performs header sanitization, injects the
-// verified GitHub login as X-GitHub-Login, and invalidates the token cache
-// when the upstream returns HTTP 401.
+// NewHandler returns an HTTP handler that reverse-proxies authenticated
+// requests to the upstream MCP server. It performs header sanitization,
+// injects the verified user identifier as X-Authenticated-User (and the
+// legacy X-GitHub-Login during the migration window), and invalidates the
+// token cache when the upstream returns HTTP 401.
 func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
@@ -27,6 +28,7 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 
 			pr.Out.Header.Del("X-Forwarded-For")
 			pr.Out.Header.Del("X-Real-Ip")
+			pr.Out.Header.Del("X-Authenticated-User")
 			pr.Out.Header.Del("X-GitHub-Login")
 			pr.Out.Header.Del("X-Forwarded-Host")
 			pr.Out.Header.Del("X-Forwarded-Proto")
@@ -37,12 +39,16 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 				pr.Out.Header.Set("Authorization", "Bearer "+token)
 			}
 
-			if login := middleware.LoginFromContext(pr.In.Context()); login != "" {
-				pr.Out.Header.Set("X-GitHub-Login", login)
+			if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
+				pr.Out.Header.Set("X-Authenticated-User", subject)
+				// Legacy header retained during the migration window so that
+				// upstream MCP services (github-mcp, copilot-review-mcp) keep
+				// working until they migrate to X-Authenticated-User.
+				pr.Out.Header.Set("X-GitHub-Login", subject)
 			}
 
 			slog.Info("proxy request",
-				"login", middleware.LoginFromContext(pr.In.Context()),
+				"user", middleware.IdentityFromContext(pr.In.Context()),
 				"method", pr.Out.Method,
 				"path", pr.Out.URL.Path,
 				"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
 
+// testValidator is a stub TokenValidator for integration-level tests.
+type testValidator struct{ login string }
+
+func (v *testValidator) ValidateToken(_ context.Context, _ string) (string, error) {
+	return v.login, nil
+}
+
 type mockInvalidator struct {
 	tokens []string
 }
@@ -176,4 +183,45 @@ func TestProxyNilInvalidatorDoesNotPanicOn401(t *testing.T) {
 	w := httptest.NewRecorder()
 	// Must not panic.
 	h.ServeHTTP(w, requestWithContext("eve", "tok"))
+}
+
+// TestMiddlewareToProxyInjectsIdentityHeaders verifies the complete pipeline:
+// Auth middleware → proxy handler → upstream, confirming that both
+// X-Authenticated-User and X-GitHub-Login reach the upstream service
+// (e.g. github-mcp, copilot-review-mcp) on every proxied request.
+func TestMiddlewareToProxyInjectsIdentityHeaders(t *testing.T) {
+	var (
+		gotAuthUser    string
+		gotLegacyLogin string
+		gotAuth        string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthUser = r.Header.Get("X-Authenticated-User")
+		gotLegacyLogin = r.Header.Get("X-GitHub-Login")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	validator := &testValidator{login: "octocat"}
+	chain := middleware.Auth(validator)(NewHandler(u, &mockInvalidator{}))
+
+	r := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
+	r.Header.Set("Authorization", "Bearer real-github-token")
+	w := httptest.NewRecorder()
+	chain.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from upstream, got %d", w.Code)
+	}
+	if gotAuthUser != "octocat" {
+		t.Errorf("X-Authenticated-User: got %q, want %q", gotAuthUser, "octocat")
+	}
+	if gotLegacyLogin != "octocat" {
+		t.Errorf("X-GitHub-Login (legacy): got %q, want %q", gotLegacyLogin, "octocat")
+	}
+	if gotAuth != "Bearer real-github-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer real-github-token")
+	}
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -24,17 +24,18 @@ func upstreamWithStatus(code int) *httptest.Server {
 	}))
 }
 
-func requestWithContext(login, token string) *http.Request {
+func requestWithContext(identity, token string) *http.Request {
 	r := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
-	ctx := context.WithValue(r.Context(), middleware.ContextKeyLogin, login)
+	ctx := context.WithValue(r.Context(), middleware.ContextKeyIdentity, identity)
 	ctx = context.WithValue(ctx, middleware.ContextKeyToken, token)
 	return r.WithContext(ctx)
 }
 
-func TestProxyInjectsXGitHubLogin(t *testing.T) {
-	var gotLogin string
+func TestProxyInjectsIdentityHeaders(t *testing.T) {
+	var gotAuthUser, gotLegacyLogin string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotLogin = r.Header.Get("X-GitHub-Login")
+		gotAuthUser = r.Header.Get("X-Authenticated-User")
+		gotLegacyLogin = r.Header.Get("X-GitHub-Login")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()
@@ -45,8 +46,11 @@ func TestProxyInjectsXGitHubLogin(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice", "tok"))
 
-	if gotLogin != "alice" {
-		t.Errorf("X-GitHub-Login: got %q, want %q", gotLogin, "alice")
+	if gotAuthUser != "alice" {
+		t.Errorf("X-Authenticated-User: got %q, want %q", gotAuthUser, "alice")
+	}
+	if gotLegacyLogin != "alice" {
+		t.Errorf("X-GitHub-Login (legacy): got %q, want %q", gotLegacyLogin, "alice")
 	}
 }
 
@@ -54,14 +58,16 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	var got struct {
 		xff      string
 		realIP   string
-		login    string
+		authUser string
+		legacy   string
 		fwdHost  string
 		fwdProto string
 	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got.xff = r.Header.Get("X-Forwarded-For")
 		got.realIP = r.Header.Get("X-Real-Ip")
-		got.login = r.Header.Get("X-GitHub-Login")
+		got.authUser = r.Header.Get("X-Authenticated-User")
+		got.legacy = r.Header.Get("X-GitHub-Login")
 		got.fwdHost = r.Header.Get("X-Forwarded-Host")
 		got.fwdProto = r.Header.Get("X-Forwarded-Proto")
 		w.WriteHeader(http.StatusOK)
@@ -74,6 +80,7 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	r := requestWithContext("bob", "tok")
 	r.Header.Set("X-Forwarded-For", "1.2.3.4")
 	r.Header.Set("X-Real-Ip", "1.2.3.4")
+	r.Header.Set("X-Authenticated-User", "evil-spoof")
 	r.Header.Set("X-GitHub-Login", "evil-spoof")
 	r.Header.Set("X-Forwarded-Host", "evil.example.com")
 	r.Header.Set("X-Forwarded-Proto", "https")
@@ -87,8 +94,11 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	if got.realIP != "" {
 		t.Errorf("X-Real-Ip not stripped: %q", got.realIP)
 	}
-	if got.login != "bob" {
-		t.Errorf("X-GitHub-Login spoofed: got %q, want %q", got.login, "bob")
+	if got.authUser != "bob" {
+		t.Errorf("X-Authenticated-User spoofed: got %q, want %q", got.authUser, "bob")
+	}
+	if got.legacy != "bob" {
+		t.Errorf("X-GitHub-Login spoofed: got %q, want %q", got.legacy, "bob")
 	}
 	if got.fwdHost != "" {
 		t.Errorf("X-Forwarded-Host not stripped: %q", got.fwdHost)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
@@ -143,6 +144,25 @@ func TestProxyInvalidatesCacheOn401(t *testing.T) {
 
 	if len(inv.tokens) != 1 || inv.tokens[0] != "secret-token" {
 		t.Errorf("invalidated tokens: %v", inv.tokens)
+	}
+}
+
+func TestProxySanitizesHeaderInjectionCharacters(t *testing.T) {
+	var gotAuthUser string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthUser = r.Header.Get("X-Authenticated-User")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice\r\nevil: injected", "tok"))
+
+	if strings.Contains(gotAuthUser, "\r") || strings.Contains(gotAuthUser, "\n") {
+		t.Errorf("X-Authenticated-User contains CR/LF: %q", gotAuthUser)
 	}
 }
 

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,97 @@
+# Tasks
+
+`mcp-gateway` の継続的なタスク管理ファイル。各 issue の状態とサブタスク、依存関係を記録する。
+
+## 凡例
+
+- `[ ]` 未着手
+- `[~]` 進行中
+- `[x]` 完了
+- `[-]` 保留 / 別 issue へ移管
+
+---
+
+## Issue 一覧
+
+### [#2 refactor: OAuth プロバイダ抽象化（Provider インターフェース導入・GitHub 実装の移植）](https://github.com/scottlz0310/mcp-gateway/issues/2)
+
+**状態**: 実装完了・PR レビュー中
+**ブランチ**: `refactor/oauth-provider-abstraction`
+**依存**: なし
+
+GitHub 固定の OAuth フローを `Provider` インターフェースに抽象化。本 issue は **GitHub-only リファクタ**に限定し、外部 IF（環境変数・エンドポイント・OAuth フロー）は 100% 維持する。
+
+#### サブタスク
+
+- [x] `internal/auth/provider/provider.go` — `Provider` IF + `Identity` 構造体
+- [x] `internal/auth/provider/errors.go` — `UpstreamError` 移設
+- [x] `internal/auth/provider/github.go` — GitHub 実装（既存ロジック移植）
+- [x] `internal/auth/provider/factory.go` — `New(cfg) (Provider, error)`
+- [x] `internal/auth/provider/mock.go` — テスト用 Mock
+- [x] `internal/auth/provider/github_test.go` — GitHub 実装の単体テスト
+- [x] `internal/auth/handler.go` — Provider 委譲、Config から GitHub 専用フィールド除去
+- [x] `internal/middleware/auth.go` — `ContextKeyIdentity` へ rename
+- [x] `internal/proxy/handler.go` — `X-Authenticated-User` 注入（`X-GitHub-Login` も互換併存）
+- [x] `cmd/server/main.go` — Provider factory 経由で生成
+- [x] `README.md` — 内部設計の補足
+- [x] `CHANGELOG.md` — 変更履歴記載
+- [x] テスト緑（`go test ./...`）
+
+---
+
+### [#3 spike: fly.io 認証方式の調査（OAuth Provider vs Macaroon Tokens）](https://github.com/scottlz0310/mcp-gateway/issues/3)
+
+**状態**: 未着手
+**依存**: なし（#2 と並行可能）
+
+#### サブタスク
+
+- [ ] fly.io OAuth Provider の `authorize` / `token` / userinfo エンドポイント仕様確認
+- [ ] fly.io OAuth App 登録手段の確認
+- [ ] Fly Tokens（Macaroon）検証手段の確認
+- [ ] mcp-gateway のユースケースに必要な系統の確定
+- [ ] 調査メモ作成（`docs/spikes/flyio-auth.md`）
+- [ ] Issue #2 / #4 へのフィードバック
+
+---
+
+### [#4 feat: fly.io OAuth プロバイダ実装](https://github.com/scottlz0310/mcp-gateway/issues/4)
+
+**状態**: 未着手
+**依存**: #2, #3
+
+#### サブタスク
+
+- [ ] `internal/auth/provider/flyio.go` 実装
+- [ ] `internal/auth/provider/factory.go` の `flyio` 分岐追加
+- [ ] 単体テスト追加
+- [ ] README に fly.io 設定例追記
+
+---
+
+### [#5 refactor: 環境変数を OAUTH_* 系に移行・GITHUB_MCP_* を deprecate](https://github.com/scottlz0310/mcp-gateway/issues/5)
+
+**状態**: 未着手
+**依存**: #2
+
+#### サブタスク
+
+- [ ] `OAUTH_PROVIDER` / `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `OAUTH_SCOPES` を導入
+- [ ] `GITHUB_MCP_*` の後方互換ロジック追加（warning 付き）
+- [ ] README 環境変数表の更新
+- [ ] CHANGELOG に移行ガイド記載
+
+---
+
+### [#6 feat: 汎用 OIDC（OpenID Connect）プロバイダサポート](https://github.com/scottlz0310/mcp-gateway/issues/6)
+
+**状態**: 未着手
+**依存**: #2
+
+#### サブタスク
+
+- [ ] `internal/auth/provider/oidc.go` 実装
+- [ ] OIDC Discovery + JWKS フェッチ
+- [ ] ID Token 検証（署名・クレーム）
+- [ ] 環境変数追加（`OAUTH_ISSUER_URL`, `OAUTH_AUDIENCE` 等）
+- [ ] Auth0 / Keycloak での結合テスト


### PR DESCRIPTION
Closes #2 のうち本 PR は **Provider 抽象化と GitHub 実装の分離** を扱う。fly.io 実装（#4）・env var 移行（#5）・OIDC 対応（#6）は別 PR で続く。

## Summary

- `internal/auth/provider/` パッケージを新設し、`Provider` インターフェースと `Identity` 構造体を導入
- GitHub OAuth 通信ロジック（authorize URL 生成・token exchange・user 検証）を `provider/github.go` に移植
- `auth.Handler` を Provider 委譲構造に改修し、`auth.Config` から GitHub 専用フィールドを除去
- リバースプロキシに `X-Authenticated-User` ヘッダを注入。互換のため `X-GitHub-Login` も併存
- `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装）
- 継続性確保のため `tasks.md` と `CHANGELOG.md` を新設

## 外部互換

**外部 IF は 100% 維持**：
- 環境変数（`GITHUB_MCP_CLIENT_ID` 等）変更なし — `OAUTH_*` 系への rename は #5 で扱う
- OAuth エンドポイント（`/authorize`, `/callback`, `/token`, `/register`）の挙動変更なし
- token response の scope 形式（カンマ区切り）変更なし — RFC 6749 §3.3 への正規化は別 issue で検討
- 上流 MCP サービス向け `X-GitHub-Login` ヘッダ送出も継続（移行期間）

## アーキテクチャ

```
auth.Handler (HTTP 層 + セッション管理)
        │
        ▼ 委譲
provider.Provider (interface)
        │
        ▼ 実装
provider.NewGitHub(GitHubConfig) — GitHub OAuth 2.0
provider.Mock — テスト用
```

新規プロバイダは `provider/factory.go` の `New(cfg) (Provider, error)` に分岐を追加するだけで対応可能。

## Test plan

- [x] `go test ./...` — 全パッケージ緑
- [x] `go vet ./...` — pre-commit hook 通過
- [x] `golangci-lint run ./...` — 0 issues
- [x] `provider/github_test.go` を新規追加（authorize URL / ExchangeCode / ValidateToken / factory のパラメータ化テスト、`UpstreamError` 判定含む）
- [x] `proxy/handler_test.go` を更新し、`X-Authenticated-User` と `X-GitHub-Login` の両ヘッダ注入を検証
- [x] 既存テスト（`TestAuthorizeRedirectsToGitHub` 等）の挙動が変わらないことを確認
- [x] ステージング環境での GitHub OAuth フロー疎通確認（マージ前）
- [x] 上流 MCP サービス（github-mcp / copilot-review-mcp）が両ヘッダのいずれかで動作することの確認

## レビュー観点

- `provider.Provider` インターフェース設計が fly.io (#4) / OIDC (#6) を素直に受け入れるか
- `Identity` 構造体を middleware/proxy レイヤーに伝搬させない判断（#4 で必要になった時点で再検討）の妥当性
- `X-GitHub-Login` の併存期間中の運用方針（いつ削除するか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)