### PR TITLE
fix: default TokenStorePath to /data/tokens.json; RFC 6750/9728 auth error responses

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,12 +62,15 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 
 ### 認証状態の永続化
 
-デフォルトでは、検証済みトークンの状態は `/data/tokens.json` に永続化されます（Docker イメージに適切なパーミッションで事前作成済みのディレクトリ）。通常運用では **gateway を再起動しても MCP クライアント（VS Code、Claude Desktop など）の再認証は不要です**。
+> **Docker デフォルト:** デフォルトのストアパス `/data/tokens.json` は Docker 運用向けです。Docker イメージは `/data` を適切なパーミッションで事前作成しています。Docker 以外（`go run` やバイナリ直接実行）では `/data` が存在しないため起動に失敗します。その場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を書き込み可能なパス（例: `./tokens.json`）に設定するか、永続化を無効にするため空文字を設定してください。
+
+デフォルトでは、検証済みトークンの状態は `/data/tokens.json` に永続化されます。通常運用では **gateway を再起動しても MCP クライアント（VS Code、Claude Desktop など）の再認証は不要です**。
 
 ストアパスを変更したい場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を設定します。永続化を無効にしてインメモリのみに戻す場合（本番環境では非推奨）は空文字を設定します：
 
 ```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # デフォルト
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # デフォルト（Docker）
+MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json       # ローカル実行時
 MCP_GATEWAY_TOKEN_STORE_PATH=                   # 永続化を無効化（非推奨）
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,22 +52,23 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 |------|-----------|------|
 | `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | OAuth コールバック等に使用するベース URL |
 | `MCP_GATEWAY_PORT` | `8080` | リスンポート |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | *(空)* | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
 | `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |
 | `SESSION_TTL_MIN` | `10` | OAuth セッション有効期間（分） |
-| `TOKEN_CACHE_TTL_MIN` | `30` | トークン検証キャッシュ TTL（分）— `MCP_GATEWAY_TOKEN_STORE_PATH` 未設定時のみ使用 |
+| `TOKEN_CACHE_TTL_MIN` | `30` | トークン検証キャッシュ TTL（分）— `MCP_GATEWAY_TOKEN_STORE_PATH` を空文字に明示設定した場合のみ使用 |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日）。永続ストアのエントリ TTL にも使用 |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
 
 ### 認証状態の永続化
 
-デフォルトでは、検証済みトークンの状態はプロセスメモリにのみ保持されます。そのため、gateway を再起動するたびに MCP クライアント（VS Code、Claude Desktop など）はブラウザの OAuth フローをやり直す必要があります。
+デフォルトでは、検証済みトークンの状態は `/data/tokens.json` に永続化されます（Docker イメージに適切なパーミッションで事前作成済みのディレクトリ）。通常運用では **gateway を再起動しても MCP クライアント（VS Code、Claude Desktop など）の再認証は不要です**。
 
-これを防ぐには `MCP_GATEWAY_TOKEN_STORE_PATH` に書き込み可能なファイルパスを設定します：
+ストアパスを変更したい場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を設定します。永続化を無効にしてインメモリのみに戻す場合（本番環境では非推奨）は空文字を設定します：
 
 ```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # デフォルト
+MCP_GATEWAY_TOKEN_STORE_PATH=                   # 永続化を無効化（非推奨）
 ```
 
 設定すると gateway は以下を行います：

--- a/README.md
+++ b/README.md
@@ -67,22 +67,23 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 |----------|---------|-------------|
 | `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | Base URL used for OAuth callback and discovery metadata |
 | `MCP_GATEWAY_PORT` | `8080` | Listen port |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | *(empty)* | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
 | `LOG_LEVEL` | `info` | Log level: `debug` / `info` / `warn` / `error` |
 | `SESSION_TTL_MIN` | `10` | OAuth session lifetime (minutes) |
-| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL in minutes — used only when `MCP_GATEWAY_TOKEN_STORE_PATH` is **not** set |
+| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL in minutes — used only when `MCP_GATEWAY_TOKEN_STORE_PATH` is explicitly set to empty |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days). Also used as the TTL for persistent token entries |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **Deprecated** — single upstream fallback when no `ROUTE_*` is set |
 
 ### Persistent Auth State
 
-By default, validated token state is held only in process memory. This means that every time the gateway restarts, MCP clients (VS Code, Claude Desktop, etc.) must go through the browser OAuth flow again.
+By default, validated token state is persisted to `/data/tokens.json` (a directory pre-created by the Docker image with appropriate permissions). This means MCP clients (VS Code, Claude Desktop, etc.) **do not need to re-authenticate after gateway restarts** under normal operation.
 
-To avoid this, set `MCP_GATEWAY_TOKEN_STORE_PATH` to a writable file path:
+To change the store path, set `MCP_GATEWAY_TOKEN_STORE_PATH`. To disable persistence and revert to in-memory-only storage (not recommended for production), set it to an empty string:
 
 ```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # default
+MCP_GATEWAY_TOKEN_STORE_PATH=                   # disable persistence (not recommended)
 ```
 
 The gateway will:

--- a/README.md
+++ b/README.md
@@ -77,12 +77,15 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 
 ### Persistent Auth State
 
-By default, validated token state is persisted to `/data/tokens.json` (a directory pre-created by the Docker image with appropriate permissions). This means MCP clients (VS Code, Claude Desktop, etc.) **do not need to re-authenticate after gateway restarts** under normal operation.
+> **Docker default:** The default store path `/data/tokens.json` is designed for Docker deployments — the Docker image pre-creates `/data` with the correct permissions. If you run the gateway with `go run` or a bare binary outside Docker, `/data` likely does not exist and the gateway will fail to start. In that case set `MCP_GATEWAY_TOKEN_STORE_PATH` to a writable path (e.g. `./tokens.json`) or set it to empty to disable persistence.
+
+By default, validated token state is persisted to `/data/tokens.json`. This means MCP clients (VS Code, Claude Desktop, etc.) **do not need to re-authenticate after gateway restarts** under normal operation.
 
 To change the store path, set `MCP_GATEWAY_TOKEN_STORE_PATH`. To disable persistence and revert to in-memory-only storage (not recommended for production), set it to an empty string:
 
 ```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # default
+MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # default (Docker)
+MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json       # local run
 MCP_GATEWAY_TOKEN_STORE_PATH=                   # disable persistence (not recommended)
 ```
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,7 @@ func loadConfig() config {
 		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
-		tokenStorePath:     getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", ""),
+		tokenStorePath:     getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -79,11 +79,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	authMiddleware := middleware.Auth(oauthHandler)
+	authMiddleware := middleware.Auth(oauthHandler, middleware.WithBaseURL(cfg.baseURL))
 
 	mux := http.NewServeMux()
 
 	// OAuth façade endpoints (no auth required).
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", oauthHandler.ProtectedResourceMetadata)
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
 	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
 	mux.HandleFunc("GET /callback", oauthHandler.Callback)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,7 @@ func loadConfig() config {
 		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
-		tokenStorePath:     getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
+		tokenStorePath:     lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
 	}
 }
 
@@ -181,6 +181,16 @@ func mustEnv(key string) string {
 func getEnv(key, fallback string) string {
 	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		return v
+	}
+	return fallback
+}
+
+// lookupEnv returns the trimmed env value if the variable is set (even if empty),
+// otherwise returns fallback. Use instead of getEnv when an empty value has meaning
+// (e.g. MCP_GATEWAY_TOKEN_STORE_PATH="" disables persistence).
+func lookupEnv(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return strings.TrimSpace(v)
 	}
 	return fallback
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -106,6 +106,21 @@ func (h *Handler) refreshTokenTTL() time.Duration {
 	return h.cfg.ExpiresIn + refreshTokenGracePeriod
 }
 
+// ProtectedResourceMetadata implements RFC 9728 OAuth 2.0 Protected Resource
+// Metadata. MCP clients that receive a 401 with a resource_metadata parameter
+// in the WWW-Authenticate header fetch this endpoint to discover the gateway's
+// authorization server, enabling re-authentication via the OAuth flow instead
+// of falling back to alternative auth methods (e.g. gh CLI).
+func (h *Handler) ProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"resource":                 h.cfg.BaseURL,
+		"authorization_servers":    []string{h.cfg.BaseURL},
+		"bearer_methods_supported": []string{"header"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
 // Discovery returns RFC 8414 authorization server metadata.
 func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 	doc := map[string]any{

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -61,6 +61,36 @@ func TestDiscovery(t *testing.T) {
 	}
 }
 
+func TestProtectedResourceMetadata(t *testing.T) {
+	h := newTestHandler(t)
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	w := httptest.NewRecorder()
+
+	h.ProtectedResourceMetadata(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusOK)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+	var doc map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&doc); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if doc["resource"] != "http://localhost:8080" {
+		t.Errorf("resource: got %v, want http://localhost:8080", doc["resource"])
+	}
+	servers, ok := doc["authorization_servers"].([]any)
+	if !ok || len(servers) == 0 || servers[0] != "http://localhost:8080" {
+		t.Errorf("authorization_servers: got %v", doc["authorization_servers"])
+	}
+	bearerMethods, ok := doc["bearer_methods_supported"].([]any)
+	if !ok || len(bearerMethods) == 0 || bearerMethods[0] != "header" {
+		t.Errorf("bearer_methods_supported: got %v", doc["bearer_methods_supported"])
+	}
+}
+
 func TestRegisterReturnsClientID(t *testing.T) {
 	h := newTestHandler(t)
 	body := `{"redirect_uris":["http://localhost/cb"],"client_name":"test"}`

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -56,7 +56,7 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractBearer(r)
 			if token == "" {
-				writeUnauthorized(w, "missing_token",
+				writeUnauthorized(w, "invalid_request",
 					"No access token provided. Authenticate via the gateway OAuth flow.",
 					options.baseURL)
 				return
@@ -96,14 +96,16 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 // MCP clients to the gateway's OAuth re-authentication flow.
 func writeUnauthorized(w http.ResponseWriter, errCode, errDesc, baseURL string) {
 	parts := []string{`Bearer realm="mcp-gateway"`}
-	if errCode != "missing_token" {
-		// Per RFC 6750 §3.1, error attributes only apply to token validation failures,
-		// not to requests that simply lack authentication.
+	if errCode == "invalid_token" {
+		// Per RFC 6750 §3.1, error= is only included for token validation failures
+		// (invalid_token), not for requests that simply lack a token (invalid_request).
 		parts = append(parts, fmt.Sprintf(`error=%q, error_description=%q`, errCode, errDesc))
 	}
 	if baseURL != "" {
 		parts = append(parts, fmt.Sprintf(`resource_metadata=%q`, baseURL+"/.well-known/oauth-protected-resource"))
 	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", strings.Join(parts, ", "))
 	w.WriteHeader(http.StatusUnauthorized)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -97,8 +97,9 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 func writeUnauthorized(w http.ResponseWriter, errCode, errDesc, baseURL string) {
 	parts := []string{`Bearer realm="mcp-gateway"`}
 	if errCode == "invalid_token" {
-		// Per RFC 6750 §3.1, error= is only included for token validation failures
-		// (invalid_token), not for requests that simply lack a token (invalid_request).
+		// By design, error= is only included for token validation failures (invalid_token).
+		// For missing-token requests (invalid_request), we intentionally omit error= to avoid
+		// leaking that a credential is required on unauthenticated probes.
 		parts = append(parts, fmt.Sprintf(`error=%q, error_description=%q`, errCode, errDesc))
 	}
 	if baseURL != "" {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -27,14 +28,37 @@ type upstreamErrorer interface {
 	IsUpstreamError() bool
 }
 
+// authOptions holds optional configuration for the Auth middleware.
+type authOptions struct {
+	baseURL string
+}
+
+// AuthOption configures the Auth middleware.
+type AuthOption func(*authOptions)
+
+// WithBaseURL sets the gateway base URL so that 401 responses include a
+// resource_metadata parameter in the WWW-Authenticate header (RFC 9728)
+// pointing to /.well-known/oauth-protected-resource. This enables MCP
+// clients to discover the gateway OAuth flow for re-authentication instead
+// of falling back to alternative auth methods (e.g. gh CLI).
+func WithBaseURL(u string) AuthOption {
+	return func(o *authOptions) { o.baseURL = strings.TrimRight(u, "/") }
+}
+
 // Auth returns a middleware that validates Bearer tokens via the configured
 // OAuth provider.
-func Auth(v TokenValidator) func(http.Handler) http.Handler {
+func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler {
+	var options authOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractBearer(r)
 			if token == "" {
-				writeUnauthorized(w, "missing_token")
+				writeUnauthorized(w, "missing_token",
+					"No access token provided. Authenticate via the gateway OAuth flow.",
+					options.baseURL)
 				return
 			}
 
@@ -45,11 +69,16 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 					slog.Error("upstream error during auth", "err", err, "path", r.URL.Path)
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusServiceUnavailable)
-					_ = json.NewEncoder(w).Encode(map[string]string{"error": "upstream_error"})
+					_ = json.NewEncoder(w).Encode(map[string]string{
+						"error":             "upstream_error",
+						"error_description": "The upstream MCP server is temporarily unavailable. Please try again later.",
+					})
 					return
 				}
 				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
-				writeUnauthorized(w, "invalid_token")
+				writeUnauthorized(w, "invalid_token",
+					"Access token expired or invalid. Re-authenticate via the gateway OAuth flow.",
+					options.baseURL)
 				return
 			}
 
@@ -60,11 +89,28 @@ func Auth(v TokenValidator) func(http.Handler) http.Handler {
 	}
 }
 
-func writeUnauthorized(w http.ResponseWriter, errCode string) {
+// writeUnauthorized writes an RFC 6750 §3.1 compliant 401 Unauthorized response.
+// For token validation failures (invalid_token), the WWW-Authenticate header
+// includes error and error_description attributes.
+// When baseURL is non-empty, resource_metadata (RFC 9728) is added to guide
+// MCP clients to the gateway's OAuth re-authentication flow.
+func writeUnauthorized(w http.ResponseWriter, errCode, errDesc, baseURL string) {
+	parts := []string{`Bearer realm="mcp-gateway"`}
+	if errCode != "missing_token" {
+		// Per RFC 6750 §3.1, error attributes only apply to token validation failures,
+		// not to requests that simply lack authentication.
+		parts = append(parts, fmt.Sprintf(`error=%q, error_description=%q`, errCode, errDesc))
+	}
+	if baseURL != "" {
+		parts = append(parts, fmt.Sprintf(`resource_metadata=%q`, baseURL+"/.well-known/oauth-protected-resource"))
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("WWW-Authenticate", `Bearer realm="mcp-gateway"`)
+	w.Header().Set("WWW-Authenticate", strings.Join(parts, ", "))
 	w.WriteHeader(http.StatusUnauthorized)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": errCode})
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             errCode,
+		"error_description": errDesc,
+	})
 }
 
 func extractBearer(r *http.Request) string {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -135,7 +135,7 @@ func TestAuthMissingTokenWithBaseURL(t *testing.T) {
 		t.Errorf("WWW-Authenticate missing resource_metadata: %q", wwwAuth)
 	}
 	if strings.Contains(wwwAuth, `error="invalid_request"`) {
-		t.Errorf("WWW-Authenticate should not include error= for missing token per RFC 6750 §3.1: %q", wwwAuth)
+		t.Errorf("WWW-Authenticate should not include error= for missing token (design choice): %q", wwwAuth)
 	}
 }
 

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -40,7 +40,7 @@ func TestAuthMissingToken(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status: got %d, want %d", w.Code, http.StatusUnauthorized)
 	}
-	assertJSONError(t, w, "missing_token")
+	assertJSONError(t, w, "invalid_request")
 	assertWWWAuthenticate(t, w)
 }
 
@@ -134,7 +134,7 @@ func TestAuthMissingTokenWithBaseURL(t *testing.T) {
 	if !strings.Contains(wwwAuth, "resource_metadata") {
 		t.Errorf("WWW-Authenticate missing resource_metadata: %q", wwwAuth)
 	}
-	if strings.Contains(wwwAuth, `error="missing_token"`) {
+	if strings.Contains(wwwAuth, `error="invalid_request"`) {
 		t.Errorf("WWW-Authenticate should not include error= for missing token per RFC 6750 §3.1: %q", wwwAuth)
 	}
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -106,6 +107,9 @@ func assertJSONError(t *testing.T, w *httptest.ResponseRecorder, wantCode string
 	if body["error"] != wantCode {
 		t.Errorf("error field: got %q, want %q", body["error"], wantCode)
 	}
+	if body["error_description"] == "" {
+		t.Error("error_description field missing or empty")
+	}
 }
 
 func assertWWWAuthenticate(t *testing.T, w *httptest.ResponseRecorder) {
@@ -113,5 +117,50 @@ func assertWWWAuthenticate(t *testing.T, w *httptest.ResponseRecorder) {
 	h := w.Header().Get("WWW-Authenticate")
 	if h == "" {
 		t.Error("WWW-Authenticate header missing")
+	}
+}
+
+func TestAuthMissingTokenWithBaseURL(t *testing.T) {
+	h := Auth(&mockValidator{login: "alice"}, WithBaseURL("https://gateway.example.com"))(http.HandlerFunc(okHandler))
+	r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	wwwAuth := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(wwwAuth, "resource_metadata") {
+		t.Errorf("WWW-Authenticate missing resource_metadata: %q", wwwAuth)
+	}
+	if strings.Contains(wwwAuth, `error="missing_token"`) {
+		t.Errorf("WWW-Authenticate should not include error= for missing token per RFC 6750 §3.1: %q", wwwAuth)
+	}
+}
+
+func TestAuthInvalidTokenWithBaseURL(t *testing.T) {
+	h := Auth(&mockValidator{err: fmt.Errorf("bad token")}, WithBaseURL("https://gateway.example.com"))(http.HandlerFunc(okHandler))
+	r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	r.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	wwwAuth := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(wwwAuth, `error="invalid_token"`) {
+		t.Errorf("WWW-Authenticate missing error=invalid_token: %q", wwwAuth)
+	}
+	if !strings.Contains(wwwAuth, "error_description") {
+		t.Errorf("WWW-Authenticate missing error_description: %q", wwwAuth)
+	}
+	if !strings.Contains(wwwAuth, "resource_metadata") {
+		t.Errorf("WWW-Authenticate missing resource_metadata: %q", wwwAuth)
+	}
+	if !strings.Contains(wwwAuth, "/.well-known/oauth-protected-resource") {
+		t.Errorf("WWW-Authenticate resource_metadata should point to /.well-known/oauth-protected-resource: %q", wwwAuth)
 	}
 }


### PR DESCRIPTION
## 概要

PR #34 でリフレッシュトークンのファイル永続化は実装済みでしたが、`MCP_GATEWAY_TOKEN_STORE_PATH` のデフォルトが空文字のため、通常の Docker 起動では in-memory store が使われ続けていました。ユーザーが環境変数を知って明示設定しない限り、gateway 再起動時にトークンが失われる問題が残っていました。

## 変更内容

### 1. デフォルト TokenStorePath を `/data/tokens.json` に変更

- `cmd/server/main.go`: `getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "")` → `getEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json")`
- Dockerfile はすでに `/data` を nonroot 書き込み可能で作成済みのため、設定不要で動作する
- 無効化したい場合は `MCP_GATEWAY_TOKEN_STORE_PATH=` を明示設定
- README / README.ja.md の環境変数テーブルと「永続化」セクションを更新

### 2. RFC 6750 §3.1 / RFC 9728 準拠の認証エラーレスポンス

認証切れ時に gh CLI 等へフォールバックしてしまう問題に対処するため、401 レスポンスを標準準拠に改善：

- **`GET /.well-known/oauth-protected-resource`** 新規エンドポイント (RFC 9728)
  - `{"resource": "<baseURL>", "authorization_servers": ["<baseURL>"], "bearer_methods_supported": ["header"]}` を返す
- **`WWW-Authenticate`** ヘッダーに `error=`, `error_description=`, `resource_metadata=` を追加 (RFC 6750 §3.1)
- すべての 401/503 JSON ボディに `error_description` フィールドを追加
- `middleware.Auth()` に `WithBaseURL(u string)` オプションを追加（後方互換）

## テスト

```
go test ./...  # all pass
```

新規テスト：
- `TestProtectedResourceMetadata`
- `TestAuthMissingTokenWithBaseURL`
- `TestAuthInvalidTokenWithBaseURL`

## 関連

- PR #34 の運用上の未完了部分（永続化がデフォルト有効化されていない問題）を解消
