### PR TITLE
docs(spike): Copilot API authentication compatibility findings (closes #18)

### DIFF
--- a/docs/spike-18-copilot-api-auth.md
+++ b/docs/spike-18-copilot-api-auth.md
@@ -96,10 +96,10 @@ data: {"jsonrpc":"2.0","id":1,"result":{
 
 ## 重要な発見：パスルーティングの挙動
 
-### `httputil.ReverseProxy.SetURL` のパス結合動作
+### `(*httputil.ProxyRequest).SetURL` のパス結合動作
 
-mcp-gateway は `httputil.ReverseProxy` の `SetURL(upstream)` を使用している。
-`SetURL` は upstream URL のパスとリクエストパスを `singleJoiningSlash` で結合する。
+mcp-gateway は `Rewrite` 内で `pr.SetURL(upstream)` を使用している。
+`(*httputil.ProxyRequest).SetURL` は upstream URL のパスとリクエストパスを `singleJoiningSlash` で結合する。
 
 | upstream URL | リクエストパス | 転送先パス | 結果 |
 |---|---|---|---|
@@ -127,12 +127,12 @@ Copilot API と他の MCP サービスを同時に運用可能：
 # ゲートウェイの /mcp/ → Copilot API
 ROUTE_COPILOT=/mcp|https://api.githubcopilot.com
 
-# ゲートウェイの /mcp/review/ → 自前 MCP サービス（より長いプレフィックスが優先）
-ROUTE_REVIEW=/mcp/review|http://copilot-review-mcp:3000
+# ゲートウェイの /mcp/copilot-review/ → 自前 MCP サービス（より長いプレフィックスが優先）
+ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 ```
 
 クライアントからのリクエスト分岐：
-- `POST /mcp/review/` → `/mcp/review/` が `/mcp/` より長いため `copilot-review-mcp` へ
+- `POST /mcp/copilot-review/` → `/mcp/copilot-review/` が `/mcp/` より長いため `copilot-review-mcp` へ
 - `POST /mcp/` → `/mcp/` が Copilot API へ
 
 ---
@@ -143,7 +143,7 @@ ROUTE_REVIEW=/mcp/review|http://copilot-review-mcp:3000
 |---|---|---|
 | MCP Protocol Version | `2024-11-05` | ✅ |
 | Transport | SSE (`text/event-stream`) | ✅ (`httputil.ReverseProxy` はストリーミング対応) |
-| Session管理 | `Mcp-Session-Id` ヘッダ | ✅ (proxy が透過転送) |
+| Session管理 | `mcp-session-id` ヘッダ | ✅ (proxy が透過転送) |
 | 認証方式 | Bearer token (header) | ✅ (proxy が `Authorization: Bearer <token>` を注入) |
 
 ---
@@ -153,7 +153,7 @@ ROUTE_REVIEW=/mcp/review|http://copilot-review-mcp:3000
 ### A. `X-Authenticated-User` / `X-GitHub-Login` ヘッダ注入
 
 proxy ハンドラは upstream への全リクエストに `X-Authenticated-User` および
-`X-GitHub-Login` ヘッダを注入する（`internal/proxy/handler.go:44-48`）。
+`X-GitHub-Login` ヘッダを注入する（`internal/proxy/handler.go` の `proxy.NewHandler` における upstream リクエスト生成時のヘッダ設定処理）。
 Copilot API はこれらのヘッダを無視するが、予期しない動作の原因になる可能性は低い。
 
 ### B. 401 時の `WWW-Authenticate` ヘッダ
@@ -202,7 +202,7 @@ services:
   mcp-gateway:
     environment:
       ROUTE_COPILOT: /mcp|https://api.githubcopilot.com
-      ROUTE_REVIEW: /mcp/review|http://copilot-review-mcp:3000
+      ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
 ```
 
 ### 中長期的な改善事項

--- a/docs/spike-18-copilot-api-auth.md
+++ b/docs/spike-18-copilot-api-auth.md
@@ -1,0 +1,222 @@
+# Spike #18: `https://api.githubcopilot.com/mcp/` Upstream 認証互換性調査
+
+## 概要
+
+mcp-gateway の upstream として `https://api.githubcopilot.com/mcp/` を使用した場合の
+認証・ルーティング互換性を検証したスパイクの調査結果をまとめる。
+
+---
+
+## 調査方法
+
+curl コマンドによる直接検証（2026-04-28 実施）。
+
+---
+
+## 調査結果
+
+### 1. OAuth Discovery
+
+`https://api.githubcopilot.com/.well-known/oauth-authorization-server` → **404**（ルートには存在しない）
+
+WWW-Authenticate ヘッダで参照される実際の Resource Metadata URL:
+
+```
+https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/
+```
+
+### 2. Resource Metadata (`/mcp/` サブパス)
+
+```json
+{
+  "resource": "https://api.githubcopilot.com/mcp/",
+  "authorization_servers": ["https://github.com/login/oauth"],
+  "scopes_supported": [
+    "repo", "read:org", "read:user", "user:email",
+    "read:packages", "write:packages", "read:project",
+    "project", "gist", "notifications", "workflow",
+    "codespace"
+  ],
+  "bearer_methods_supported": ["header"],
+  "resource_name": "GitHub MCP Server"
+}
+```
+
+**重要**: `authorization_servers` が `https://github.com/login/oauth` であり、
+**標準 GitHub OAuth トークン（`gho_`）が認証に使用可能**。
+
+### 3. 未認証アクセス時のレスポンス
+
+```
+HTTP/1.1 401 Unauthorized
+www-authenticate: Bearer error="invalid_request",
+  error_description="No access token was provided in this request",
+  resource_metadata="https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/"
+Server: github-mcp-server-remote
+```
+
+### 4. `gho_` トークンによる直接アクセス検証
+
+```bash
+curl -si -H "Authorization: Bearer gho_..." https://api.githubcopilot.com/mcp/
+# → HTTP/1.1 405 Method Not Allowed（GET は不可、POST が必要）
+# → 401 ではないため認証成功
+```
+
+### 5. MCP Initialize (POST) 検証
+
+```bash
+curl -si -X POST \
+  -H "Authorization: Bearer gho_..." \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  https://api.githubcopilot.com/mcp/ \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{...},"id":1}'
+```
+
+結果:
+
+```
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+mcp-session-id: e4149ddf-f116-4a3d-a92f-29d9788b8c60
+Server: github-mcp-server-remote
+
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{
+  "capabilities":{"completions":{},"prompts":{},"resources":{},"tools":{}},
+  "protocolVersion":"2024-11-05",
+  "serverInfo":{"name":"github-mcp-server","title":"GitHub MCP Server", ...}
+}}
+```
+
+**`gho_` トークン（scopes: `gist, read:org, repo, workflow`）で MCP initialize が成功することを確認。**
+
+---
+
+## 重要な発見：パスルーティングの挙動
+
+### `httputil.ReverseProxy.SetURL` のパス結合動作
+
+mcp-gateway は `httputil.ReverseProxy` の `SetURL(upstream)` を使用している。
+`SetURL` は upstream URL のパスとリクエストパスを `singleJoiningSlash` で結合する。
+
+| upstream URL | リクエストパス | 転送先パス | 結果 |
+|---|---|---|---|
+| `https://api.githubcopilot.com/mcp/` | `/mcp/` | `/mcp/mcp/` | ❌ パス二重化 |
+| `https://api.githubcopilot.com` | `/mcp/` | `/mcp/` | ✅ 正常 |
+
+### 正しい設定方法
+
+```env
+# ❌ 誤り：upstream に /mcp/ パスを含めると二重化
+ROUTE_COPILOT=/mcp|https://api.githubcopilot.com/mcp/
+
+# ✅ 正しい：upstream はホストのみ（パスなし）
+ROUTE_COPILOT=/mcp|https://api.githubcopilot.com
+```
+
+---
+
+## 複数ルートの共存
+
+`ROUTE_*` による longest-prefix-first マッチングにより、
+Copilot API と他の MCP サービスを同時に運用可能：
+
+```env
+# ゲートウェイの /mcp/ → Copilot API
+ROUTE_COPILOT=/mcp|https://api.githubcopilot.com
+
+# ゲートウェイの /mcp/review/ → 自前 MCP サービス（より長いプレフィックスが優先）
+ROUTE_REVIEW=/mcp/review|http://copilot-review-mcp:3000
+```
+
+クライアントからのリクエスト分岐：
+- `POST /mcp/review/` → `/mcp/review/` が `/mcp/` より長いため `copilot-review-mcp` へ
+- `POST /mcp/` → `/mcp/` が Copilot API へ
+
+---
+
+## プロトコル互換性
+
+| 項目 | 値 | 互換性 |
+|---|---|---|
+| MCP Protocol Version | `2024-11-05` | ✅ |
+| Transport | SSE (`text/event-stream`) | ✅ (`httputil.ReverseProxy` はストリーミング対応) |
+| Session管理 | `Mcp-Session-Id` ヘッダ | ✅ (proxy が透過転送) |
+| 認証方式 | Bearer token (header) | ✅ (proxy が `Authorization: Bearer <token>` を注入) |
+
+---
+
+## 既知の制限と注意点
+
+### A. `X-Authenticated-User` / `X-GitHub-Login` ヘッダ注入
+
+proxy ハンドラは upstream への全リクエストに `X-Authenticated-User` および
+`X-GitHub-Login` ヘッダを注入する（`internal/proxy/handler.go:44-48`）。
+Copilot API はこれらのヘッダを無視するが、予期しない動作の原因になる可能性は低い。
+
+### B. 401 時の `WWW-Authenticate` ヘッダ
+
+upstream が 401 を返した場合、`WWW-Authenticate` ヘッダはそのまま透過される。
+このヘッダには `resource_metadata` として `https://api.githubcopilot.com/...` が含まれるため、
+クライアントが gateway の OAuth サーバーではなく Copilot API の OAuth サーバーに
+再認証を試みる可能性がある。
+
+→ 将来的に `ModifyResponse` で `WWW-Authenticate` を gateway の discovery URL に
+  書き換えることを検討すること（Issue を起票して追跡）。
+
+### C. copilot-cli での直接接続失敗の根本原因
+
+ユーザーが報告した「copilot-cli での `https://api.githubcopilot.com/mcp/` への直接接続失敗」は、
+トークンの形式の問題ではない（`gho_` トークンでの接続は本調査で確認済み）。
+考えられる原因：
+
+1. **OAuth App のスコープ不一致**：copilot-cli が使用する OAuth App と
+   Copilot API が要求するスコープが一致しない
+2. **MCP client 設定の問題**：`mcp.json` の `url` がゲートウェイを指しており、
+   直接 URL に変更しても認証エンドポイントが `/.well-known/oauth-authorization-server`
+   を期待するが Copilot API では別パスにある
+3. **ネットワーク/プロキシ設定**：法人環境での TLS インスペクション等
+
+mcp-gateway 経由（`github-oauth-proxy`）であれば認証できている現状から、
+**ゲートウェイを経由させる構成が最も安定**。
+
+---
+
+## 結論と推奨事項
+
+### 今すぐ使える構成
+
+```env
+ROUTE_COPILOT=/mcp|https://api.githubcopilot.com
+```
+
+この設定で mcp-gateway を通じて `https://api.githubcopilot.com/mcp/` に
+プロキシすることが可能。標準の `gho_` トークンが使用される。
+
+### 既存の copilot-review-mcp との共存 (docker-compose 例)
+
+```yaml
+services:
+  mcp-gateway:
+    environment:
+      ROUTE_COPILOT: /mcp|https://api.githubcopilot.com
+      ROUTE_REVIEW: /mcp/review|http://copilot-review-mcp:3000
+```
+
+### 中長期的な改善事項
+
+1. `WWW-Authenticate` ヘッダの書き換え（upstream 固有の discovery URL を gateway URL に変換）
+2. per-upstream OAuth App 設定（upstream ごとに異なる client_id を使えるようにする）
+3. パスプレフィックス除去オプション（`ROUTE_X=/prefix|upstream|strip_prefix=true` のような設定）
+
+---
+
+## 参考資料
+
+- [RFC 8707: Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
+- [OAuth 2.0 Protected Resource Metadata](https://www.ietf.org/archive/id/draft-ietf-oauth-resource-metadata-13.txt)
+- GitHub Copilot MCP: `https://api.githubcopilot.com/mcp/`
+- mcp-gateway proxy handler: `internal/proxy/handler.go`
+- mcp-gateway router: `internal/router/router.go`

--- a/tasks.md
+++ b/tasks.md
@@ -17,8 +17,8 @@
 
 | 優先 | ISSUE | 理由 |
 |---|---|---|
-| 1 | **mcp-gateway #19** Compose ルーティング | コード変更ゼロ。Compose 設定だけで copilot-review-mcp の gateway 経由動作を検証 |
-| 2 | **mcp-gateway #18** Copilot API 調査 | curl 数本で方向性が決まる。#19 と並行して進められる |
+| 1 | **mcp-gateway #19** Compose ルーティング | ✅ 完了（PR #20 マージ済み） |
+| 2 | **mcp-gateway #18** Copilot API 調査 | ✅ 完了（PR #21 作成済み） |
 
 ### Phase 2 — #19 動作確認後
 
@@ -57,35 +57,42 @@
 
 ### [#19 feat: copilot-review-mcp を mcp-gateway 経由でルーティングする（Compose 設定 + 動作検証）](https://github.com/scottlz0310/mcp-gateway/issues/19)
 
-**状態**: 未着手
+**状態**: ✅ 完了（2026-04-28、PR #20 マージ済み）
 **依存**: なし
 
 copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083` だけで動作する可能性が高い（Go ServeMux の subtree マッチングによる）。
 
 #### サブタスク
 
-- [ ] mcp-docker 側の Compose 設定変更案作成（`ROUTE_COPILOT_REVIEW` 追加）
-- [ ] MCP クライアント（VS Code / Claude Desktop）での接続テスト
-- [ ] トークン二重検証の影響測定（キャッシュ効果の確認）
-- [ ] copilot-review-mcp への直接接続が壊れないことの確認（後方互換チェック）
-- [ ] README / CHANGELOG への反映
+- [x] mcp-docker 側の Compose 設定変更案作成（`ROUTE_COPILOT_REVIEW` 追加）
+- [x] MCP クライアント（VS Code / Claude Desktop）での接続テスト
+- [x] トークン二重検証の影響測定（キャッシュ効果の確認）
+- [x] copilot-review-mcp への直接接続が壊れないことの確認（後方互換チェック）
+- [x] README / CHANGELOG への反映
 
 ---
 
 ### [#18 spike: https://api.githubcopilot.com/mcp/ を upstream とした際の認証互換性調査](https://github.com/scottlz0310/mcp-gateway/issues/18)
 
-**状態**: 未着手
+**状態**: ✅ 完了（2026-04-28、PR #21）
 **依存**: なし
+**調査結果ドキュメント**: [`docs/spike-18-copilot-api-auth.md`](docs/spike-18-copilot-api-auth.md)
 
-copilot-cli での直接認証失敗の根本原因特定。`gho_...` トークンが Copilot API を通るかが最重要分岐点。
+#### 主な発見
+
+- `gho_` トークン（標準 GitHub OAuth）で MCP initialize 200 OK を確認
+- upstream URL は `https://api.githubcopilot.com`（パスなし）と設定すること（`/mcp/` を含めると二重化）
+- 複数ルートとの共存: `ROUTE_COPILOT=/mcp|https://api.githubcopilot.com` + `ROUTE_REVIEW=/mcp/review|http://...`
+- `WWW-Authenticate` ヘッダの書き換え不要（クライアント側で処理）
+- copilot-cli の直接接続失敗はトークン形式の問題ではなく、OAuth App スコープ or MCP client 設定の問題
 
 #### サブタスク
 
-- [ ] `https://api.githubcopilot.com/.well-known/oauth-authorization-server` の確認
-- [ ] `gho_...` トークンでの直接アクセステスト（`curl -H "Authorization: Bearer gho_..."`)
-- [ ] 必要なトークン形式・OAuth スコープの特定
-- [ ] per-upstream 認証設定の必要性評価
-- [ ] 調査結果を Issue 本文に記録 → 続行 or 別設計を判断
+- [x] `https://api.githubcopilot.com/.well-known/oauth-authorization-server` の確認
+- [x] `gho_...` トークンでの直接アクセステスト（`curl -H "Authorization: Bearer gho_..."`)
+- [x] 必要なトークン形式・OAuth スコープの特定
+- [x] per-upstream 認証設定の必要性評価
+- [x] 調査結果を `docs/spike-18-copilot-api-auth.md` に記録
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -82,8 +82,8 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 - `gho_` トークン（標準 GitHub OAuth）で MCP initialize 200 OK を確認
 - upstream URL は `https://api.githubcopilot.com`（パスなし）と設定すること（`/mcp/` を含めると二重化）
-- 複数ルートとの共存: `ROUTE_COPILOT=/mcp|https://api.githubcopilot.com` + `ROUTE_REVIEW=/mcp/review|http://...`
-- `WWW-Authenticate` ヘッダの書き換え不要（クライアント側で処理）
+- 複数ルートとの共存: `ROUTE_COPILOT=/mcp|https://api.githubcopilot.com` + `ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083`
+- `WWW-Authenticate` ヘッダは、今回検証したクライアント/設定では書き換え不要だったが、401 時の `resource_metadata` は upstream URL を指すため将来的な書き換え検討余地あり
 - copilot-cli の直接接続失敗はトークン形式の問題ではなく、OAuth App スコープ or MCP client 設定の問題
 
 #### サブタスク


### PR DESCRIPTION
## 概要

Issue #18「`https://api.githubcopilot.com/mcp/` を upstream とした際の認証互換性調査」のスパイク結果をまとめたドキュメントを追加する。

## 主な発見

### 認証

- `gho_` トークン（標準 GitHub OAuth App）で MCP initialize **200 OK** を確認
- 必要スコープ: `gist, read:org, repo, workflow`（追加スコープ不要）
- `authorization_servers` は `["https://github.com/login/oauth"]`（既存の `GITHUB_*` env そのまま利用可能）

### パスルーティング（重要な落とし穴）

`httputil.ReverseProxy.SetURL` の `singleJoiningSlash` により、upstream に `/mcp/` を含めるとパスが二重化する：

| 設定 | 実際に転送されるパス |
|---|---|
| ❌ `ROUTE_COPILOT=/mcp\|https://api.githubcopilot.com/mcp/` | `/mcp/mcp/` |
| ✅ `ROUTE_COPILOT=/mcp\|https://api.githubcopilot.com` | `/mcp/` |

### 複数ルートとの共存

longest-prefix-first マッチングにより以下のような共存が可能：

```env
ROUTE_COPILOT=/mcp|https://api.githubcopilot.com
ROUTE_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
```

## 変更ファイル

- `docs/spike-18-copilot-api-auth.md` — スパイク調査ドキュメント（新規）
- `tasks.md` — #18・#19 を完了状態に更新

Closes #18