### PR TITLE
feat(auth): persistent token store to avoid repeated browser auth (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ Thumbs.db
 
 # Claude Code CLI agent
 .claude/
+
+# coverage artifacts
+*.out
+coverage

--- a/README.ja.md
+++ b/README.ja.md
@@ -46,12 +46,36 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 |------|-----------|------|
 | `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | OAuth コールバック等に使用するベース URL |
 | `MCP_GATEWAY_PORT` | `8080` | リスンポート |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | *(空)* | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
 | `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |
 | `SESSION_TTL_MIN` | `10` | OAuth セッション有効期間（分） |
-| `TOKEN_CACHE_TTL_MIN` | `30` | トークンキャッシュ有効期間（分） |
-| `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日） |
+| `TOKEN_CACHE_TTL_MIN` | `30` | トークン検証キャッシュ TTL（分）— `MCP_GATEWAY_TOKEN_STORE_PATH` 未設定時のみ使用 |
+| `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日）。永続ストアのエントリ TTL にも使用 |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
+
+### 認証状態の永続化
+
+デフォルトでは、検証済みトークンの状態はプロセスメモリにのみ保持されます。そのため、gateway を再起動するたびに MCP クライアント（VS Code、Claude Desktop など）はブラウザの OAuth フローをやり直す必要があります。
+
+これを防ぐには `MCP_GATEWAY_TOKEN_STORE_PATH` に書き込み可能なファイルパスを設定します：
+
+```bash
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
+```
+
+設定すると gateway は以下を行います：
+
+- 起動時にファイルから検証済みトークン ↔ ユーザー識別子のマッピングを読み込む
+- 認証成功のたびにファイルへ保存（期限は `TOKEN_EXPIRES_IN_SEC`、デフォルト 90 日）
+- 毎分、期限切れエントリを自動削除
+- ファイルパーミッション `0600`（所有者のみ読み書き）で書き込む
+- SHA-256 ハッシュ済みのキーのみ保存（生のトークン値はディスクに書き込まれない）
+
+> **Docker ユーザー:** ストアパスに named volume をマウントしてコンテナ入れ替え後もデータを保持してください。
+> 推奨の `docker-compose.yml` スニペットは [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) の関連 Issue を参照してください。
+
+全クライアントの認証状態をリセット（再認証を強制）したい場合は、ストアファイルを削除して gateway を再起動してください。
 
 ## エンドポイント
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,35 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 |----------|---------|-------------|
 | `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | Base URL used for OAuth callback and discovery metadata |
 | `MCP_GATEWAY_PORT` | `8080` | Listen port |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | *(empty)* | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
 | `LOG_LEVEL` | `info` | Log level: `debug` / `info` / `warn` / `error` |
 | `SESSION_TTL_MIN` | `10` | OAuth session lifetime (minutes) |
-| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL (minutes) |
-| `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days) |
+| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL in minutes — used only when `MCP_GATEWAY_TOKEN_STORE_PATH` is **not** set |
+| `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days). Also used as the TTL for persistent token entries |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **Deprecated** — single upstream fallback when no `ROUTE_*` is set |
+
+### Persistent Auth State
+
+By default, validated token state is held only in process memory. This means that every time the gateway restarts, MCP clients (VS Code, Claude Desktop, etc.) must go through the browser OAuth flow again.
+
+To avoid this, set `MCP_GATEWAY_TOKEN_STORE_PATH` to a writable file path:
+
+```bash
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
+```
+
+The gateway will:
+- Load previously validated token ↔ identity mappings on startup
+- Save new mappings on each successful authentication
+- Automatically sweep expired entries every minute
+- Write the file with mode `0600` (owner read/write only)
+- Store only SHA-256-hashed token keys — raw token values never appear on disk
+
+> **Docker users:** mount a named volume at the store path so data survives container replacement.
+> See the companion issue in [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) for the recommended `docker-compose.yml` snippet.
+
+To reset all authentication state (force re-auth for all clients), delete the store file and restart the gateway.
 
 ## Endpoints
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,12 +67,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	oauthHandler := auth.NewHandler(auth.Config{
-		BaseURL:    cfg.baseURL,
-		SessionTTL: time.Duration(cfg.sessionTTLMin) * time.Minute,
-		CacheTTL:   time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
-		ExpiresIn:  time.Duration(cfg.tokenExpiresInSec) * time.Second,
+	oauthHandler, err := auth.NewHandler(auth.Config{
+		BaseURL:        cfg.baseURL,
+		SessionTTL:     time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:       time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:      time.Duration(cfg.tokenExpiresInSec) * time.Second,
+		TokenStorePath: cfg.tokenStorePath,
 	}, prov)
+	if err != nil {
+		slog.Error("auth handler init failed", "err", err)
+		os.Exit(1)
+	}
 
 	authMiddleware := middleware.Auth(oauthHandler)
 
@@ -144,6 +149,7 @@ type config struct {
 	sessionTTLMin      int
 	tokenCacheTTLMin   int
 	tokenExpiresInSec  int
+	tokenStorePath     string
 }
 
 func loadConfig() config {
@@ -158,6 +164,7 @@ func loadConfig() config {
 		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		tokenStorePath:     getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", ""),
 	}
 }
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -32,6 +32,11 @@ type Config struct {
 	// GitHub classic OAuth tokens do not expire on GitHub's side; this only
 	// controls how long the MCP client trusts its cached copy. Defaults to 90 days.
 	ExpiresIn time.Duration
+	// TokenStorePath is the path to the JSON file used for persistent token storage.
+	// When empty, an in-memory store is used (default; data lost on restart).
+	// When set, validated tokens survive container restarts; the file is written
+	// with mode 0600 and only hashed token keys are stored.
+	TokenStorePath string
 }
 
 // Handler implements the OAuth façade endpoints, delegating provider-specific
@@ -43,10 +48,16 @@ type Handler struct {
 }
 
 // NewHandler creates a new OAuth Handler with the given configuration and provider.
-// It panics if p is nil, because all handler methods dereference the provider.
-func NewHandler(cfg Config, p provider.Provider) *Handler {
+// It returns an error if the provider is nil or if the persistent token store
+// cannot be initialized.
+//
+// When cfg.TokenStorePath is non-empty, validated tokens are stored durably in a
+// JSON file so that MCP clients do not need to re-authenticate after gateway
+// restarts. Tokens are stored with TTL equal to cfg.ExpiresIn (default 90 days).
+// When cfg.TokenStorePath is empty, an in-memory store is used (TTL = cfg.CacheTTL).
+func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 	if p == nil {
-		panic("auth.NewHandler: provider must not be nil")
+		return nil, fmt.Errorf("auth.NewHandler: provider must not be nil")
 	}
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	if len(cfg.AllowedRedirectHosts) == 0 {
@@ -55,11 +66,26 @@ func NewHandler(cfg Config, p provider.Provider) *Handler {
 	if cfg.ExpiresIn <= 0 {
 		cfg.ExpiresIn = 90 * 24 * time.Hour
 	}
+
+	var ts TokenStore
+	var tokensTTL time.Duration
+	if cfg.TokenStorePath != "" {
+		fileStore, err := NewFileTokenStore(cfg.TokenStorePath)
+		if err != nil {
+			return nil, fmt.Errorf("auth.NewHandler: token store: %w", err)
+		}
+		ts = fileStore
+		tokensTTL = cfg.ExpiresIn
+	} else {
+		ts = NewMemTokenStore()
+		tokensTTL = cfg.CacheTTL
+	}
+
 	return &Handler{
 		cfg:      cfg,
 		provider: p,
-		store:    NewStore(cfg.SessionTTL, cfg.CacheTTL),
-	}
+		store:    NewStore(cfg.SessionTTL, tokensTTL, ts),
+	}, nil
 }
 
 // Discovery returns RFC 8414 authorization server metadata.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
 )
 
-func newTestHandler() *Handler {
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
 	p := provider.NewGitHub(provider.GitHubConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
@@ -27,13 +28,13 @@ func newTestHandler() *Handler {
 		ExpiresIn:  90 * 24 * time.Hour,
 	}, p)
 	if err != nil {
-		panic(err)
+		t.Fatalf("NewHandler: %v", err)
 	}
 	return h
 }
 
 func TestDiscovery(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
 	w := httptest.NewRecorder()
 
@@ -58,7 +59,7 @@ func TestDiscovery(t *testing.T) {
 }
 
 func TestRegisterReturnsClientID(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	body := `{"redirect_uris":["http://localhost/cb"],"client_name":"test"}`
 	r := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
@@ -82,7 +83,7 @@ func TestRegisterReturnsClientID(t *testing.T) {
 }
 
 func TestRegisterInvalidJSON(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader("not json"))
 	w := httptest.NewRecorder()
 
@@ -94,7 +95,7 @@ func TestRegisterInvalidJSON(t *testing.T) {
 }
 
 func TestAuthorizeMissingParams(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet, "/authorize?response_type=code", nil)
 	w := httptest.NewRecorder()
 
@@ -106,7 +107,7 @@ func TestAuthorizeMissingParams(t *testing.T) {
 }
 
 func TestAuthorizeInvalidResponseType(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet,
 		"/authorize?response_type=token&state=s&redirect_uri=http://localhost/cb", nil)
 	w := httptest.NewRecorder()
@@ -119,7 +120,7 @@ func TestAuthorizeInvalidResponseType(t *testing.T) {
 }
 
 func TestAuthorizeDisallowedRedirectHost(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet,
 		"/authorize?response_type=code&state=s&redirect_uri=http://evil.example.com/cb", nil)
 	w := httptest.NewRecorder()
@@ -139,7 +140,7 @@ func TestNewHandlerErrorsOnNilProvider(t *testing.T) {
 }
 
 func TestAuthorizeRedirectsToGitHub(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet,
 		"/authorize?response_type=code&state=abc123&redirect_uri=http://localhost/cb", nil)
 	w := httptest.NewRecorder()
@@ -159,7 +160,7 @@ func TestAuthorizeRedirectsToGitHub(t *testing.T) {
 }
 
 func TestDiscoveryIncludesDeviceEndpoints(t *testing.T) {
-	h := newTestHandler()
+	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
 	w := httptest.NewRecorder()
 
@@ -210,7 +211,7 @@ func TestDeviceAuthorizeSuccess(t *testing.T) {
 	githubClient = ghServer.Client()
 	defer func() { githubClient = origClient }()
 
-	h := newTestHandler()
+	h := newTestHandler(t)
 
 	// Override the GitHub device endpoint URL by monkey-patching startGitHubDeviceFlow
 	// via a local httptest transport. We can't easily override the URL, so instead we
@@ -258,7 +259,7 @@ func TestTokenDeviceGrantPending(t *testing.T) {
 	defer func() { githubClient.Transport = originalTransport }()
 	githubClient.Transport = rewriteHostTransport{target: ghServer.URL, inner: ghServer.Client().Transport}
 
-	h := newTestHandler()
+	h := newTestHandler(t)
 
 	// Create a pending device session directly in the store.
 	expiresAt := time.Now().Add(15 * time.Minute)
@@ -298,7 +299,7 @@ func TestTokenDeviceGrantSuccess(t *testing.T) {
 	defer func() { githubClient.Transport = originalTransport }()
 	githubClient.Transport = rewriteHostTransport{target: ghServer.URL, inner: ghServer.Client().Transport}
 
-	h := newTestHandler()
+	h := newTestHandler(t)
 
 	expiresAt := time.Now().Add(15 * time.Minute)
 	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5)

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -20,12 +20,16 @@ func newTestHandler() *Handler {
 		RedirectURI:  "http://localhost:8080/callback",
 		Scopes:       "repo,user",
 	})
-	return NewHandler(Config{
+	h, err := NewHandler(Config{
 		BaseURL:    "http://localhost:8080",
 		SessionTTL: 10 * time.Minute,
 		CacheTTL:   5 * time.Minute,
 		ExpiresIn:  90 * 24 * time.Hour,
 	}, p)
+	if err != nil {
+		panic(err)
+	}
+	return h
 }
 
 func TestDiscovery(t *testing.T) {
@@ -127,13 +131,11 @@ func TestAuthorizeDisallowedRedirectHost(t *testing.T) {
 	}
 }
 
-func TestNewHandlerPanicsOnNilProvider(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for nil provider")
-		}
-	}()
-	NewHandler(Config{}, nil)
+func TestNewHandlerErrorsOnNilProvider(t *testing.T) {
+	_, err := NewHandler(Config{}, nil)
+	if err == nil {
+		t.Error("expected error for nil provider")
+	}
 }
 
 func TestAuthorizeRedirectsToGitHub(t *testing.T) {

--- a/internal/auth/os_unix_test.go
+++ b/internal/auth/os_unix_test.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package auth
+
+func isWindows() bool { return false }

--- a/internal/auth/os_windows_test.go
+++ b/internal/auth/os_windows_test.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package auth
+
+func isWindows() bool { return true }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -59,6 +59,9 @@ type Store struct {
 // NewStore creates a Store with the given session TTL and TokenStore, then
 // starts a background janitor.
 func NewStore(sessionTTL, tokensTTL time.Duration, ts TokenStore) *Store {
+	if ts == nil {
+		ts = NewMemTokenStore()
+	}
 	s := &Store{
 		sessions:  make(map[string]*Session),
 		codes:     make(map[string]*Session),

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -206,8 +207,8 @@ func (s *Store) DenyDevice(internalCode string) {
 // TokenStore is configured.
 func (s *Store) CacheToken(token, subject string) {
 	if err := s.tokens.Save(token, subject, time.Now().Add(s.tokensTTL)); err != nil {
-		// Non-fatal: the next request will re-validate against the upstream provider.
-		_ = err
+		// Non-fatal: next request will re-validate against the upstream provider.
+		slog.Warn("token store save failed", "err", err)
 	}
 }
 
@@ -249,7 +250,7 @@ func (s *Store) janitor() {
 			s.mu.Unlock()
 
 			if err := s.tokens.Sweep(); err != nil {
-				_ = err // non-fatal; log suppressed to avoid noise
+				slog.Warn("token store sweep failed", "err", err)
 			}
 		}
 	}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -219,7 +219,11 @@ func (s *Store) LookupToken(token string) (string, bool) {
 
 // InvalidateCachedToken removes a token from the store immediately.
 func (s *Store) InvalidateCachedToken(token string) {
-	_ = s.tokens.Delete(token)
+	if err := s.tokens.Delete(token); err != nil {
+		// Non-fatal: the token will expire naturally, but operators should know
+		// if the store is unwritable.
+		slog.Warn("token store delete failed", "err", err)
+	}
 }
 
 func (s *Store) janitor() {

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -40,18 +40,8 @@ type DeviceSession struct {
 	Status          deviceStatus
 }
 
-type tokenEntry struct {
-	login     string
-	expiresAt time.Time
-}
-
-// TokenCache caches validated GitHub tokens to reduce API calls.
-type TokenCache struct {
-	mu      sync.RWMutex
-	entries map[string]tokenEntry
-}
-
-// Store holds OAuth sessions and the token validation cache.
+// Store holds OAuth flow state (sessions, codes, devices) and delegates token
+// validation persistence to a TokenStore.
 type Store struct {
 	mu       sync.RWMutex
 	sessions map[string]*Session
@@ -59,22 +49,23 @@ type Store struct {
 	devices  map[string]*DeviceSession // keyed by gateway-internal device code
 	ttl      time.Duration
 
-	cache    *TokenCache
-	cacheTTL time.Duration
+	tokens    TokenStore
+	tokensTTL time.Duration // TTL applied when saving a validated token
 
 	stopCh chan struct{}
 }
 
-// NewStore creates a Store with the given TTLs and starts a background janitor.
-func NewStore(sessionTTL, cacheTTL time.Duration) *Store {
+// NewStore creates a Store with the given session TTL and TokenStore, then
+// starts a background janitor.
+func NewStore(sessionTTL, tokensTTL time.Duration, ts TokenStore) *Store {
 	s := &Store{
-		sessions: make(map[string]*Session),
-		codes:    make(map[string]*Session),
-		devices:  make(map[string]*DeviceSession),
-		ttl:      sessionTTL,
-		cache:    &TokenCache{entries: make(map[string]tokenEntry)},
-		cacheTTL: cacheTTL,
-		stopCh:   make(chan struct{}),
+		sessions:  make(map[string]*Session),
+		codes:     make(map[string]*Session),
+		devices:   make(map[string]*DeviceSession),
+		ttl:       sessionTTL,
+		tokens:    ts,
+		tokensTTL: tokensTTL,
+		stopCh:    make(chan struct{}),
 	}
 	go s.janitor()
 	return s
@@ -210,29 +201,24 @@ func (s *Store) DenyDevice(internalCode string) {
 	}
 }
 
-// CacheToken stores a validated login for a token.
-func (s *Store) CacheToken(token, login string) {
-	s.cache.mu.Lock()
-	defer s.cache.mu.Unlock()
-	s.cache.entries[token] = tokenEntry{login: login, expiresAt: time.Now().Add(s.cacheTTL)}
-}
-
-// LookupToken returns (login, true) if token is cached and not expired.
-func (s *Store) LookupToken(token string) (string, bool) {
-	s.cache.mu.RLock()
-	defer s.cache.mu.RUnlock()
-	e, ok := s.cache.entries[token]
-	if !ok || time.Now().After(e.expiresAt) {
-		return "", false
+// CacheToken records that token maps to subject (e.g. GitHub login) and is valid
+// for tokensTTL from now. The entry survives process restarts when a persistent
+// TokenStore is configured.
+func (s *Store) CacheToken(token, subject string) {
+	if err := s.tokens.Save(token, subject, time.Now().Add(s.tokensTTL)); err != nil {
+		// Non-fatal: the next request will re-validate against the upstream provider.
+		_ = err
 	}
-	return e.login, true
 }
 
-// InvalidateCachedToken removes a token from the cache immediately.
+// LookupToken returns (subject, true) if token is cached and not expired.
+func (s *Store) LookupToken(token string) (string, bool) {
+	return s.tokens.Lookup(token)
+}
+
+// InvalidateCachedToken removes a token from the store immediately.
 func (s *Store) InvalidateCachedToken(token string) {
-	s.cache.mu.Lock()
-	defer s.cache.mu.Unlock()
-	delete(s.cache.entries, token)
+	_ = s.tokens.Delete(token)
 }
 
 func (s *Store) janitor() {
@@ -262,13 +248,9 @@ func (s *Store) janitor() {
 			}
 			s.mu.Unlock()
 
-			s.cache.mu.Lock()
-			for k, v := range s.cache.entries {
-				if now.After(v.expiresAt) {
-					delete(s.cache.entries, k)
-				}
+			if err := s.tokens.Sweep(); err != nil {
+				_ = err // non-fatal; log suppressed to avoid noise
 			}
-			s.cache.mu.Unlock()
 		}
 	}
 }

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -196,4 +197,40 @@ func TestTokenCache(t *testing.T) {
 	if ok {
 		t.Fatal("expected cache miss after invalidation")
 	}
+}
+
+// errTokenStore always returns an error from Save and Delete to exercise
+// the error-logging paths in CacheToken and InvalidateCachedToken.
+type errTokenStore struct{ mem *memTokenStore }
+
+func (e *errTokenStore) Save(_, _ string, _ time.Time) error { return fmt.Errorf("injected save error") }
+func (e *errTokenStore) Lookup(token string) (string, bool)  { return e.mem.Lookup(token) }
+func (e *errTokenStore) Delete(_ string) error               { return fmt.Errorf("injected delete error") }
+func (e *errTokenStore) Sweep() error                        { return e.mem.Sweep() }
+
+// TestNewStoreNilTokenStore verifies that a nil TokenStore defaults to memTokenStore.
+func TestNewStoreNilTokenStore(t *testing.T) {
+s := NewStore(10*time.Minute, 5*time.Minute, nil)
+s.CacheToken("tok-nil", "niluser")
+if _, ok := s.LookupToken("tok-nil"); !ok {
+t.Fatal("expected cache hit: nil TokenStore should default to mem store")
+}
+}
+
+// TestCacheTokenSaveError verifies that CacheToken logs (does not panic) when the
+// underlying store returns a Save error.
+func TestCacheTokenSaveError(t *testing.T) {
+ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
+s := NewStore(10*time.Minute, 5*time.Minute, ts)
+// Must not panic; error is logged via slog.Warn.
+s.CacheToken("tok-err", "user")
+}
+
+// TestInvalidateCachedTokenDeleteError verifies that InvalidateCachedToken logs
+// (does not panic) when the underlying store returns a Delete error.
+func TestInvalidateCachedTokenDeleteError(t *testing.T) {
+ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
+s := NewStore(10*time.Minute, 5*time.Minute, ts)
+// Must not panic; error is logged via slog.Warn.
+s.InvalidateCachedToken("tok-err")
 }

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestStoreSessionLifecycle(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
 	s.SaveSession("state1", "http://localhost/cb", "")
 	if !s.HasSession("state1") {
@@ -18,7 +18,7 @@ func TestStoreSessionLifecycle(t *testing.T) {
 }
 
 func TestStoreCompleteCallback(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state2", "http://localhost/cb", "")
 
 	code, err := s.CompleteCallback("state2", "token123", "repo,user")
@@ -43,7 +43,7 @@ func TestStoreCompleteCallback(t *testing.T) {
 }
 
 func TestStoreCompleteCallbackUnknownState(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	_, err := s.CompleteCallback("nosuchstate", "tok", "")
 	if err == nil {
 		t.Fatal("expected error for unknown state")
@@ -51,7 +51,7 @@ func TestStoreCompleteCallbackUnknownState(t *testing.T) {
 }
 
 func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state3", "http://localhost/cb", "")
 
 	code, _ := s.CompleteCallback("state3", "tok", "")
@@ -70,7 +70,7 @@ func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 }
 
 func TestStoreExchangeCodeRedirectURIMismatch(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state4", "http://localhost/cb", "")
 
 	code, _ := s.CompleteCallback("state4", "tok", "")
@@ -85,7 +85,7 @@ func TestStorePKCE(t *testing.T) {
 	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state5", "http://localhost/cb", challenge)
 	code, _ := s.CompleteCallback("state5", "tok", "")
 
@@ -106,7 +106,7 @@ func TestStorePKCE(t *testing.T) {
 func TestStorePKCEInvalidVerifierLength(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state6", "http://localhost/cb", challenge)
 	code, _ := s.CompleteCallback("state6", "tok", "")
 
@@ -117,7 +117,7 @@ func TestStorePKCEInvalidVerifierLength(t *testing.T) {
 }
 
 func TestStoreDeviceLifecycle(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
 	code, err := s.CreateDevice("gh-dev-code", "ABCD-1234", "https://github.com/login/device", expiresAt, 5)
@@ -152,7 +152,7 @@ func TestStoreDeviceLifecycle(t *testing.T) {
 }
 
 func TestStoreDeviceDeny(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
 	code, err := s.CreateDevice("gh-dev", "WXYZ-5678", "https://github.com/login/device", expiresAt, 5)
@@ -171,7 +171,7 @@ func TestStoreDeviceDeny(t *testing.T) {
 }
 
 func TestStoreDeviceNotFound(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
 	_, ok := s.GetDevice("nonexistent-code")
 	if ok {
@@ -180,7 +180,7 @@ func TestStoreDeviceNotFound(t *testing.T) {
 }
 
 func TestTokenCache(t *testing.T) {
-	s := NewStore(10*time.Minute, 5*time.Minute)
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
 	s.CacheToken("tok1", "alice")
 	login, ok := s.LookupToken("tok1")

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+)
+
+// TokenStore persists validated token → identity mappings.
+// Two implementations are provided: memTokenStore (default, in-process) and
+// fileTokenStore (JSON file, survives container restarts).
+type TokenStore interface {
+	// Save records that token maps to subject and is valid until expiresAt.
+	Save(token, subject string, expiresAt time.Time) error
+	// Lookup returns the subject for a non-expired token, or ("", false).
+	Lookup(token string) (subject string, ok bool)
+	// Delete removes a single token entry immediately.
+	Delete(token string) error
+	// Sweep removes all expired entries. Called periodically by the Store janitor.
+	Sweep() error
+}
+
+// tokenKey returns a SHA-256-based key so raw token values are never written
+// to persistent storage.
+func tokenKey(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// ── in-memory implementation ────────────────────────────────────────────────
+
+type memEntry struct {
+	subject   string
+	expiresAt time.Time
+}
+
+type memTokenStore struct {
+	mu      sync.RWMutex
+	entries map[string]memEntry // key: tokenKey(rawToken)
+}
+
+// NewMemTokenStore returns an in-memory TokenStore.
+// All data is lost when the process exits.
+func NewMemTokenStore() TokenStore {
+	return &memTokenStore{entries: make(map[string]memEntry)}
+}
+
+func (m *memTokenStore) Save(token, subject string, expiresAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[tokenKey(token)] = memEntry{subject: subject, expiresAt: expiresAt}
+	return nil
+}
+
+func (m *memTokenStore) Lookup(token string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[tokenKey(token)]
+	if !ok || time.Now().After(e.expiresAt) {
+		return "", false
+	}
+	return e.subject, true
+}
+
+func (m *memTokenStore) Delete(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, tokenKey(token))
+	return nil
+}
+
+func (m *memTokenStore) Sweep() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	for k, v := range m.entries {
+		if now.After(v.expiresAt) {
+			delete(m.entries, k)
+		}
+	}
+	return nil
+}
+
+// ── file-backed implementation ───────────────────────────────────────────────
+
+// fileEntry is the on-disk representation of a single token record.
+// The map key is tokenKey(rawToken), so raw tokens never appear in the file.
+type fileEntry struct {
+	Subject   string    `json:"s"`
+	ExpiresAt time.Time `json:"e"`
+}
+
+type fileTokenStore struct {
+	mu      sync.RWMutex
+	path    string
+	entries map[string]fileEntry // key: tokenKey(rawToken)
+}
+
+// NewFileTokenStore returns a file-backed TokenStore that loads existing entries
+// from path on startup and flushes atomically on every write.
+// The file is created with mode 0600 (owner read/write only).
+// If the file does not yet exist, an empty store is returned without error.
+func NewFileTokenStore(path string) (TokenStore, error) {
+	s := &fileTokenStore{
+		path:    path,
+		entries: make(map[string]fileEntry),
+	}
+	if err := s.load(); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("loading token store %q: %w", path, err)
+	}
+	// Sweep stale entries immediately after load so the first Lookup is clean.
+	_ = s.sweepLocked()
+	count := len(s.entries)
+	slog.Info("token store loaded", "path", path, "entries", count)
+	return s, nil
+}
+
+func (f *fileTokenStore) Save(token, subject string, expiresAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries[tokenKey(token)] = fileEntry{Subject: subject, ExpiresAt: expiresAt}
+	return f.flush()
+}
+
+func (f *fileTokenStore) Lookup(token string) (string, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	e, ok := f.entries[tokenKey(token)]
+	if !ok || time.Now().After(e.ExpiresAt) {
+		return "", false
+	}
+	return e.Subject, true
+}
+
+func (f *fileTokenStore) Delete(token string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.entries, tokenKey(token))
+	return f.flush()
+}
+
+func (f *fileTokenStore) Sweep() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if changed := f.sweepLocked(); !changed {
+		return nil
+	}
+	return f.flush()
+}
+
+// sweepLocked removes expired entries and returns true if any were removed.
+// Must be called with f.mu held for writing.
+func (f *fileTokenStore) sweepLocked() bool {
+	now := time.Now()
+	changed := false
+	for k, v := range f.entries {
+		if now.After(v.ExpiresAt) {
+			delete(f.entries, k)
+			changed = true
+		}
+	}
+	return changed
+}
+
+// load reads and unmarshals the store file. Must be called before the store
+// is shared across goroutines (no lock needed during construction).
+func (f *fileTokenStore) load() error {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, &f.entries)
+}
+
+// flush writes entries to disk atomically via a temp file + rename.
+// Must be called with f.mu held for writing.
+func (f *fileTokenStore) flush() error {
+	data, err := json.Marshal(f.entries)
+	if err != nil {
+		return fmt.Errorf("marshaling token store: %w", err)
+	}
+	tmp := f.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing token store temp file: %w", err)
+	}
+	if err := os.Rename(tmp, f.path); err != nil {
+		return fmt.Errorf("renaming token store: %w", err)
+	}
+	return nil
+}

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -124,12 +124,27 @@ func NewFileTokenStore(path string) (TokenStore, error) {
 		}
 	}
 	// Sweep stale entries immediately after load; flush to disk when any were removed.
+	// Hold the write lock to satisfy flush()'s locking contract even though the store
+	// is not yet shared across goroutines.
+	s.mu.Lock()
 	if changed := s.sweepLocked(); changed {
 		if err := s.flush(); err != nil {
+			s.mu.Unlock()
 			slog.Warn("token store startup sweep flush failed", "path", path, "err", err)
+			// Non-fatal: the store is still usable; stale entries will be removed
+			// by the next periodic Sweep.
+			count := len(s.entries)
+			slog.Info("token store loaded", "path", path, "entries", count)
+			return s, nil
 		}
 	}
 	count := len(s.entries)
+	s.mu.Unlock()
+	// Best-effort: enforce owner-only permissions on an existing file so the
+	// security property holds even when the file was pre-created with looser perms.
+	if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+		slog.Warn("token store chmod failed", "path", path, "err", err)
+	}
 	slog.Info("token store loaded", "path", path, "entries", count)
 	return s, nil
 }
@@ -205,13 +220,34 @@ func (f *fileTokenStore) flush() error {
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
 		return fmt.Errorf("writing token store temp file: %w", err)
 	}
-	if err := os.Rename(tmp, f.path); err != nil {
-		// On some Windows configurations rename fails when the destination exists.
-		// Fall back to an explicit remove-then-rename so the store works cross-platform.
-		_ = os.Remove(f.path)
-		if err2 := os.Rename(tmp, f.path); err2 != nil {
-			return fmt.Errorf("renaming token store: %w", err2)
+	if err := os.Rename(tmp, f.path); err == nil {
+		return nil
+	}
+	// On some Windows configurations rename fails when the destination exists.
+	// Use a backup-based strategy: rename the existing store aside first, promote
+	// the temp file, then remove the backup. On any failure we can restore.
+	backup := f.path + ".bak"
+	_ = os.Remove(backup)
+
+	hadOriginal := false
+	if err2 := os.Rename(f.path, backup); err2 == nil {
+		hadOriginal = true
+	} else if !os.IsNotExist(err2) {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("backing up token store: %w", err2)
+	}
+
+	if err2 := os.Rename(tmp, f.path); err2 != nil {
+		if hadOriginal {
+			if restoreErr := os.Rename(backup, f.path); restoreErr != nil {
+				return fmt.Errorf("renaming token store: %w (restore failed: %v)", err2, restoreErr)
+			}
 		}
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming token store: %w", err2)
+	}
+	if hadOriginal {
+		_ = os.Remove(backup)
 	}
 	return nil
 }

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -115,12 +115,28 @@ func NewFileTokenStore(path string) (TokenStore, error) {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("loading token store %q: %w", path, err)
 		}
-		// File doesn't exist yet — verify the parent directory is accessible so
-		// later Save calls don't silently fail.
-		if dir := filepath.Dir(path); dir != "." {
-			if _, statErr := os.Stat(dir); statErr != nil {
-				return nil, fmt.Errorf("token store parent directory inaccessible %q: %w", dir, statErr)
-			}
+		// File doesn't exist yet — verify the parent directory exists, is a
+		// directory, and is writable so later Save calls don't fail due to a
+		// startup-time misconfiguration.
+		dir := filepath.Dir(path)
+		info, statErr := os.Stat(dir)
+		if statErr != nil {
+			return nil, fmt.Errorf("token store parent directory inaccessible %q: %w", dir, statErr)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("token store parent path is not a directory %q", dir)
+		}
+		f, createErr := os.CreateTemp(dir, ".tokenstore-writecheck-*")
+		if createErr != nil {
+			return nil, fmt.Errorf("token store parent directory not writable %q: %w", dir, createErr)
+		}
+		name := f.Name()
+		if closeErr := f.Close(); closeErr != nil {
+			_ = os.Remove(name)
+			return nil, fmt.Errorf("closing token store parent directory probe file in %q: %w", dir, closeErr)
+		}
+		if removeErr := os.Remove(name); removeErr != nil {
+			return nil, fmt.Errorf("removing token store parent directory probe file %q: %w", name, removeErr)
 		}
 	}
 	// Sweep stale entries immediately after load; flush to disk when any were removed.

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -110,11 +111,24 @@ func NewFileTokenStore(path string) (TokenStore, error) {
 		path:    path,
 		entries: make(map[string]fileEntry),
 	}
-	if err := s.load(); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("loading token store %q: %w", path, err)
+	if err := s.load(); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("loading token store %q: %w", path, err)
+		}
+		// File doesn't exist yet — verify the parent directory is accessible so
+		// later Save calls don't silently fail.
+		if dir := filepath.Dir(path); dir != "." {
+			if _, statErr := os.Stat(dir); statErr != nil {
+				return nil, fmt.Errorf("token store parent directory inaccessible %q: %w", dir, statErr)
+			}
+		}
 	}
-	// Sweep stale entries immediately after load so the first Lookup is clean.
-	_ = s.sweepLocked()
+	// Sweep stale entries immediately after load; flush to disk when any were removed.
+	if changed := s.sweepLocked(); changed {
+		if err := s.flush(); err != nil {
+			slog.Warn("token store startup sweep flush failed", "path", path, "err", err)
+		}
+	}
 	count := len(s.entries)
 	slog.Info("token store loaded", "path", path, "entries", count)
 	return s, nil
@@ -174,6 +188,9 @@ func (f *fileTokenStore) load() error {
 	if err != nil {
 		return err
 	}
+	if len(data) == 0 {
+		return nil // empty or pre-created file — treat as empty store
+	}
 	return json.Unmarshal(data, &f.entries)
 }
 
@@ -189,7 +206,12 @@ func (f *fileTokenStore) flush() error {
 		return fmt.Errorf("writing token store temp file: %w", err)
 	}
 	if err := os.Rename(tmp, f.path); err != nil {
-		return fmt.Errorf("renaming token store: %w", err)
+		// On some Windows configurations rename fails when the destination exists.
+		// Fall back to an explicit remove-then-rename so the store works cross-platform.
+		_ = os.Remove(f.path)
+		if err2 := os.Rename(tmp, f.path); err2 != nil {
+			return fmt.Errorf("renaming token store: %w", err2)
+		}
 	}
 	return nil
 }

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -129,11 +129,11 @@ func NewFileTokenStore(path string) (TokenStore, error) {
 	s.mu.Lock()
 	if changed := s.sweepLocked(); changed {
 		if err := s.flush(); err != nil {
+			count := len(s.entries)
 			s.mu.Unlock()
 			slog.Warn("token store startup sweep flush failed", "path", path, "err", err)
 			// Non-fatal: the store is still usable; stale entries will be removed
 			// by the next periodic Sweep.
-			count := len(s.entries)
 			slog.Info("token store loaded", "path", path, "entries", count)
 			return s, nil
 		}

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func testTokenStoreContract(t *testing.T, ts TokenStore) {
+	t.Helper()
+
+	// Save and Lookup — hit
+	if err := ts.Save("tok1", "alice", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	subj, ok := ts.Lookup("tok1")
+	if !ok {
+		t.Fatal("Lookup: expected hit after Save")
+	}
+	if subj != "alice" {
+		t.Errorf("Lookup: subject got %q, want %q", subj, "alice")
+	}
+
+	// Lookup — miss for unknown token
+	if _, ok := ts.Lookup("unknown"); ok {
+		t.Error("Lookup: expected miss for unknown token")
+	}
+
+	// Delete
+	if err := ts.Delete("tok1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := ts.Lookup("tok1"); ok {
+		t.Error("Lookup: expected miss after Delete")
+	}
+
+	// Expired entries are not returned by Lookup
+	if err := ts.Save("tok2", "bob", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save expired: %v", err)
+	}
+	if _, ok := ts.Lookup("tok2"); ok {
+		t.Error("Lookup: expected miss for expired entry")
+	}
+
+	// Sweep removes expired entries
+	if err := ts.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+}
+
+// ── memTokenStore ─────────────────────────────────────────────────────────────
+
+func TestMemTokenStore(t *testing.T) {
+	testTokenStoreContract(t, NewMemTokenStore())
+}
+
+func TestMemTokenStoreMultiple(t *testing.T) {
+	ts := NewMemTokenStore()
+
+	for i, name := range []string{"alice", "bob", "carol"} {
+		token := string(rune('a' + i))
+		if err := ts.Save(token, name, time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("Save %q: %v", token, err)
+		}
+	}
+
+	for i, want := range []string{"alice", "bob", "carol"} {
+		token := string(rune('a' + i))
+		got, ok := ts.Lookup(token)
+		if !ok {
+			t.Fatalf("Lookup %q: expected hit", token)
+		}
+		if got != want {
+			t.Errorf("Lookup %q: got %q, want %q", token, got, want)
+		}
+	}
+}
+
+// ── fileTokenStore ────────────────────────────────────────────────────────────
+
+func tempStorePath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "tokens.json")
+}
+
+func TestFileTokenStore(t *testing.T) {
+	ts, err := NewFileTokenStore(tempStorePath(t))
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	testTokenStoreContract(t, ts)
+}
+
+// TestFileTokenStorePersistence verifies that entries survive a reload
+// (simulating a container restart).
+func TestFileTokenStorePersistence(t *testing.T) {
+	path := tempStorePath(t)
+
+	ts1, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("initial NewFileTokenStore: %v", err)
+	}
+	if err := ts1.Save("persist-tok", "dave", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Reload from same path — simulates container restart.
+	ts2, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileTokenStore: %v", err)
+	}
+	subj, ok := ts2.Lookup("persist-tok")
+	if !ok {
+		t.Fatal("after reload: expected cache hit for previously saved token")
+	}
+	if subj != "dave" {
+		t.Errorf("after reload: subject got %q, want %q", subj, "dave")
+	}
+}
+
+// TestFileTokenStoreExpiredNotLoaded verifies that expired entries written before
+// a reload do not surface after the reload's startup sweep.
+func TestFileTokenStoreExpiredNotLoaded(t *testing.T) {
+	path := tempStorePath(t)
+
+	ts1, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("initial NewFileTokenStore: %v", err)
+	}
+	// Save an entry that is already expired.
+	if err := ts1.Save("expired-tok", "eve", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Reload: the startup sweep should discard the expired entry.
+	ts2, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileTokenStore: %v", err)
+	}
+	if _, ok := ts2.Lookup("expired-tok"); ok {
+		t.Error("after reload: expired entry should not be returned")
+	}
+}
+
+// TestFileTokenStoreFilePermissions verifies that the store file is written
+// with mode 0600 on Unix systems. Skipped on Windows where ACLs govern access.
+func TestFileTokenStoreFilePermissions(t *testing.T) {
+	if os.Getenv("GOOS") == "windows" {
+		t.Skip("file permission bits not enforced on Windows")
+	}
+	// Also skip at runtime on Windows regardless of GOOS env var.
+	if isWindows() {
+		t.Skip("file permission bits not enforced on Windows")
+	}
+	path := tempStorePath(t)
+	ts, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	if err := ts.Save("tok", "frank", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file permissions: got %04o, want 0600", perm)
+	}
+}
+
+// TestFileTokenStoreMissingFileOK verifies that a non-existent store file is
+// treated as an empty store (no error on startup).
+func TestFileTokenStoreMissingFileOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	if _, err := NewFileTokenStore(path); err != nil {
+		t.Fatalf("NewFileTokenStore with missing file: %v", err)
+	}
+}
+
+// TestFileTokenStoreSweepWritesToDisk verifies that Sweep flushes the pruned
+// state to disk.
+func TestFileTokenStoreSweepWritesToDisk(t *testing.T) {
+	path := tempStorePath(t)
+
+	ts1, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	// One valid, one expired.
+	_ = ts1.Save("valid-tok", "grace", time.Now().Add(time.Hour))
+	_ = ts1.Save("stale-tok", "harry", time.Now().Add(-time.Second))
+	_ = ts1.Sweep()
+
+	// Reload: only valid-tok should be present.
+	ts2, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileTokenStore: %v", err)
+	}
+	if _, ok := ts2.Lookup("valid-tok"); !ok {
+		t.Error("after sweep+reload: valid token should still be present")
+	}
+	if _, ok := ts2.Lookup("stale-tok"); ok {
+		t.Error("after sweep+reload: stale token should have been removed")
+	}
+}

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -149,10 +149,6 @@ func TestFileTokenStoreExpiredNotLoaded(t *testing.T) {
 // TestFileTokenStoreFilePermissions verifies that the store file is written
 // with mode 0600 on Unix systems. Skipped on Windows where ACLs govern access.
 func TestFileTokenStoreFilePermissions(t *testing.T) {
-	if os.Getenv("GOOS") == "windows" {
-		t.Skip("file permission bits not enforced on Windows")
-	}
-	// Also skip at runtime on Windows regardless of GOOS env var.
 	if isWindows() {
 		t.Skip("file permission bits not enforced on Windows")
 	}
@@ -193,9 +189,15 @@ func TestFileTokenStoreSweepWritesToDisk(t *testing.T) {
 		t.Fatalf("NewFileTokenStore: %v", err)
 	}
 	// One valid, one expired.
-	_ = ts1.Save("valid-tok", "grace", time.Now().Add(time.Hour))
-	_ = ts1.Save("stale-tok", "harry", time.Now().Add(-time.Second))
-	_ = ts1.Sweep()
+	if err := ts1.Save("valid-tok", "grace", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save valid token: %v", err)
+	}
+	if err := ts1.Save("stale-tok", "harry", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save stale token: %v", err)
+	}
+	if err := ts1.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
 
 	// Reload: only valid-tok should be present.
 	ts2, err := NewFileTokenStore(path)

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -179,6 +179,40 @@ func TestFileTokenStoreMissingFileOK(t *testing.T) {
 	}
 }
 
+// TestFileTokenStoreParentIsFile verifies that NewFileTokenStore returns an
+// error when the parent path is a regular file rather than a directory.
+func TestFileTokenStoreParentIsFile(t *testing.T) {
+	// Create a regular file and use it as the "directory" component.
+	dir := t.TempDir()
+	notADir := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0600); err != nil {
+		t.Fatalf("setup: WriteFile: %v", err)
+	}
+	path := filepath.Join(notADir, "tokens.json")
+	if _, err := NewFileTokenStore(path); err == nil {
+		t.Fatal("expected error when parent path is a file, got nil")
+	}
+}
+
+// TestFileTokenStoreParentNotWritable verifies that NewFileTokenStore returns
+// an error when the parent directory exists but is not writable.
+// Skipped on Windows where removing write bits via chmod is not reliable.
+func TestFileTokenStoreParentNotWritable(t *testing.T) {
+	if isWindows() {
+		t.Skip("Unix-only: chmod write-bit removal not reliable on Windows")
+	}
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(roDir, 0500); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0700) }) // allow cleanup
+	path := filepath.Join(roDir, "tokens.json")
+	if _, err := NewFileTokenStore(path); err == nil {
+		t.Fatal("expected error for unwritable parent directory, got nil")
+	}
+}
+
 // TestFileTokenStoreSweepWritesToDisk verifies that Sweep flushes the pruned
 // state to disk.
 func TestFileTokenStoreSweepWritesToDisk(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements #24 — Phase 1 (persistent token store).

### Problem
The gateway's uth.Store held all token validation state in process memory. Every container restart forced MCP clients (VS Code, Claude Desktop) through the browser OAuth flow again.

### Solution

**New TokenStore interface** (internal/auth/tokenstore.go) with two implementations:

| Implementation | When used | TTL |
|---|---|---|
| memTokenStore | MCP_GATEWAY_TOKEN_STORE_PATH unset (default) | TOKEN_CACHE_TTL_MIN (30 min) |
| ileTokenStore | MCP_GATEWAY_TOKEN_STORE_PATH set | TOKEN_EXPIRES_IN_SEC (90 days) |

**Security properties of ileTokenStore:**
- Keys are SHA-256 hashes of raw token values — raw tokens never written to disk
- File written with mode \