### PR TITLE
chore: add issues #10/#11/#12 to tasks.md (env var independence roadmap)

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -107,3 +107,71 @@ GitHub 固定の OAuth フローを `Provider` インターフェースに抽象
 - [-] ID Token 検証（署名・クレーム）（保留）
 - [-] 環境変数追加（`OAUTH_ISSUER_URL`, `OAUTH_AUDIENCE` 等）（保留）
 - [-] Auth0 / Keycloak での結合テスト（保留）
+
+---
+
+### [#10 spike: Device Authorization Grant を gateway レイヤーで実装する可能性調査](https://github.com/scottlz0310/mcp-gateway/issues/10)
+
+**状態**: 未着手
+**依存**: #2（完了済み）、#11（config persistence）
+
+"OAuthログインで全認証完了" を実現するための前調査。Device Grant は **gateway が実行する**アーキテクチャを採用する。
+
+**確定アーキテクチャ:**
+```
+MCP Client → mcp-gateway（Device Grant 実行）→ GitHub
+```
+
+MCPクライアント直の Device Grant（gateway は validation のみ）は**採用しない**（トークン分散・セッション非共有・refresh管理破綻のため）。
+
+#### サブタスク
+
+- [ ] GitHub Device Grant エンドポイント（`client_secret` 要否）の確認
+- [ ] gateway 内 Device Grant フロー設計（`POST /auth/device`・`GET /auth/device/poll`）
+- [ ] MCP Authorization Server Metadata への `device_authorization_endpoint` 追加検討
+- [ ] VS Code Copilot 拡張が Device Grant を実際に利用するか動作確認
+- [ ] 既存 Authorization Code Flow との共存設計
+- [ ] 後続実装 ISSUE のスコープ・前提条件確定
+
+---
+
+### [#11 feat: Config Persistence Layer（env vars → YAML/SQLite 設定ファイル）](https://github.com/scottlz0310/mcp-gateway/issues/11)
+
+**状態**: 未着手
+**依存**: なし（独立着手可能）
+
+`mustEnv` によるクラッシュを撤廃し、設定を YAML / SQLite で永続管理する。env vars はオーバーライド手段として維持（12-factor 互換）。
+
+#### サブタスク
+
+- [ ] `internal/config/` パッケージ新設（Config 構造体・YAML 読み書き・env override マージ）
+- [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > XDG > デフォルト）
+- [ ] `cmd/server/main.go` の `mustEnv` を config ロードに置き換え
+- [ ] `internal/router/router.go` の `ParseEnv()` を config ベース実装に切り替え
+- [ ] SQLite ルートストアの設計・実装（CRUD）
+- [ ] `internal/auth/session.go` のトークン永続化対応
+- [ ] テスト / README.md / CHANGELOG.md 更新
+
+---
+
+### [#12 feat: First-run Setup Wizard（初回デプロイ時のインタラクティブ設定フロー）](https://github.com/scottlz0310/mcp-gateway/issues/12)
+
+**状態**: 未着手
+**依存**: #11（Config Persistence Layer）
+
+設定ファイルが存在しない初回起動時に `/setup` エンドポイントを自動活性化し、ブラウザ or CLI で初期設定を完了できるようにする。
+
+起動フロー:
+```
+設定なし → setup_token を stdout に出力 → GET /setup?token=<token> → POST /setup → 設定完了 → 通常起動
+```
+
+#### サブタスク
+
+- [ ] `internal/setup/` パッケージ新設（token 生成・検証・一度限り保証）
+- [ ] `setup_completed` フラグの config 統合（#11 依存）
+- [ ] `GET /setup` / `POST /setup` ハンドラ実装
+- [ ] 起動ログへの setup_token 出力（`log/slog`）
+- [ ] 未 setup 状態での通常ルートのレスポンス
+- [ ] HTTPS チェック（production 判定）
+- [ ] テスト / README.md（first-run guide 書き換え） / CHANGELOG.md 更新


### PR DESCRIPTION
## 変更内容

`tasks.md` に "環境変数完全脱却" ロードマップの新規 ISSUE (#10/#11/#12) を追加。

### 追加した ISSUE

| # | タイトル | 状態 |
|---|---------|------|
| [#10](https://github.com/scottlz0310/mcp-gateway/issues/10) | spike: Device Authorization Grant を gateway レイヤーで実装する可能性調査 | 未着手 |
| [#11](https://github.com/scottlz0310/mcp-gateway/issues/11) | feat: Config Persistence Layer（env vars → YAML/SQLite 設定ファイル） | 未着手 |
| [#12](https://github.com/scottlz0310/mcp-gateway/issues/12) | feat: First-run Setup Wizard（初回デプロイ時のインタラクティブ設定フロー） | 未着手 |

### ロードマップの背景

"OAuthログインで全認証完了" を実現するための段階的な計画:

1. **#10 spike**: Device Grant を gateway が実行するアーキテクチャの技術調査
2. **#11 feat**: `mustEnv` クラッシュの撤廃・設定ファイルによる永続管理
3. **#12 feat**: 初回デプロイ時の setup wizard によるブートストラップ

依存関係: #11 → #12 → #10 の調査結果を踏まえて実装