### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run tests
+        run: go test -race ./...
+
+  release:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/scottlz0310/mcp-gateway
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -12,7 +12,7 @@
 - Device Authorization Grant (RFC 8628) 実装 ([#10](https://github.com/scottlz0310/mcp-gateway/issues/10))
   - `POST /device_authorization` エンドポイント: gateway が GitHub に Device Flow を開始し、`user_code` と `verification_uri` をクライアントに返す
   - `POST /token` を `grant_type` に応じてディスパッチするよう拡張（`authorization_code` / `urn:ietf:params:oauth:grant-type:device_code`）
-  - `/.well-known/oauth-authorization-server` に `device_authorization_endpoint` と `device_code` grant type を追加
+  - `/.well-known/oauth-authorization-server` に `device_authorization_endpoint` と `urn:ietf:params:oauth:grant-type:device_code` grant type を追加
   - `internal/auth.Store` に `DeviceSession` 管理（CreateDevice / GetDevice / AuthorizeAndConsumeDevice / DenyDevice）を追加
   - `AuthorizeAndConsumeDevice` による TOCTOU 排除：トークン記録とセッション削除を単一 Lock で atomic に実行
 - ルート単位の認証バイパス: `ROUTE_*` の値に `|auth=none` を追加することで、特定ルートの Bearer 検証をスキップ可能 ([#22](https://github.com/scottlz0310/mcp-gateway/issues/22), [PR #23](https://github.com/scottlz0310/mcp-gateway/pull/23))

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,14 +5,23 @@
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-30
+
 ### Added
 
-- Device Authorization Grant (RFC 8628) スパイク実装 (#10)
+- Device Authorization Grant (RFC 8628) 実装 ([#10](https://github.com/scottlz0310/mcp-gateway/issues/10))
   - `POST /device_authorization` エンドポイント: gateway が GitHub に Device Flow を開始し、`user_code` と `verification_uri` をクライアントに返す
   - `POST /token` を `grant_type` に応じてディスパッチするよう拡張（`authorization_code` / `urn:ietf:params:oauth:grant-type:device_code`）
   - `/.well-known/oauth-authorization-server` に `device_authorization_endpoint` と `device_code` grant type を追加
   - `internal/auth.Store` に `DeviceSession` 管理（CreateDevice / GetDevice / AuthorizeAndConsumeDevice / DenyDevice）を追加
   - `AuthorizeAndConsumeDevice` による TOCTOU 排除：トークン記録とセッション削除を単一 Lock で atomic に実行
+- ルート単位の認証バイパス: `ROUTE_*` の値に `|auth=none` を追加することで、特定ルートの Bearer 検証をスキップ可能 ([#22](https://github.com/scottlz0310/mcp-gateway/issues/22), [PR #23](https://github.com/scottlz0310/mcp-gateway/pull/23))
+  - 例: `ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none`
+- `MCP_GATEWAY_TOKEN_STORE_PATH` による永続トークンストア ([#24](https://github.com/scottlz0310/mcp-gateway/issues/24), [PR #25](https://github.com/scottlz0310/mcp-gateway/pull/25))
+  - SHA-256 ハッシュ済みキーによるファイルストア（生トークンはディスクに書き込まれない）
+  - gateway 再起動後も認証状態を維持; エントリは `TOKEN_EXPIRES_IN_SEC`（デフォルト 90 日）で失効
+  - パス未設定時はインメモリストアにフォールバック
+- リフレッシュトークングラント: `POST /token` が `grant_type=refresh_token` をサポート（シングルユース ローテーション）([#26](https://github.com/scottlz0310/mcp-gateway/issues/26), [PR #27](https://github.com/scottlz0310/mcp-gateway/pull/27))
 - マルチアップストリーム例: `examples/copilot-review-routing/` — 単一の mcp-gateway で `github-mcp-server` と `copilot-review-mcp` 両方を `ROUTE_GITHUB` / `ROUTE_COPILOT_REVIEW` でルーティング（[#19](https://github.com/scottlz0310/mcp-gateway/issues/19)）
   - `copilot-review-mcp` 側のコード変更ゼロで動作（Go `ServeMux` の `/mcp/` サブツリーハンドラが転送パスに正しくマッチ）
   - `docker-compose.yml`・`.env.example`・専用 `README.md` を含む
@@ -22,7 +31,15 @@
 - `internal/auth` を `Provider` インターフェースで抽象化。GitHub OAuth 通信ロジックを `internal/auth/provider/github.go` に分離した。外部 IF（環境変数・エンドポイント・OAuth フロー）は変更なし（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
 - リバースプロキシが上流 MCP サービスに送出するヘッダに `X-Authenticated-User` を追加。`X-GitHub-Login` も互換のため引き続き送出する（[#2](https://github.com/scottlz0310/mcp-gateway/issues/2)）。
 
+### Fixed
+
+- Docker イメージに `/data` ディレクトリを事前作成。`MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json` がディレクトリの手動作成なしで動作するよう修正 ([#28](https://github.com/scottlz0310/mcp-gateway/issues/28), [PR #29](https://github.com/scottlz0310/mcp-gateway/pull/29))
+- `.gitignore` に `*.exe` を追加（Windows ビルド成果物を除外）
+
 ### Internal
 
 - `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
 - `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。
+
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/scottlz0310/mcp-gateway/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Device Authorization Grant (RFC 8628) implementation ([#10](https://github.com/scottlz0310/mcp-gateway/issues/10))
   - `POST /device_authorization` endpoint: gateway initiates GitHub Device Flow and returns `user_code` and `verification_uri` to the client
   - `POST /token` extended to dispatch by `grant_type` (`authorization_code` / `urn:ietf:params:oauth:grant-type:device_code`)
-  - `/.well-known/oauth-authorization-server` now includes `device_authorization_endpoint` and `device_code` grant type
+  - `/.well-known/oauth-authorization-server` now includes `device_authorization_endpoint` and `urn:ietf:params:oauth:grant-type:device_code` in supported `grant_types`
   - Added `DeviceSession` management to `internal/auth.Store` (CreateDevice / GetDevice / AuthorizeAndConsumeDevice / DenyDevice)
   - `AuthorizeAndConsumeDevice` eliminates TOCTOU races: token recording and session deletion are atomic under a single lock
 - Per-route authentication bypass: append `|auth=none` to a `ROUTE_*` value to opt individual routes out of Bearer validation ([#22](https://github.com/scottlz0310/mcp-gateway/issues/22), [PR #23](https://github.com/scottlz0310/mcp-gateway/pull/23))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,23 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-30
+
 ### Added
-- Device Authorization Grant (RFC 8628) spike implementation (#10)
-  - `POST /device_authorization` endpoint: gateway が GitHub に Device Flow を開始し、`user_code` と `verification_uri` をクライアントに返す
-  - `POST /token` を `grant_type` に応じてディスパッチするよう拡張（`authorization_code` / `urn:ietf:params:oauth:grant-type:device_code`）
-  - `/.well-known/oauth-authorization-server` に `device_authorization_endpoint` と `device_code` grant type を追加
-  - `internal/auth.Store` に `DeviceSession` 管理（CreateDevice / GetDevice / AuthorizeAndConsumeDevice / DenyDevice）を追加
-  - `AuthorizeAndConsumeDevice` による TOCTOU 排除：トークン記録とセッション削除を単一 Lock で atomic に実行
-  - GitHub Device Flow では `client_secret` 不要であることを確認済み（`client_id` のみで動作）
+
+- Device Authorization Grant (RFC 8628) implementation ([#10](https://github.com/scottlz0310/mcp-gateway/issues/10))
+  - `POST /device_authorization` endpoint: gateway initiates GitHub Device Flow and returns `user_code` and `verification_uri` to the client
+  - `POST /token` extended to dispatch by `grant_type` (`authorization_code` / `urn:ietf:params:oauth:grant-type:device_code`)
+  - `/.well-known/oauth-authorization-server` now includes `device_authorization_endpoint` and `device_code` grant type
+  - Added `DeviceSession` management to `internal/auth.Store` (CreateDevice / GetDevice / AuthorizeAndConsumeDevice / DenyDevice)
+  - `AuthorizeAndConsumeDevice` eliminates TOCTOU races: token recording and session deletion are atomic under a single lock
+- Per-route authentication bypass: append `|auth=none` to a `ROUTE_*` value to opt individual routes out of Bearer validation ([#22](https://github.com/scottlz0310/mcp-gateway/issues/22), [PR #23](https://github.com/scottlz0310/mcp-gateway/pull/23))
+  - Example: `ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none`
+- Persistent token store via `MCP_GATEWAY_TOKEN_STORE_PATH` ([#24](https://github.com/scottlz0310/mcp-gateway/issues/24), [PR #25](https://github.com/scottlz0310/mcp-gateway/pull/25))
+  - File-backed store with SHA-256-hashed keys (raw tokens never written to disk)
+  - Survives gateway restarts; entries expire after `TOKEN_EXPIRES_IN_SEC` (default 90 days)
+  - Falls back to in-memory store when path is not set
+- Refresh token grant: `POST /token` now supports `grant_type=refresh_token` with single-use rotation ([#26](https://github.com/scottlz0310/mcp-gateway/issues/26), [PR #27](https://github.com/scottlz0310/mcp-gateway/pull/27))
 - Multi-upstream example: `examples/copilot-review-routing/` — single mcp-gateway routing both `github-mcp-server` and `copilot-review-mcp` via `ROUTE_GITHUB` / `ROUTE_COPILOT_REVIEW` ([#19](https://github.com/scottlz0310/mcp-gateway/issues/19))
   - `copilot-review-mcp` requires no code changes; its Go `ServeMux` `/mcp/` subtree handler matches the forwarded path correctly
   - Includes `docker-compose.yml`, `.env.example`, and a dedicated `README.md`
@@ -25,9 +34,14 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Reverse proxy now injects `X-Authenticated-User` header into upstream requests. `X-GitHub-Login` continues to be sent for backward compatibility ([#2](https://github.com/scottlz0310/mcp-gateway/issues/2)).
 
 ### Fixed
-- `.gitignore` に `*.exe` を追加（Windows ビルド成果物を除外）
+
+- Docker image now pre-creates `/data` directory so `MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json` works without a manually created volume directory ([#28](https://github.com/scottlz0310/mcp-gateway/issues/28), [PR #29](https://github.com/scottlz0310/mcp-gateway/pull/29))
+- `.gitignore`: added `*.exe` to exclude Windows build artifacts
 
 ### Internal
 
 - Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
 - Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).
+
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/scottlz0310/mcp-gateway/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 scottlz0310
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,6 +40,12 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 
 複数のルートを設定した場合、**最長プレフィックスが優先**されます。
 
+特定のルートで Bearer 検証を無効にするには、第3セグメントとして `|auth=none` を追加します（公開エンドポイントや認証前のパスに使用）:
+
+```bash
+ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
+```
+
 ### オプション環境変数
 
 | 変数 | デフォルト | 説明 |
@@ -84,7 +90,8 @@ MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
 | `/.well-known/oauth-authorization-server` | GET | RFC 8414 メタデータ |
 | `/authorize` | GET | OAuth 認可エンドポイント |
 | `/callback` | GET | GitHub OAuth コールバック |
-| `/token` | POST | トークンエンドポイント（PKCE 対応） |
+| `/device_authorization` | POST | Device Authorization Grant エンドポイント（RFC 8628） |
+| `/token` | POST | トークンエンドポイント（`authorization_code` + PKCE、`device_code`、`refresh_token` グラント対応） |
 | `/register` | POST | RFC 7591 動的クライアント登録（疑似） |
 | `/health` | GET | ヘルスチェック |
 | `/<prefix>` | ANY | Bearer 検証後、対応アップストリームへリバースプロキシ |

--- a/README.ja.md
+++ b/README.ja.md
@@ -91,10 +91,10 @@ MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
 | `/authorize` | GET | OAuth 認可エンドポイント |
 | `/callback` | GET | GitHub OAuth コールバック |
 | `/device_authorization` | POST | Device Authorization Grant エンドポイント（RFC 8628） |
-| `/token` | POST | トークンエンドポイント（`authorization_code` + PKCE、`device_code`、`refresh_token` グラント対応） |
+| `/token` | POST | トークンエンドポイント（`authorization_code` + PKCE、`urn:ietf:params:oauth:grant-type:device_code`、`refresh_token` グラント対応） |
 | `/register` | POST | RFC 7591 動的クライアント登録（疑似） |
 | `/health` | GET | ヘルスチェック |
-| `/<prefix>` | ANY | Bearer 検証後、対応アップストリームへリバースプロキシ |
+| `/<prefix>` | ANY | マッチしたルート設定に応じて認証（例: Bearer 検証または `auth=none`）を適用し、対応アップストリームへリバースプロキシ |
 
 ## クイックスタート
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 - Prefixes **must** start with `/`
 - Upstream URLs must be absolute `http` or `https`
 - When multiple routes match, the **longest prefix wins**
+- Append `|auth=none` as a third segment to disable Bearer validation for a specific route (e.g., for public or pre-auth endpoints):
+
+  ```bash
+  ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
+  ```
 
 ### Optional Environment Variables
 
@@ -99,7 +104,8 @@ To reset all authentication state (force re-auth for all clients), delete the st
 | `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server metadata |
 | `/authorize` | GET | OAuth 2.0 authorization endpoint |
 | `/callback` | GET | GitHub OAuth callback |
-| `/token` | POST | Token endpoint (authorization code + PKCE) |
+| `/device_authorization` | POST | Device Authorization Grant endpoint (RFC 8628) |
+| `/token` | POST | Token endpoint — supports `authorization_code` + PKCE, `urn:ietf:params:oauth:grant-type:device_code`, and `refresh_token` grants |
 | `/register` | POST | RFC 7591 dynamic client registration (pseudo) |
 | `/health` | GET | Health check — returns `{"status":"ok"}` |
 | `/<prefix>` | ANY | Bearer-validated reverse proxy to the matched upstream |

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To reset all authentication state (force re-auth for all clients), delete the st
 | `/token` | POST | Token endpoint — supports `authorization_code` + PKCE, `urn:ietf:params:oauth:grant-type:device_code`, and `refresh_token` grants |
 | `/register` | POST | RFC 7591 dynamic client registration (pseudo) |
 | `/health` | GET | Health check — returns `{"status":"ok"}` |
-| `/<prefix>` | ANY | Bearer-validated reverse proxy to the matched upstream |
+| `/<prefix>` | ANY | Reverse proxy to the matched upstream — Bearer-validated unless `auth=none` is set for the matched route |
 
 ## Internal Design
 

--- a/tasks.md
+++ b/tasks.md
@@ -344,6 +344,6 @@ builder ステージで `/data` を `nonroot:nonroot` 所有で作成し、init 
 #### サブタスク
 
 - [x] GitHub Device Grant エンドポイント（`client_secret` 要否）の確認
-- [x] gateway 内 Device Grant フロー設計（`POST /device_authorization`・`POST /token` device_code grant）
+- [x] gateway 内 Device Grant フロー設計（`POST /device_authorization`・`POST /token` `grant_type=urn:ietf:params:oauth:grant-type:device_code`）
 - [x] MCP Authorization Server Metadata への `device_authorization_endpoint` 追加
 - [x] 既存 Authorization Code Flow との共存設計・実装

--- a/tasks.md
+++ b/tasks.md
@@ -11,14 +11,14 @@
 
 ---
 
-## 推奨消化順（2026-04-28 更新）
+## 推奨消化順（2026-04-30 更新）
 
 ### Phase 1 — 今すぐ着手（コード変更不要）
 
 | 優先 | ISSUE | 理由 |
 |---|---|---|
 | 1 | **mcp-gateway #19** Compose ルーティング | ✅ 完了（PR #20 マージ済み） |
-| 2 | **mcp-gateway #18** Copilot API 調査 | ✅ 完了（PR #21 作成済み） |
+| 2 | **mcp-gateway #18** Copilot API 調査 | ✅ 完了（PR #21 マージ済み） |
 
 ### Phase 2 — #19 動作確認後
 
@@ -39,7 +39,6 @@
 
 | ISSUE | 保留理由 |
 |---|---|
-| **#10** Device Authorization Grant 調査 | #11 依存・優先度低 |
 | **#6** 汎用 OIDC | #18 結果次第で再評価 |
 | **#5** env var 移行 | 追加プロバイダ確定まで YAGNI |
 | **#4** fly.io OAuth | fly.io と直接調整が必要 |
@@ -74,7 +73,7 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 ### [#18 spike: https://api.githubcopilot.com/mcp/ を upstream とした際の認証互換性調査](https://github.com/scottlz0310/mcp-gateway/issues/18)
 
-**状態**: ✅ 完了（2026-04-28、PR #21）
+**状態**: ✅ 完了（2026-04-28、PR #21 マージ済み）
 **依存**: なし
 **調査結果ドキュメント**: [`docs/spike-18-copilot-api-auth.md`](docs/spike-18-copilot-api-auth.md)
 
@@ -199,31 +198,6 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 ---
 
-### [#10 spike: Device Authorization Grant を gateway レイヤーで実装する可能性調査](https://github.com/scottlz0310/mcp-gateway/issues/10)
-
-**状態**: 未着手
-**依存**: #2（完了済み）、#11（config persistence）
-
-"OAuthログインで全認証完了" を実現するための前調査。Device Grant は **gateway が実行する**アーキテクチャを採用する。
-
-**確定アーキテクチャ:**
-```
-MCP Client → mcp-gateway（Device Grant 実行）→ GitHub
-```
-
-MCPクライアント直の Device Grant（gateway は validation のみ）は**採用しない**（トークン分散・セッション非共有・refresh管理破綻のため）。
-
-#### サブタスク
-
-- [ ] GitHub Device Grant エンドポイント（`client_secret` 要否）の確認
-- [ ] gateway 内 Device Grant フロー設計（`POST /auth/device`・`GET /auth/device/poll`）
-- [ ] MCP Authorization Server Metadata への `device_authorization_endpoint` 追加検討
-- [ ] VS Code Copilot 拡張が Device Grant を実際に利用するか動作確認
-- [ ] 既存 Authorization Code Flow との共存設計
-- [ ] 後続実装 ISSUE のスコープ・前提条件確定
-
----
-
 ### [#6 feat: 汎用 OIDC（OpenID Connect）プロバイダサポート](https://github.com/scottlz0310/mcp-gateway/issues/6)
 
 **状態**: 保留（2026-04-27）
@@ -294,8 +268,7 @@ MCPクライアント直の Device Grant（gateway は validation のみ）は**
 
 ### [#2 refactor: OAuth プロバイダ抽象化（Provider インターフェース導入・GitHub 実装の移植）](https://github.com/scottlz0310/mcp-gateway/issues/2)
 
-**状態**: 実装完了・PR レビュー中
-**ブランチ**: `refactor/oauth-provider-abstraction`
+**状態**: ✅ 完了（2026-04-28、PR #7 マージ済み）
 **依存**: なし
 
 GitHub 固定の OAuth フローを `Provider` インターフェースに抽象化。本 issue は **GitHub-only リファクタ**に限定し、外部 IF（環境変数・エンドポイント・OAuth フロー）は 100% 維持する。
@@ -322,3 +295,55 @@ GitHub 固定の OAuth フローを `Provider` インターフェースに抽象
 
 **状態**: クローズ（2026-04-27・YAGNI）
 **理由**: Google 公式 MCP サーバーは OAuth + Streamable HTTP を既に内包。対象 MCP サーバーが具体的に決まるまで見送り。
+
+---
+
+### [#22 feat: per-route auth bypass via ROUTE_<NAME>=<prefix>|<upstream>|auth=none](https://github.com/scottlz0310/mcp-gateway/issues/22)
+
+**状態**: ✅ 完了（2026-04-28、PR #23 マージ済み）
+**依存**: なし
+
+`ROUTE_<NAME>` 環境変数の第3セグメントに `auth=none` を指定すると、そのルートで認証ミドルウェアをスキップする。Copilot API の like public upstream に使用。
+
+---
+
+### [#24 feat: OAuth トークン/セッション状態の永続化（再認証スキップ）](https://github.com/scottlz0310/mcp-gateway/issues/24)
+
+**状態**: ✅ 完了（2026-04-28、PR #25 マージ済み）
+**依存**: なし
+
+`MCP_GATEWAY_TOKEN_STORE_PATH` 環境変数でJSON ファイルベースのトークンストアを有効化。ゲートウェイ再起動後もMCPクライアントの再認証不要。
+
+---
+
+### [#26 fix: リフレッシュトークン切れによる「session not found」エラー調査と対処](https://github.com/scottlz0310/mcp-gateway/issues/26)
+
+**状態**: ✅ 完了（2026-04-30、PR #27 マージ済み）
+**依存**: なし
+
+RFC 6749 §6 の `grant_type=refresh_token` を実装。アクセストークン期限切れ時にリフレッシュトークンで再発行できるようにした（ローテーション付き・並列リクエスト対応）。
+
+---
+
+### [#28 fix: Dockerfile `/data` ディレクトリを nonroot 所有で作成](https://github.com/scottlz0310/mcp-gateway/issues/28)
+
+**状態**: ✅ 完了（2026-04-30、PR #29 マージ済み）
+**依存**: なし
+
+builder ステージで `/data` を `nonroot:nonroot` 所有で作成し、init コンテナなしで永続ストアが書き込み可能になった。
+
+---
+
+### [#10 spike: Device Authorization Grant を gateway レイヤーで実装する可能性調査](https://github.com/scottlz0310/mcp-gateway/issues/10)
+
+**状態**: ✅ 完了（2026-04-28、PR #14 マージ済み）
+**依存**: #2（完了済み）
+
+`POST /device_authorization` + `/token` の device_code grant を実装済み。アーキテクチャは **gateway が Device Grant を実行する**方式（MCP Client → mcp-gateway → GitHub）。
+
+#### サブタスク
+
+- [x] GitHub Device Grant エンドポイント（`client_secret` 要否）の確認
+- [x] gateway 内 Device Grant フロー設計（`POST /device_authorization`・`POST /token` device_code grant）
+- [x] MCP Authorization Server Metadata への `device_authorization_endpoint` 追加
+- [x] 既存 Authorization Code Flow との共存設計・実装


### PR DESCRIPTION
## Summary

v0.1.0 初回リリースに向けた準備一式。

## Changes

| File | Description |
|------|-------------|
| \LICENSE\ | MIT ライセンス追加（新規） |
| \CHANGELOG.md\ | \[Unreleased]\ → \[0.1.0] - 2026-04-30\ に昇格。auth=none (#22)・persistent token store (#24)・refresh_token (#26)・Docker /data fix (#28) のエントリを追加 |
| \CHANGELOG.ja.md\ | 英語版と同期（全エントリを日本語で整理・補完） |
| \README.md\ | Endpoints テーブルに \/device_authorization\・複数 grant 対応を追記。Route Configuration に \uth=none\ の説明を追加 |
| \README.ja.md\ | 同様に日本語側も更新 |
| \.github/workflows/release.yml\ | \*\ タグ push をトリガーに：テスト → multi-arch Docker ビルド（amd64/arm64）→ semver タグ（\0.1.0\, \