### PR TITLE
docs: add English documentation (README.md / CHANGELOG.md)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -1,0 +1,16 @@
+# Changelog
+
+すべての変更は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に従い、
+バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に従う。
+
+## [Unreleased]
+
+### Changed
+
+- `internal/auth` を `Provider` インターフェースで抽象化。GitHub OAuth 通信ロジックを `internal/auth/provider/github.go` に分離した。外部 IF（環境変数・エンドポイント・OAuth フロー）は変更なし（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
+- リバースプロキシが上流 MCP サービスに送出するヘッダに `X-Authenticated-User` を追加。`X-GitHub-Login` も互換のため引き続き送出する（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
+
+### Internal
+
+- `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
+- `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Changelog
 
-すべての変更は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に従い、
-バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に従う。
+All notable changes to this project will be documented in this file.
+
+This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
 ### Changed
 
-- `internal/auth` を `Provider` インターフェースで抽象化。GitHub OAuth 通信ロジックを `internal/auth/provider/github.go` に分離した。外部 IF（環境変数・エンドポイント・OAuth フロー）は変更なし（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
-- リバースプロキシが上流 MCP サービスに送出するヘッダに `X-Authenticated-User` を追加。`X-GitHub-Login` も互換のため引き続き送出する（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
+- Abstracted `internal/auth` behind a `Provider` interface. GitHub OAuth HTTP logic extracted to `internal/auth/provider/github.go`. External interface (env vars, endpoints, OAuth flow) is unchanged ([#2](https://github.com/scottlz0310/mcp-gateway/issues/2)).
+- Reverse proxy now injects `X-Authenticated-User` header into upstream requests. `X-GitHub-Login` continues to be sent for backward compatibility ([#2](https://github.com/scottlz0310/mcp-gateway/issues/2)).
 
 ### Internal
 
-- `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
-- `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。
+- Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
+- Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,85 @@
+# mcp-gateway
+
+MCP サービス群への統合ゲートウェイ（GitHub OAuth 認証・リクエストルーティング・Fly.io デプロイ対応）
+
+## 概要
+
+`mcp-gateway` は複数の MCP サービスへのリクエストルーティングと GitHub OAuth 2.0 認証を一元管理するリバースプロキシです。`github-oauth-proxy` の後継として設計されています（[Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)）。
+
+## アーキテクチャ
+
+```
+MCP クライアント
+      │
+      ▼
+mcp-gateway (:8080)
+  ├── OAuth フロー   (/authorize, /callback, /token, /register)
+  ├── Bearer 検証   (GitHub API キャッシュ付き)
+  └── ルーティング
+        ├── /mcp/github       → github-mcp:8082
+        └── /mcp/copilot-review → copilot-review-mcp:8083
+```
+
+## 設定
+
+### 必須環境変数
+
+| 変数 | 説明 |
+|------|------|
+| `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App の Client ID |
+| `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App の Client Secret |
+
+### ルーティング設定
+
+`ROUTE_<NAME>=<prefix>|<upstream_url>` の形式で設定します。
+
+```bash
+ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
+ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
+```
+
+複数のルートを設定した場合、**最長プレフィックスが優先**されます。
+
+### オプション環境変数
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | OAuth コールバック等に使用するベース URL |
+| `MCP_GATEWAY_PORT` | `8080` | リスンポート |
+| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
+| `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |
+| `SESSION_TTL_MIN` | `10` | OAuth セッション有効期間（分） |
+| `TOKEN_CACHE_TTL_MIN` | `30` | トークンキャッシュ有効期間（分） |
+| `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日） |
+| `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
+
+## エンドポイント
+
+| パス | メソッド | 説明 |
+|------|---------|------|
+| `/.well-known/oauth-authorization-server` | GET | RFC 8414 メタデータ |
+| `/authorize` | GET | OAuth 認可エンドポイント |
+| `/callback` | GET | GitHub OAuth コールバック |
+| `/token` | POST | トークンエンドポイント（PKCE 対応） |
+| `/register` | POST | RFC 7591 動的クライアント登録（疑似） |
+| `/health` | GET | ヘルスチェック |
+| `/<prefix>` | ANY | Bearer 検証後、対応アップストリームへリバースプロキシ |
+
+## 開発
+
+```bash
+# テスト
+go test ./...
+
+# ビルド
+go build ./cmd/server
+
+# Docker ビルド
+docker build -t mcp-gateway .
+```
+
+## Docker Image
+
+```
+ghcr.io/scottlz0310/mcp-gateway:latest
+```

--- a/README.md
+++ b/README.md
@@ -1,80 +1,166 @@
 # mcp-gateway
 
-MCP サービス群への統合ゲートウェイ（GitHub OAuth 認証・リクエストルーティング・Fly.io デプロイ対応）
+Unified authentication and routing gateway for MCP (Model Context Protocol) services — GitHub OAuth 2.0, multi-upstream reverse proxy, and Fly.io deployment ready.
 
-## 概要
+> **Part of the [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) ecosystem** — designed to work alongside `mcp-docker` and `copilot-review-mcp` as a composable self-hosted MCP infrastructure stack.
 
-`mcp-gateway` は複数の MCP サービスへのリクエストルーティングと GitHub OAuth 2.0 認証を一元管理するリバースプロキシです。`github-oauth-proxy` の後継として設計されています（[Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)）。
+## Overview
 
-## アーキテクチャ
+`mcp-gateway` is a reverse proxy that centralizes **GitHub OAuth 2.0 authentication** and **request routing** for multiple MCP services. It acts as the single entry point for MCP clients (e.g., Claude Desktop, VS Code GitHub Copilot), handling the full OAuth 2.0 authorization code flow with PKCE before forwarding authenticated requests to upstream MCP servers.
+
+It is the successor to `github-oauth-proxy` ([Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)).
+
+## Architecture
 
 ```
-MCP クライアント
-      │
-      ▼
-mcp-gateway (:8080)
-  ├── OAuth フロー   (/authorize, /callback, /token, /register)
-  ├── Bearer 検証   (GitHub API キャッシュ付き)
-  └── ルーティング
-        ├── /mcp/github       → github-mcp:8082
-        └── /mcp/copilot-review → copilot-review-mcp:8083
+MCP Client (Claude Desktop / VS Code / etc.)
+        │
+        ▼
+mcp-gateway  :8080
+  ├── OAuth façade     /authorize  /callback  /token  /register
+  ├── Bearer validation  (GitHub API with in-memory cache)
+  └── Routing (longest-prefix match)
+        ├── /mcp/github           → github-mcp-server  :8082
+        └── /mcp/copilot-review   → copilot-review-mcp :8083
 ```
 
-## 設定
+### 3-Repo Stack
 
-### 必須環境変数
-
-| 変数 | 説明 |
+| Repo | Role |
 |------|------|
-| `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App の Client ID |
-| `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App の Client Secret |
+| **mcp-gateway** (this repo) | OAuth 2.0 auth + routing gateway |
+| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | Docker Compose orchestration for the full MCP stack |
+| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot code-review MCP server |
 
-### ルーティング設定
+## Configuration
 
-`ROUTE_<NAME>=<prefix>|<upstream_url>` の形式で設定します。
+### Required Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App Client ID |
+| `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App Client Secret |
+
+### Route Configuration
+
+Routes are defined via `ROUTE_<NAME>=<prefix>|<upstream_url>` environment variables.
 
 ```bash
 ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
 ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 ```
 
-複数のルートを設定した場合、**最長プレフィックスが優先**されます。
+- Prefixes **must** start with `/`
+- Upstream URLs must be absolute `http` or `https`
+- When multiple routes match, the **longest prefix wins**
 
-### オプション環境変数
+### Optional Environment Variables
 
-| 変数 | デフォルト | 説明 |
-|------|-----------|------|
-| `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | OAuth コールバック等に使用するベース URL |
-| `MCP_GATEWAY_PORT` | `8080` | リスンポート |
-| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
-| `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |
-| `SESSION_TTL_MIN` | `10` | OAuth セッション有効期間（分） |
-| `TOKEN_CACHE_TTL_MIN` | `30` | トークンキャッシュ有効期間（分） |
-| `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日） |
-| `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | Base URL used for OAuth callback and discovery metadata |
+| `MCP_GATEWAY_PORT` | `8080` | Listen port |
+| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
+| `LOG_LEVEL` | `info` | Log level: `debug` / `info` / `warn` / `error` |
+| `SESSION_TTL_MIN` | `10` | OAuth session lifetime (minutes) |
+| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL (minutes) |
+| `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days) |
+| `GITHUB_MCP_UPSTREAM_URL` | — | **Deprecated** — single upstream fallback when no `ROUTE_*` is set |
 
-## エンドポイント
+## Endpoints
 
-| パス | メソッド | 説明 |
-|------|---------|------|
-| `/.well-known/oauth-authorization-server` | GET | RFC 8414 メタデータ |
-| `/authorize` | GET | OAuth 認可エンドポイント |
-| `/callback` | GET | GitHub OAuth コールバック |
-| `/token` | POST | トークンエンドポイント（PKCE 対応） |
-| `/register` | POST | RFC 7591 動的クライアント登録（疑似） |
-| `/health` | GET | ヘルスチェック |
-| `/<prefix>` | ANY | Bearer 検証後、対応アップストリームへリバースプロキシ |
+| Path | Method | Description |
+|------|--------|-------------|
+| `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server metadata |
+| `/authorize` | GET | OAuth 2.0 authorization endpoint |
+| `/callback` | GET | GitHub OAuth callback |
+| `/token` | POST | Token endpoint (authorization code + PKCE) |
+| `/register` | POST | RFC 7591 dynamic client registration (pseudo) |
+| `/health` | GET | Health check — returns `{"status":"ok"}` |
+| `/<prefix>` | ANY | Bearer-validated reverse proxy to the matched upstream |
 
-## 開発
+## Internal Design
+
+### Provider Interface
+
+The OAuth provider is abstracted behind a `Provider` interface, making it straightforward to add new identity providers (fly.io, OIDC, etc.) without touching the auth handler or middleware:
+
+```go
+type Provider interface {
+    Name() string
+    ClientID() string
+    AuthorizeURL(state, codeChallenge string) string
+    ExchangeCode(ctx context.Context, code string) (token string, scopes string, err error)
+    ValidateToken(ctx context.Context, token string) (Identity, error)
+}
+
+type Identity struct {
+    Subject string // stable user identifier forwarded as X-Authenticated-User
+    Login   string // provider-specific display name (GitHub login, etc.)
+}
+```
+
+The proxy forwards two headers to upstream MCP servers:
+
+| Header | Value |
+|--------|-------|
+| `X-Authenticated-User` | `Identity.Subject` (canonical, provider-agnostic) |
+| `X-GitHub-Login` | `Identity.Login` (legacy compatibility) |
+
+Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`) are stripped before proxying.
+
+## Quick Start
+
+### 1. Create a GitHub OAuth App
+
+Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**:
+
+- **Authorization callback URL**: `http://localhost:8080/callback` (or your `MCP_GATEWAY_BASE_URL` + `/callback`)
+
+### 2. Run with Docker Compose
+
+```yaml
+services:
+  mcp-gateway:
+    image: ghcr.io/scottlz0310/mcp-gateway:latest
+    ports:
+      - "8080:8080"
+    environment:
+      GITHUB_MCP_CLIENT_ID: <your-client-id>
+      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      MCP_GATEWAY_BASE_URL: http://localhost:8080
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+    depends_on:
+      - github-mcp
+```
+
+See [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) for a full Compose stack.
+
+### 3. Configure your MCP Client
+
+Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "http://localhost:8080/mcp/github",
+      "transport": "http"
+    }
+  }
+}
+```
+
+## Development
 
 ```bash
-# テスト
+# Run tests
 go test ./...
 
-# ビルド
+# Build binary
 go build ./cmd/server
 
-# Docker ビルド
+# Build Docker image
 docker build -t mcp-gateway .
 ```
 
@@ -83,3 +169,9 @@ docker build -t mcp-gateway .
 ```
 ghcr.io/scottlz0310/mcp-gateway:latest
 ```
+
+Built on `gcr.io/distroless/static-debian12:nonroot` — no shell, no package manager, runs as non-root (UID 65532).
+
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ mcp-gateway  :8080
 | `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App Client ID |
 | `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App Client Secret |
 
+At least one route must also be configured via `ROUTE_<NAME>` (see below) — the server exits on startup if no routes are defined.
+
 ### Route Configuration
 
 Routes are defined via `ROUTE_<NAME>=<prefix>|<upstream_url>` environment variables.
@@ -90,13 +92,14 @@ type Provider interface {
     Name() string
     ClientID() string
     AuthorizeURL(state, codeChallenge string) string
-    ExchangeCode(ctx context.Context, code string) (token string, scopes string, err error)
+    ExchangeCode(ctx context.Context, code string) (token string, scopes []string, err error)
     ValidateToken(ctx context.Context, token string) (Identity, error)
 }
 
 type Identity struct {
-    Subject string // stable user identifier forwarded as X-Authenticated-User
-    Login   string // provider-specific display name (GitHub login, etc.)
+    Provider    string
+    Subject     string // stable user identifier forwarded upstream
+    DisplayName string // optional human-readable name for logging
 }
 ```
 
@@ -105,7 +108,7 @@ The proxy forwards two headers to upstream MCP servers:
 | Header | Value |
 |--------|-------|
 | `X-Authenticated-User` | `Identity.Subject` (canonical, provider-agnostic) |
-| `X-GitHub-Login` | `Identity.Login` (legacy compatibility) |
+| `X-GitHub-Login` | same as `X-Authenticated-User` (legacy compatibility; both set from `Identity.Subject`) |
 
 Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`) are stripped before proxying.
 

--- a/tasks.md
+++ b/tasks.md
@@ -41,57 +41,69 @@ GitHub 固定の OAuth フローを `Provider` インターフェースに抽象
 
 ### [#3 spike: fly.io 認証方式の調査（OAuth Provider vs Macaroon Tokens）](https://github.com/scottlz0310/mcp-gateway/issues/3)
 
-**状態**: 未着手
-**依存**: なし（#2 と並行可能）
+**状態**: 調査完了（2026-04-27）
+**依存**: なし
+
+**結論**: Sign in with Fly（OAuth 2.0）を Issue #4 で採用。Macaroon は Provider IF 不適合のため対象外。Provider IF（#2 で確定）に変更不要。詳細は Issue #3 本文参照。
 
 #### サブタスク
 
-- [ ] fly.io OAuth Provider の `authorize` / `token` / userinfo エンドポイント仕様確認
-- [ ] fly.io OAuth App 登録手段の確認
-- [ ] Fly Tokens（Macaroon）検証手段の確認
-- [ ] mcp-gateway のユースケースに必要な系統の確定
-- [ ] 調査メモ作成（`docs/spikes/flyio-auth.md`）
-- [ ] Issue #2 / #4 へのフィードバック
+- [x] fly.io OAuth Provider の `authorize` / `token` / userinfo エンドポイント仕様確認
+- [x] fly.io OAuth App 登録手段の確認（self-service 不可・fly.io と直接調整）
+- [x] Fly Tokens（Macaroon）検証手段の確認（`superfly/macaroon` + tkdb・外部利用非推奨）
+- [x] mcp-gateway のユースケースに必要な系統の確定（Sign in with Fly）
+- [-] 調査メモ作成（`docs/spikes/flyio-auth.md`）→ Issue #3 本文に集約
+- [x] Issue #2 / #4 へのフィードバック（IF 変更不要・#4 前提条件を本文に記載）
 
 ---
 
 ### [#4 feat: fly.io OAuth プロバイダ実装](https://github.com/scottlz0310/mcp-gateway/issues/4)
 
-**状態**: 未着手
+**状態**: 保留（2026-04-27）
 **依存**: #2, #3
+**保留理由**: fly.io OAuth（Sign in with Fly）は Extensions Provider 専用であり、開発用 client_id/client_secret の self-service 登録手段がない。fly.io と直接調整が必要なため、プロダクト品質が整うまで後回し。代替 OAuth プロバイダの検討を優先する。
 
 #### サブタスク
 
-- [ ] `internal/auth/provider/flyio.go` 実装
-- [ ] `internal/auth/provider/factory.go` の `flyio` 分岐追加
-- [ ] 単体テスト追加
-- [ ] README に fly.io 設定例追記
+- [-] `internal/auth/provider/flyio.go` 実装（保留）
+- [-] `internal/auth/provider/factory.go` の `flyio` 分岐追加（保留）
+- [-] 単体テスト追加（保留）
+- [-] README に fly.io 設定例追記（保留）
 
 ---
 
 ### [#5 refactor: 環境変数を OAUTH_* 系に移行・GITHUB_MCP_* を deprecate](https://github.com/scottlz0310/mcp-gateway/issues/5)
 
-**状態**: 未着手
+**状態**: 保留（2026-04-27）
 **依存**: #2
+**保留理由**: 追加プロバイダがすべて保留・クローズとなったため優先度低下。プロバイダ追加が確定した時点で再開。
 
 #### サブタスク
 
-- [ ] `OAUTH_PROVIDER` / `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `OAUTH_SCOPES` を導入
-- [ ] `GITHUB_MCP_*` の後方互換ロジック追加（warning 付き）
-- [ ] README 環境変数表の更新
-- [ ] CHANGELOG に移行ガイド記載
+- [-] `OAUTH_PROVIDER` / `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `OAUTH_SCOPES` を導入（保留）
+- [-] `GITHUB_MCP_*` の後方互換ロジック追加（warning 付き）（保留）
+- [-] README 環境変数表の更新（保留）
+- [-] CHANGELOG に移行ガイド記載（保留）
+
+---
+
+### [#8 feat: Google OAuth 2.0 プロバイダ実装](https://github.com/scottlz0310/mcp-gateway/issues/8)
+
+**状態**: クローズ（2026-04-27・YAGNI）
+**理由**: Google 公式 MCP サーバーは OAuth + Streamable HTTP を既に内包。対象 MCP サーバーが具体的に決まるまで見送り。
 
 ---
 
 ### [#6 feat: 汎用 OIDC（OpenID Connect）プロバイダサポート](https://github.com/scottlz0310/mcp-gateway/issues/6)
 
-**状態**: 未着手
+**状態**: 保留（2026-04-27）
 **依存**: #2
+**保留理由**: Entra ID は DCR 未サポートで MCP OAuth 2.1 仕様と不適合。対象 MCP サーバーが具体的に決まるまで見送り（YAGNI）。
 
 #### サブタスク
 
-- [ ] `internal/auth/provider/oidc.go` 実装
-- [ ] OIDC Discovery + JWKS フェッチ
-- [ ] ID Token 検証（署名・クレーム）
-- [ ] 環境変数追加（`OAUTH_ISSUER_URL`, `OAUTH_AUDIENCE` 等）
-- [ ] Auth0 / Keycloak での結合テスト
+- [-] `internal/auth/provider/oidc.go` 実装（保留）
+- [-] OIDC Discovery + JWKS フェッチ（保留）
+- [-] ID Token 検証（署名・クレーム）（保留）
+- [-] 環境変数追加（`OAUTH_ISSUER_URL`, `OAUTH_AUDIENCE` 等）（保留）
+- [-] Auth0 / Keycloak での結合テスト（保留）


### PR DESCRIPTION
## Summary

Adds comprehensive English documentation for `mcp-gateway` in preparation for proposing the 3-repo stack (mcp-gateway + mcp-docker + copilot-review-mcp) to the upstream `github-mcp-server` project.

## Changes

| File | Action |
|------|--------|
| `README.md` | **Replaced** with full English version |
| `CHANGELOG.md` | **Replaced** with English version |
| `README.ja.md` | **Added** — original Japanese README (renamed) |
| `CHANGELOG.ja.md` | **Added** — original Japanese CHANGELOG (renamed) |
| `tasks.md` | Updated issue statuses (#3 completed, #4/#5/#6 pending, #8 closed) |

## English README covers

- Overview and project context (3-repo stack relationship)
- Architecture diagram
- Configuration reference (required + optional env vars)
- Route configuration syntax (`ROUTE_<NAME>=<prefix>|<upstream_url>`)
- Endpoints table
- `Provider` interface design (extensibility)
- Header injection (`X-Authenticated-User` / `X-GitHub-Login`)
- Quick start guide (GitHub OAuth App setup + Docker Compose)
- Development commands
- Docker image info

## Motivation

This repo, alongside `mcp-docker` and `copilot-review-mcp`, is intended as a self-hosted MCP infrastructure proposal for the `github/github-mcp-server` ecosystem. English documentation is a prerequisite for that proposal.
