### PR TITLE
feat(router): per-route auth bypass via auth=none option

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,7 @@ func main() {
 			"name", route.Name,
 			"prefix", route.Prefix,
 			"upstream", route.Upstream.String(),
-			"auth", !route.NoAuth,
+			"auth_required", !route.NoAuth,
 		)
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -92,15 +92,22 @@ func main() {
 		_, _ = fmt.Fprintln(w, `{"status":"ok"}`)
 	})
 
-	// Authenticated proxy routes.
+	// Proxy routes — apply auth middleware unless the route opts out.
 	for _, route := range routes {
 		h := proxy.NewHandler(route.Upstream, oauthHandler)
-		mux.Handle(route.Prefix, authMiddleware(h))
-		mux.Handle(route.Prefix+"/", authMiddleware(h))
+		var wrapped http.Handler
+		if route.NoAuth {
+			wrapped = h
+		} else {
+			wrapped = authMiddleware(h)
+		}
+		mux.Handle(route.Prefix, wrapped)
+		mux.Handle(route.Prefix+"/", wrapped)
 		slog.Info("registered route",
 			"name", route.Name,
 			"prefix", route.Prefix,
 			"upstream", route.Upstream.String(),
+			"auth", !route.NoAuth,
 		)
 	}
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -13,6 +13,7 @@ type Route struct {
 	Name     string
 	Prefix   string
 	Upstream *url.URL
+	NoAuth   bool // true when auth=none is specified; skips OAuth middleware
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url> environment variables
@@ -33,9 +34,21 @@ func parseRoutes(env []string) ([]Route, error) {
 		if name == "" {
 			return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
 		}
-		prefix, upstreamRaw, found := strings.Cut(val, "|")
+		prefix, rest, found := strings.Cut(val, "|")
 		if !found {
 			return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)
+		}
+		upstreamRaw, authOpt, hasAuthOpt := strings.Cut(rest, "|")
+		var noAuth bool
+		if hasAuthOpt {
+			switch authOpt {
+			case "auth=none":
+				noAuth = true
+			case "auth=oauth":
+				noAuth = false
+			default:
+				return nil, fmt.Errorf("%s: unknown auth option %q (use auth=none or auth=oauth)", key, authOpt)
+			}
 		}
 		// Strip trailing slash(es) only when it won't erase the root prefix.
 		if prefix != "/" {
@@ -64,7 +77,7 @@ func parseRoutes(env []string) ([]Route, error) {
 			return nil, fmt.Errorf("%s: duplicate prefix %q", key, prefix)
 		}
 		seen[prefix] = struct{}{}
-		routes = append(routes, Route{Name: name, Prefix: prefix, Upstream: u})
+		routes = append(routes, Route{Name: name, Prefix: prefix, Upstream: u, NoAuth: noAuth})
 	}
 	// Longest prefix first for correct matching order.
 	sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -168,3 +168,67 @@ func TestParseRoutesDuplicatePrefix(t *testing.T) {
 		t.Fatal("expected error for duplicate prefix")
 	}
 }
+
+func TestParseRoutesAuthNone(t *testing.T) {
+	env := []string{"ROUTE_PLAY=/mcp/playwright|http://playwright:8931|auth=none"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !routes[0].NoAuth {
+		t.Error("expected NoAuth=true for auth=none")
+	}
+}
+
+func TestParseRoutesAuthOAuth(t *testing.T) {
+	env := []string{"ROUTE_GH=/mcp/github|http://github-mcp:8082|auth=oauth"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].NoAuth {
+		t.Error("expected NoAuth=false for auth=oauth")
+	}
+}
+
+func TestParseRoutesAuthDefault(t *testing.T) {
+	env := []string{"ROUTE_GH=/mcp/github|http://github-mcp:8082"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].NoAuth {
+		t.Error("expected NoAuth=false when auth option is omitted")
+	}
+}
+
+func TestParseRoutesAuthInvalid(t *testing.T) {
+	env := []string{"ROUTE_BAD=/mcp/bad|http://bad:9000|auth=magic"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for unknown auth option")
+	}
+}
+
+func TestParseRoutesMixedAuth(t *testing.T) {
+	env := []string{
+		"ROUTE_GH=/mcp/github|http://github-mcp:8082",
+		"ROUTE_PLAY=/mcp/playwright|http://playwright:8931|auth=none",
+	}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range routes {
+		switch r.Name {
+		case "gh":
+			if r.NoAuth {
+				t.Errorf("github route should require auth")
+			}
+		case "play":
+			if !r.NoAuth {
+				t.Errorf("playwright route should skip auth")
+			}
+		}
+	}
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -175,6 +175,9 @@ func TestParseRoutesAuthNone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if !routes[0].NoAuth {
 		t.Error("expected NoAuth=true for auth=none")
 	}
@@ -186,6 +189,9 @@ func TestParseRoutesAuthOAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].NoAuth {
 		t.Error("expected NoAuth=false for auth=oauth")
 	}
@@ -196,6 +202,9 @@ func TestParseRoutesAuthDefault(t *testing.T) {
 	routes, err := parseRoutes(env)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 	if routes[0].NoAuth {
 		t.Error("expected NoAuth=false when auth option is omitted")


### PR DESCRIPTION
## 概要 / Summary

ルートごとに OAuth 認証をバイパスできる `auth=none` オプションを追加します。

Adds per-route authentication bypass via `|auth=none` appended to `ROUTE_<NAME>` env vars.

Closes #22

## 変更内容 / Changes

### `internal/router/router.go`
- `Route` 構造体に `NoAuth bool` フィールドを追加
- `parseRoutes` が第3パイプセグメント `auth=none` / `auth=oauth` を解析
- 不明な値は起動時エラー

### `cmd/server/main.go`
- `NoAuth=true` のルートは `authMiddleware` をスキップ
- `registered route` ログに `auth` フィールドを追加

### `internal/router/router_test.go`
- 5件のテストケース追加:
  `TestParseRoutesAuthNone`, `TestParseRoutesAuthOAuth`,
  `TestParseRoutesAuthDefault`, `TestParseRoutesAuthInvalid`,
  `TestParseRoutesMixedAuth`

## 設定例 / Configuration Example

```env
# 認証あり（デフォルト）
ROUTE_GITHUB=/mcp/github|http://github-mcp:8082

# 認証なし（新機能）
ROUTE_PLAYWRIGHT=/mcp/playwright|http://playwright-mcp:8931|auth=none
```

## 後方互換性 / Backward Compatibility

第3セグメントなしの既存設定はすべて `auth=oauth`（認証あり）として動作します。
