### PR TITLE
fix(docker): create /data with nonroot ownership in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
     -o /out/mcp-gateway ./cmd/server
+# Pre-create /data with nonroot ownership so Docker copies it into a new named
+# volume on first mount, giving nonroot write access without an init container.
+RUN mkdir -p /out/data && chown 65532:65532 /out/data
 
 # distroless: no shell, no package manager
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /out/mcp-gateway /mcp-gateway
+COPY --chown=nonroot:nonroot --from=builder /out/data /data
 EXPOSE 8080
 # Trivy DS-0002: explicitly declare non-root user (distroless:nonroot UID=65532)
 USER nonroot:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
     -o /out/mcp-gateway ./cmd/server
-# Pre-create /data with nonroot ownership so Docker copies it into a new named
-# volume on first mount, giving nonroot write access without an init container.
-RUN mkdir -p /out/data && chown 65532:65532 /out/data
+# Pre-create /out/data; COPY --chown in the final stage sets nonroot ownership
+# so Docker copies it into a new named volume on first mount, giving nonroot
+# write access without an init container.
+RUN mkdir -p /out/data
 
 # distroless: no shell, no package manager
 FROM gcr.io/distroless/static-debian12:nonroot


### PR DESCRIPTION
## 概要

Fixes #28

Dockerfile の builder stage で \/data\ ディレクトリを UID=65532 (nonroot) 所有で作成し、\COPY --chown=nonroot:nonroot\ で distroless final image に組み込みます。

Docker は名前付きボリュームの**初回マウント時**にイメージのディレクトリ内容（ownership 含む）をボリュームへコピーするため、nonroot プロセスが \/data\ へ書き込めるようになり、init コンテナが不要になります。

## 変更内容

\\\dockerfile
# builder stage
RUN mkdir -p /out/data && chown 65532:65532 /out/data

# final stage
COPY --chown=nonroot:nonroot --from=builder /out/data /data
\\\

## 原因

PR #1 で Dockerfile が初期実装された際、\/data\ ディレクトリの nonroot 所有設定が含まれていませんでした（詳細は issue #28 のコメント参照）。

## 注意事項

- **既存の root 所有ボリューム**には影響しません。Docker はボリュームが既存の場合はコピーを行わないため、移行には \docker volume rm mcp-gateway-data\ が必要です。
- mcp-docker 側 compose.yml から \mcp-gateway-init\ サービスを削除する対応は、本 PR マージ後に別途行います。