### PR TITLE
chore: add .claude to .gitignore and remove tracked files

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8b84f8f3-6401-4c82-b591-b77acbaf6ae8","pid":6152,"acquiredAt":1777332850027}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
+
+# Claude Code CLI agent
+.claude/


### PR DESCRIPTION
## Summary

`.claude/` ディレクトリは Claude Code CLI エージェントが使用するフォルダで、バージョン管理する必要がありません。

### Changes
- `.gitignore` に `.claude/` を追加
- リモートに存在していた `.claude/scheduled_tasks.lock` を git 管理から除外