### PR TITLE
feat(auth): serialize per-device GitHub polling to avoid rate limits

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Device Flow の per-device ポーリング直列化 ([#16](https://github.com/scottlz0310/mcp-gateway/issues/16))
+  - `internal/auth.Store` に `AcquireDevicePolling` / `ReleaseDevicePolling` を追加し、同一 `device_code` に対する GitHub ポーリングを 1 リクエストのみに制限
+  - in-flight 中に届いた並列リクエストは即座に `authorization_pending` を返すため、GitHub の `slow_down` / レート制限（RFC 8628 §3.5）を誘発しない
+
 ## [0.1.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Device Flow per-device polling serialization ([#16](https://github.com/scottlz0310/mcp-gateway/issues/16))
+  - `AcquireDevicePolling` / `ReleaseDevicePolling` added to `internal/auth.Store` to serialize concurrent GitHub polling per `device_code`
+  - Concurrent requests presenting the same `device_code` while one is already polling GitHub receive `authorization_pending` immediately, preventing `slow_down` / rate-limit responses from GitHub (RFC 8628 §3.5)
+
 ## [0.1.0] - 2026-04-30
 
 ### Added

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -297,6 +297,15 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Serialize concurrent GitHub polls for the same device_code. If another
+	// goroutine is already polling GitHub, return authorization_pending
+	// immediately to avoid triggering rate-limiting or slow_down responses.
+	if !h.store.AcquireDevicePolling(deviceCode) {
+		oauthError(w, "authorization_pending", "polling in progress, please retry", http.StatusBadRequest)
+		return
+	}
+	defer h.store.ReleaseDevicePolling(deviceCode)
+
 	// Status is pending: poll GitHub on behalf of the client.
 	result, err := h.pollGitHubDeviceToken(r.Context(), pending.GitHubDevCode)
 	if err != nil {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -297,10 +297,26 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Serialize concurrent GitHub polls for the same device_code. If another
-	// goroutine is already polling GitHub, return authorization_pending
-	// immediately to avoid triggering rate-limiting or slow_down responses.
+	// Serialize concurrent GitHub polls for the same device_code. AcquireDevicePolling
+	// returns false in two cases: (1) another goroutine is already polling, or (2) the
+	// session was consumed/removed between GetDevice and this point.
+	// Re-check the session state to return the most accurate OAuth error.
 	if !h.store.AcquireDevicePolling(deviceCode) {
+		current, ok := h.store.GetDevice(deviceCode)
+		if !ok {
+			// Session consumed by a concurrent winner.
+			oauthError(w, "invalid_grant", "device code already consumed", http.StatusBadRequest)
+			return
+		}
+		if time.Now().After(current.ExpiresAt) {
+			oauthError(w, "expired_token", "device code expired", http.StatusBadRequest)
+			return
+		}
+		if current.Status == deviceDenied {
+			oauthError(w, "access_denied", "user denied authorization", http.StatusBadRequest)
+			return
+		}
+		// Another goroutine is actively polling; client should retry.
 		oauthError(w, "authorization_pending", "polling in progress, please retry", http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -216,9 +216,15 @@ func (s *Store) DenyDevice(internalCode string) {
 
 // AcquireDevicePolling atomically marks the device session as in-flight for
 // GitHub polling. It returns true when the caller wins the race and must call
-// ReleaseDevicePolling when done. It returns false when another goroutine is
-// already polling for the same device code; the caller should return
-// authorization_pending immediately without contacting GitHub.
+// ReleaseDevicePolling when done. It returns false in two cases:
+//
+//  1. Another goroutine is already polling GitHub for the same device code
+//     (pollingInFlight is true).
+//  2. The device session no longer exists (e.g. it was already consumed or
+//     expired and cleaned up by the janitor).
+//
+// Callers should distinguish these cases by re-reading the session state when
+// false is returned.
 func (s *Store) AcquireDevicePolling(internalCode string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -39,6 +39,7 @@ type DeviceSession struct {
 	AccessToken     string
 	Scope           string
 	Status          deviceStatus
+	pollingInFlight bool // true while one request is actively polling GitHub
 }
 
 // refreshEntry stores the underlying access token for a gateway-issued refresh token.
@@ -210,6 +211,35 @@ func (s *Store) DenyDevice(internalCode string) {
 	defer s.mu.Unlock()
 	if d, ok := s.devices[internalCode]; ok {
 		d.Status = deviceDenied
+	}
+}
+
+// AcquireDevicePolling atomically marks the device session as in-flight for
+// GitHub polling. It returns true when the caller wins the race and must call
+// ReleaseDevicePolling when done. It returns false when another goroutine is
+// already polling for the same device code; the caller should return
+// authorization_pending immediately without contacting GitHub.
+func (s *Store) AcquireDevicePolling(internalCode string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d, ok := s.devices[internalCode]
+	if !ok {
+		return false
+	}
+	if d.pollingInFlight {
+		return false
+	}
+	d.pollingInFlight = true
+	return true
+}
+
+// ReleaseDevicePolling clears the in-flight flag set by AcquireDevicePolling.
+// It is a no-op when the device session no longer exists (e.g. consumed).
+func (s *Store) ReleaseDevicePolling(internalCode string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d, ok := s.devices[internalCode]; ok {
+		d.pollingInFlight = false
 	}
 }
 

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -395,3 +395,81 @@ func TestRestoreRefreshToken(t *testing.T) {
 		t.Errorf("access token after restore: got %q, want %q", got, "tok-restore")
 	}
 }
+
+func TestAcquireDevicePollingSerializes(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+	expiresAt := time.Now().Add(15 * time.Minute)
+
+	code, err := s.CreateDevice("gh-dev", "ABCD-9999", "https://github.com/login/device", expiresAt, 5)
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	// First acquire must succeed.
+	if !s.AcquireDevicePolling(code) {
+		t.Fatal("expected AcquireDevicePolling to return true for first caller")
+	}
+	// While the first is held, concurrent callers must be rejected.
+	if s.AcquireDevicePolling(code) {
+		t.Fatal("expected AcquireDevicePolling to return false when in-flight")
+	}
+
+	s.ReleaseDevicePolling(code)
+
+	// After release, next caller must succeed again.
+	if !s.AcquireDevicePolling(code) {
+		t.Fatal("expected AcquireDevicePolling to return true after release")
+	}
+	s.ReleaseDevicePolling(code)
+}
+
+func TestAcquireDevicePollingConcurrent(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+	expiresAt := time.Now().Add(15 * time.Minute)
+
+	code, err := s.CreateDevice("gh-dev-concurrent", "EFGH-0001", "https://github.com/login/device", expiresAt, 5)
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+
+	const goroutines = 20
+	wins := make(chan bool, goroutines)
+	for range goroutines {
+		go func() {
+			acquired := s.AcquireDevicePolling(code)
+			wins <- acquired
+			if acquired {
+				s.ReleaseDevicePolling(code)
+			}
+		}()
+	}
+
+	var acquired int
+	for range goroutines {
+		if <-wins {
+			acquired++
+		}
+	}
+	if acquired != goroutines {
+		// All goroutines run sequentially (each releases before the next wins),
+		// so total wins must equal goroutines.
+		// A stricter requirement would be acquired == 1, but that is timing-
+		// dependent. What we can assert is at least one won, and no more than
+		// goroutines won (which is trivially true). The real assertion is that
+		// the store never panics and all goroutines complete cleanly.
+		t.Logf("concurrent wins: %d/%d (serialization working correctly)", acquired, goroutines)
+	}
+}
+
+func TestAcquireDevicePollingUnknownCode(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+	if s.AcquireDevicePolling("no-such-code") {
+		t.Fatal("expected AcquireDevicePolling to return false for unknown code")
+	}
+}
+
+func TestReleaseDevicePollingNoOp(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+	// Must not panic when session does not exist.
+	s.ReleaseDevicePolling("no-such-code")
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -433,16 +434,26 @@ func TestAcquireDevicePollingConcurrent(t *testing.T) {
 	}
 
 	const goroutines = 20
+	start := make(chan struct{})
+	release := make(chan struct{})
 	wins := make(chan bool, goroutines)
+	var wg sync.WaitGroup
+
 	for range goroutines {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
+			<-start // wait for all goroutines to be ready before racing
 			acquired := s.AcquireDevicePolling(code)
 			wins <- acquired
 			if acquired {
+				<-release // hold the flag until the test says to release
 				s.ReleaseDevicePolling(code)
 			}
 		}()
 	}
+
+	close(start) // release all goroutines simultaneously
 
 	var acquired int
 	for range goroutines {
@@ -450,15 +461,19 @@ func TestAcquireDevicePollingConcurrent(t *testing.T) {
 			acquired++
 		}
 	}
-	if acquired != goroutines {
-		// All goroutines run sequentially (each releases before the next wins),
-		// so total wins must equal goroutines.
-		// A stricter requirement would be acquired == 1, but that is timing-
-		// dependent. What we can assert is at least one won, and no more than
-		// goroutines won (which is trivially true). The real assertion is that
-		// the store never panics and all goroutines complete cleanly.
-		t.Logf("concurrent wins: %d/%d (serialization working correctly)", acquired, goroutines)
+
+	if acquired != 1 {
+		t.Fatalf("expected exactly 1 successful acquire during contention, got %d/%d", acquired, goroutines)
 	}
+
+	close(release) // allow the winner to release
+	wg.Wait()      // ensure winner goroutine has called ReleaseDevicePolling before proceeding
+
+	// After the winner releases, the next caller must be able to acquire again.
+	if !s.AcquireDevicePolling(code) {
+		t.Fatal("expected AcquireDevicePolling to succeed after contention winner released")
+	}
+	s.ReleaseDevicePolling(code)
 }
 
 func TestAcquireDevicePollingUnknownCode(t *testing.T) {

--- a/tasks.md
+++ b/tasks.md
@@ -101,17 +101,17 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 ### [#16 feat(auth): Device Flow の同時ポーリングを per-device で直列化して GitHub レート制限を回避](https://github.com/scottlz0310/mcp-gateway/issues/16)
 
-**状態**: 未着手（PR #14 Copilot レビュー指摘：スレッド PRRT_kwDOSNXuJs59--1H）
+**状態**: 実装済み・PR 作成中
 **依存**: なし
 
 同一 `device_code` への並列リクエストが GitHub を同時 polling → `slow_down` / レート制限を誘発する問題。
 
 #### サブタスク
 
-- [ ] per-device mutex（または singleflight）の実装
-- [ ] 既存 `AuthorizeAndConsumeDevice` との整合性確認
-- [ ] テスト追加（並列リクエストのシミュレーション）
-- [ ] PR #14 のレビューコメント（PRRT_kwDOSNXuJs59--1H）への対応・スレッドクローズ
+- [x] per-device mutex（または singleflight）の実装 → `AcquireDevicePolling` / `ReleaseDevicePolling`
+- [x] 既存 `AuthorizeAndConsumeDevice` との整合性確認
+- [x] テスト追加（並列リクエストのシミュレーション）
+- [ ] PR #14 のレビューコメント（PRRT_kwDOSNXuJs59--1H）への対応・スレッドクローズ（PR マージ後）
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #16 対応。同一 `device_code` に対して複数リクエストが同時に GitHub token polling エンドポイントを叩く問題を修正する。

## 問題

`/token` エンドポイントに同一 `device_code` を持つ並列リクエストが届いた場合、それぞれが独立して GitHub の polling API を呼ぶ。`AuthorizeAndConsumeDevice` がトークン重複発行を防止する一方で、並列 polling は GitHub の `slow_down` / レート制限（RFC 8628 §3.5）を誘発しやすい。

## 変更内容

### `internal/auth/session.go`

- `DeviceSession` に `pollingInFlight bool` フィールドを追加（Store の `mu` で保護）
- `AcquireDevicePolling(internalCode string) bool` を追加
  - `pollingInFlight` を CAS 的にセット。すでに in-flight なら `false` を返す
- `ReleaseDevicePolling(internalCode string)` を追加
  - フラグをリセット。セッション消滅後（消費済み）は no-op

### `internal/auth/handler.go`

- `tokenDeviceGrant` で `pollGitHubDeviceToken` 呼び出し前に `AcquireDevicePolling` を実行
- 取得失敗（= 他リクエストが in-flight）時は `authorization_pending` を即時返却
- `defer ReleaseDevicePolling` でフラグを確実に解放

### `internal/auth/session_test.go`

- `TestAcquireDevicePollingSerializes` — 取得・保持中の拒否・解放後の再取得を検証
- `TestAcquireDevicePollingConcurrent` — 20 goroutine 並列でパニックなし・データ競合なしを確認
- `TestAcquireDevicePollingUnknownCode` — 存在しない code は `false`
- `TestReleaseDevicePollingNoOp` — 存在しない code でもパニックしない

## 受け入れ条件

- [x] 同一 `device_code` に対して同時に GitHub polling が走るリクエストは 1 つ以下に制限される
- [x] `AuthorizeAndConsumeDevice` の atomic 保証は維持される
- [x] 既存テストがすべて通ること
- [x] Store の単体テストで並列ポーリング抑制を検証すること

Closes #16