### PR TITLE
chore(tasks): record ph3-6 (#11) design decisions — age encryption + key management

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -11,7 +11,7 @@
 
 ---
 
-## 推奨消化順（2026-04-30 更新）
+## 推奨消化順（2026-05-04 更新）
 
 ### Phase 1 — 今すぐ着手（コード変更不要）
 
@@ -25,14 +25,14 @@
 | 優先 | ISSUE | 状態/理由 |
 |---|---|---|
 | 3 | **mcp-gateway #16** Device Flow 直列化 | ✅ 完了（PR #31 マージ済み） |
-| 4 | **copilot-review-mcp #12** AUTH_MODE=gateway | #19 で二重検証が問題になる場合に対処。変更量は小 |
-| 5 | **mcp-gateway #15** ユーザーホワイトリスト | 運用上の需要が出たタイミングで |
+| 4 | **copilot-review-mcp #12** AUTH_MODE=gateway | ✅ 完了（2026-05-04） |
+| 5 | **mcp-gateway #15** ユーザーホワイトリスト | ⏭️ SKIP（ローカル Docker 運用継続、ホスティング移行時に再評価） |
 
 ### Phase 3 — インフラ整備（長期）
 
 | 優先 | ISSUE | 理由 |
 |---|---|---|
-| 6 | **mcp-gateway #11** Config Persistence | 大きめ。Phase 2 が安定してから |
+| 6 | **mcp-gateway #11** Config Persistence | 🎯 次ターゲット。暗号化方式の技術選択が先決 |
 | 7 | **mcp-gateway #12** Setup Wizard | #11 完了が前提 |
 
 ### 保留維持
@@ -117,7 +117,7 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 #### [copilot-review-mcp #12 feat: AUTH_MODE=gateway 対応（mcp-gateway 経由モード・二重検証の排除）](https://github.com/scottlz0310/copilot-review-mcp/issues/12)
 
-**状態**: 未着手（#19 動作確認後に着手）
+**状態**: ✅ 完了（2026-05-04）
 **リポジトリ**: `scottlz0310/copilot-review-mcp`
 **依存**: mcp-gateway #19
 
@@ -156,24 +156,187 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 ### [#11 feat: Config Persistence Layer（env vars → YAML/SQLite 設定ファイル）](https://github.com/scottlz0310/mcp-gateway/issues/11)
 
-**状態**: 保留
+**状態**: 🎯 次ターゲット（技術選択フェーズ）
 **依存**: なし（独立着手可能）
 
-> **保留理由（2026-04-30）**: Docker 運用継続中は env var で十分機能しており YAGNI。
-> ホスティング移行やマルチユーザー運用が現実になったタイミングで再評価する。
-> SQLite・管理画面・Setup Wizard はそれ以降に検討（過剰設計を避ける）。
+> **方針変更（2026-05-04）**: ローカル Docker 運用継続を前提に着手。
+> コンテナ起動時に `GITHUB_MCP_CLIENT_SECRET` 等が必須なため、これを config ファイルに永続化し
+> 再起動時に env var 不要にすることを目的とする。
+> SQLite・管理画面は引き続き後回し。まず YAML + シークレット暗号化 に絞る。
 
-`mustEnv` によるクラッシュを撤廃し、設定を YAML / SQLite で永続管理する。env vars はオーバーライド手段として維持（12-factor 互換）。
+`mustEnv` によるクラッシュを撤廃し、設定を YAML で永続管理する。env vars はオーバーライド手段として維持（12-factor 互換）。
+
+#### シークレット暗号化 — 技術選択（2026-05-04 確定）
+
+**暗号化対象フィールド**
+
+| フィールド | env var | 暗号化 |
+|---|---|---|
+| GitHub OAuth Client Secret | `GITHUB_MCP_CLIENT_SECRET` | ✅ 必須暗号化 |
+| GitHub OAuth Client ID | `GITHUB_MCP_CLIENT_ID` | ❌ 平文（OAuth 安全モデル上公開前提） |
+| tokens.json | — | ❌ 対象外（今回のスコープ外） |
+| 将来の追加プロバイダ credential | TBD | ✅ 同様の方針で対応 |
+
+**採用ライブラリ: `filippo.io/age`（X25519）**
+
+**キー管理方針（優先順位）**
+
+```
+優先順位:  gateway.key  >  MCP_GATEWAY_MASTER_KEY  >  自動生成
+
+1. /data/gateway.key が存在する → パース・検証して使用（MCP_GATEWAY_MASTER_KEY は無視）
+   ⛔ 存在するが読み取り不能・形式不正・空ファイル・パース失敗の場合は
+      自動再生成・上書きを一切行わない。明確なエラーで起動を停止する。
+      slog.Error("gateway.key exists but is invalid; refusing to overwrite to avoid data loss", "path", path, "err", err)
+      os.Exit(1)
+      ★ 新規生成してよいのは「gateway.key が存在しない」場合だけ。
+
+2. 存在しない + MCP_GATEWAY_MASTER_KEY が設定されている
+   → age のネイティブ API / 標準フォーマットに従って X25519 identity を
+     決定論的に導出 → /data/gateway.key（age 標準 identity 文字列形式）として保存
+     ※ HKDF 出力を雑に private key として扱う独自実装は行わない
+     ※ filippo.io/age の公開 API・bech32 フォーマットに沿った実装とする
+     ※ PoC で API を確認してから実装方法を確定する
+     ※ 同じ master key からは毎回同じ identity が生成されること（決定論的性の保証）
+     ※ 別の master key では復号できないこと（PoC で検証する）
+     ※ MCP_GATEWAY_MASTER_KEY は最低 32 bytes 相当の長さを要求する
+       → 短い値・空文字・最低長未満はエラーにする
+       slog.Error("MCP_GATEWAY_MASTER_KEY must be at least 32 bytes")
+       os.Exit(1)
+       （厳密な強度判定は不要。長さチェックのみ）
+
+3. どちらも無い → age.GenerateX25519Identity() で新規生成 → /data/gateway.key 保存
+
+⚠️  gateway.key が存在する場合は MCP_GATEWAY_MASTER_KEY を無視する
+    （誤ってキーを変えることで復号不能になる事故を防止）
+⚠️  gateway.key を失った場合、既存の暗号化済み config は復号不能。
+    MCP_GATEWAY_MASTER_KEY を使って派生させた場合は同じ値で再生成可能。
+    → README に「キーファイルのバックアップは Docker volume のバックアップと同義」と明記する。
+```
+
+**gateway.key のファイル形式**
+
+```
+age の標準 identity 文字列形式（テキスト）で保存する。
+独自バイナリ形式・独自 JSON 形式・独自 Base64 形式は使わない。
+
+標準形式の例（age-keygen の出力と同じ）:
+  # created: 2026-05-04T22:00:00+09:00
+  # public key: age1xxxx...
+  AGE-SECRET-KEY-1XXXX...
+
+これにより age CLI ツールとの互換性が保たれ、手動での確認・バックアップが容易。
+```
+
+**env var 命名**
+
+```
+MCP_GATEWAY_MASTER_KEY  ← 正式名（優先）
+MCP_MASTER_KEY          ← 互換 alias（どちらも設定されている場合は MCP_GATEWAY_MASTER_KEY を優先）
+```
+
+README に以下を明記する：
+- 十分に長いランダム値（推奨: 32 bytes base64）を使用すること
+- 漏えいした場合は gateway.key が失われていなければ即座に影響はないが、
+  gateway.key の再生成には使用されるため漏えい時は MCP_GATEWAY_MASTER_KEY を変更し
+  gateway.key を削除して再初期化すること
+- gateway.key が存在する場合は MCP_GATEWAY_MASTER_KEY は無視されること
+
+**ファイルパーミッション**
+
+```
+/data/gateway.key: mode 0600 で保存（os.WriteFile / os.Chmod）
+  → Linux/macOS: 0600 が有効
+  → Windows volume 等で chmod が効かない場合: 警告ログを出力してベストエフォートで続行
+    slog.Warn("could not set restrictive permissions on key file", "path", path, "err", err)
+    ※ err メッセージのみ。キー内容はログに出さない
+```
+
+**シークレットのログ出力禁止ルール**
+
+以下を絶対にログに出さない：
+- シークレット値の平文（`GITHUB_MCP_CLIENT_SECRET` 等）
+- 復号後の値
+- env var の値
+- `/data/gateway.key` の内容
+- `ENC[...]` の全文
+
+エラーログには「フィールド名」「ファイルパス」「エラー種別」のみ含める。
+
+**config.yaml の secret フィールド移行ロジック（起動時に毎回評価）**
+
+```
+github_client_secret の値を確認:
+
+1. "ENC[age1...]" 形式 → age で復号して使用
+2. 平文が config.yaml にある → age で暗号化して config.yaml に書き戻し、再起動なしで続行
+3. config.yaml にキー自体が無い or 空
+   → GITHUB_MCP_CLIENT_SECRET env var を確認
+   → env var が設定されている → age で暗号化して config.yaml に保存し続行
+   → env var も無い → 明確なエラーで起動失敗
+     slog.Error("github_client_secret is required: set GITHUB_MCP_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
+     os.Exit(1)
+```
+
+**ファイルレイアウト（/data/ volume）**
+
+```
+/data/
+  gateway.key    ← age X25519 秘密鍵（mode 0600）← 必ず volume mount 対象
+  config.yaml    ← github_client_secret: "ENC[age1...]" を含む YAML
+  tokens.json    ← 既存（変更なし・今回のスコープ外）
+```
+
+**config.yaml イメージ**
+
+```yaml
+auth:
+  github_client_id: "Ov23liXXXXXX"        # 平文
+  github_client_secret: "ENC[age1AAAA...]" # age 暗号化済み
+gateway:
+  base_url: "http://localhost:8080"
+  port: "8080"
+  oauth_scopes: "repo,user"
+```
 
 #### サブタスク
 
-- [ ] `internal/config/` パッケージ新設（Config 構造体・YAML 読み書き・env override マージ）
-- [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > XDG > デフォルト）
+- [x] 暗号化ライブラリ・キー管理方針・追加制約の技術選択（完了）
+- [ ] `filippo.io/age` を go.mod に追加（`go get filippo.io/age`）と PoC
+  - age の公開 API で X25519 identity を master key から決定論的に生成する方法を確認
+  - bech32 フォーマット経由が最適か `age.NewScryptIdentity` 系か検討
+  - **PoC で検証すること（運用事故チェックリスト）**:
+    1. 同じ master key から毎回同じ identity が得られること（決定論的性）
+    2. 別の master key では復号できないこと
+    3. gateway.key の標準 age identity 文字列形式での保存・読み込みが往復で一致すること
+    4. gateway.key が不正形式・空・存在するが読み取り不能の場合に起動エラーになること（上書きしないこと）
+- [ ] `internal/config/` パッケージ新設
+  - Config 構造体・YAML 読み書き（`gopkg.in/yaml.v3`）
+  - `LoadKey(keyPath, masterKey string) (*age.X25519Identity, error)` — 優先順位でキーを解決・保存
+    - gateway.key 破損時は `errKeyCorrupt` 系エラーを返し、呼び出し元で `os.Exit(1)`
+    - MCP_GATEWAY_MASTER_KEY の長さが 32 bytes 未満の場合はエラー
+  - `EncryptField(identity, plaintext string) (string, error)` — `ENC[age1...]` 形式
+  - `DecryptField(identity, ciphertext string) (string, error)` — フィールド復号
+  - `MigrateSecret(cfg *Config, identity) error` — 移行ロジック（上記 3 ケース）
+  - env override マージ（12-factor 互換）
+  - 0600 ファイル保存・Windows ベストエフォート警告
+  - ログ出力禁止ルールに従うこと（シークレット値を一切 slog に渡さない）
+- [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > `/data/config.yaml`）
 - [ ] `cmd/server/main.go` の `mustEnv` を config ロードに置き換え
+  - `MCP_GATEWAY_MASTER_KEY` / `MCP_MASTER_KEY` alias の読み込み
 - [ ] `internal/router/router.go` の `ParseEnv()` を config ベース実装に切り替え
-- [ ] SQLite ルートストアの設計・実装（CRUD）
-- [ ] `internal/auth/session.go` のトークン永続化対応
-- [ ] テスト / README.md / CHANGELOG.md 更新
+- [ ] テスト — 以下のケースをすべてカバーすること:
+  - `gateway.key` あり + env var あり → `gateway.key` 優先・env var は無視
+  - `gateway.key` なし + `MCP_GATEWAY_MASTER_KEY` あり → 決定論的に生成・保存（同じ key で再実行すると同じ identity）
+  - `gateway.key` なし + env var なし → ランダム生成・保存
+  - `gateway.key` 不正（空・形式不正・権限エラー）→ 自動上書きせずエラー終了
+  - `ENC[...]` 復号成功
+  - 平文 secret が config.yaml にある → 暗号化して書き戻し
+  - secret なし + `GITHUB_MCP_CLIENT_SECRET` env var あり → 暗号化保存
+  - secret なし + env var なし → 明確なエラー
+  - ログに secret 値・ENC 全文・key 内容が含まれないこと
+  - `MCP_GATEWAY_MASTER_KEY` が 32 bytes 未満 → エラー
+- [ ] README.md（キーバックアップ警告・`MCP_GATEWAY_MASTER_KEY` のリスク・最低長・gateway.key 破損時の対応） / CHANGELOG.md 更新
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -184,7 +184,8 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 ```
 優先順位:  gateway.key  >  MCP_GATEWAY_MASTER_KEY  >  自動生成
 
-1. /data/gateway.key が存在する → パース・検証して使用（MCP_GATEWAY_MASTER_KEY は無視）
+1. `<keyPath>` が存在する → パース・検証して使用（MCP_GATEWAY_MASTER_KEY は無視）
+   （keyPath = `MCP_GATEWAY_KEY_PATH` env > `./gateway.key`）
    ⛔ 存在するが読み取り不能・形式不正・空ファイル・パース失敗の場合は
       自動再生成・上書きを一切行わない。明確なエラーで起動を停止する。
       slog.Error("gateway.key exists but is invalid; refusing to overwrite to avoid data loss", "path", path, "err", err)
@@ -253,7 +254,8 @@ MCP_MASTER_KEY          ← 互換 alias（どちらも設定されている場�
 ```
 
 README に以下を明記する：
-- 十分に長いランダム値（推奨: 32 bytes base64）を使用すること
+- 十分に長いランダム値（推奨: 32 bytes 以上のランダム値を base64 エンコードした文字列 ≈ 44 文字）を使用すること
+  （例: `openssl rand -base64 32`）
 - **漏えいリスク（重要）**: `MCP_GATEWAY_MASTER_KEY` が漏えいした場合、
   暗号化済み `config.yaml`（ENC[...]）を持つ攻撃者は `gateway.key` がなくても
   同じ master key から復号キーを再生成できるため**即座に復号可能**になる。
@@ -334,8 +336,8 @@ gateway:
 ```
 
 > ⚠️ `age1...` は age の公開鍵（受信者）のプレフィックスであり、暗号文ではない。
-> `ENC[...]` の中身は age 暗号文（バイナリまたはアーマーテキスト）を base64 エンコードしたもの。
-> 正確なフォーマット（例: `ENC[age:]<base64>` vs アーマーテキスト直書き）は PoC で確定する。
+> `ENC[...]` の中身は age 暗号文を base64 エンコードしたバイナリ（`ENC[age:]<base64-ciphertext>` 形式で統一）。
+> アーマードテキスト（`-----BEGIN AGE ENCRYPTED FILE-----` 形式）をそのまま埋め込む方式は採用しない。
 
 #### サブタスク
 
@@ -359,7 +361,7 @@ gateway:
     // KeyMaterial は復号 + 暗号化の両 interface を保持する。
     // age.Identity は復号のみ、age.Recipient は暗号化のみのため両方必要。
     type KeyMaterial struct {
-        Decrypt age.Identity   // DecryptField, EncryptField(age.Encrypt) 引数
+        Decrypt age.Identity   // DecryptField で使う復号側（age.Identity は復号専用）
         Encrypt age.Recipient  // EncryptField で使う暗号化側
     }
     // PoC 結果に応じた具体型（X25519 統一）:

--- a/tasks.md
+++ b/tasks.md
@@ -193,7 +193,7 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 2. 存在しない + MCP_GATEWAY_MASTER_KEY が設定されている
    → age のネイティブ API / 標準フォーマットに従って identity を
-     決定論的に導出 → /data/gateway.key（age 標準 identity 文字列形式）として保存
+     決定論的に導出 → gateway.key（age 標準 identity 文字列形式）として保存
      ※ HKDF 出力を雑に private key として扱う独自実装は行わない
      ※ filippo.io/age の公開 API に沿った実装とする
      ※ PoC で API を確認してから実装方法を確定する（以下参照）
@@ -224,7 +224,7 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
        os.Exit(1)
        （厳密な強度判定は不要。長さチェックのみ）
 
-3. どちらも無い → age.GenerateX25519Identity() で新規生成 → /data/gateway.key 保存
+3. どちらも無い → age.GenerateX25519Identity() で新規生成 → gateway.key 保存
 
 ⚠️  gateway.key が存在する場合は MCP_GATEWAY_MASTER_KEY を無視する
     （誤ってキーを変えることで復号不能になる事故を防止）
@@ -236,15 +236,23 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 **gateway.key のファイル形式**
 
 ```
-age の標準 identity 文字列形式（テキスト）で保存する。
-独自バイナリ形式・独自 JSON 形式・独自 Base64 形式は使わない。
+PoC での採用方式が確定するまで形式は未確定。候補:
 
-標準形式の例（age-keygen の出力と同じ）:
-  # created: 2026-05-04T22:00:00+09:00
-  # public key: age1xxxx...
-  AGE-SECRET-KEY-1XXXX...
+候補 B（X25519）採用時:
+  age の標準 identity 文字列形式（AGE-SECRET-KEY-1...）でテキスト保存。
+  age-keygen の出力と同じ形式:
+    # created: 2026-05-04T22:00:00+09:00
+    # public key: age1xxxx...
+    AGE-SECRET-KEY-1XXXX...
+  → age CLI ツールとの互換性あり、手動での確認・バックアップが容易。
 
-これにより age CLI ツールとの互換性が保たれ、手動での確認・バックアップが容易。
+候補 A（Scrypt）採用時:
+  ScryptIdentity はパスフレーズそのものが「キー」であるため、
+  MCP_GATEWAY_MASTER_KEY が存在する限り gateway.key を保存する必要がない。
+  ただし、PoC で gateway.key としての保存形式（テキスト or JSON）を確認する。
+
+どちらの形式であれ、独自バイナリ形式・独自 JSON 形式・独自 Base64 形式は使わない。
+最終的な形式は PoC 完了後に tasks.md を更新して確定する。
 ```
 
 **env var 命名**
@@ -256,15 +264,17 @@ MCP_MASTER_KEY          ← 互換 alias（どちらも設定されている場�
 
 README に以下を明記する：
 - 十分に長いランダム値（推奨: 32 bytes base64）を使用すること
-- 漏えいした場合は gateway.key が失われていなければ即座に影響はないが、
-  gateway.key の再生成には使用されるため漏えい時は MCP_GATEWAY_MASTER_KEY を変更し
-  gateway.key を削除して再初期化すること
+- **漏えいリスク（重要）**: `MCP_GATEWAY_MASTER_KEY` が漏えいした場合、
+  暗号化済み `config.yaml`（ENC[...]）を持つ攻撃者は `gateway.key` がなくても
+  同じ master key から復号キーを再生成できるため**即座に復号可能**になる。
+  漏えい時は MCP_GATEWAY_MASTER_KEY を変更し、gateway.key を削除して再初期化すること。
+  また、ENC[...] の中身も新しいキーで再暗号化すること。
 - gateway.key が存在する場合は MCP_GATEWAY_MASTER_KEY は無視されること
 
 **ファイルパーミッション**
 
 ```
-/data/gateway.key: mode 0600 で保存（os.WriteFile / os.Chmod）
+gateway.key: mode 0600 で保存（os.WriteFile / os.Chmod）
   → Linux/macOS: 0600 が有効
   → Windows volume 等で chmod が効かない場合: 警告ログを出力してベストエフォートで続行
     slog.Warn("could not set restrictive permissions on key file", "path", path, "err", err)
@@ -277,7 +287,7 @@ README に以下を明記する：
 - シークレット値の平文（`GITHUB_MCP_CLIENT_SECRET` 等）
 - 復号後の値
 - env var の値
-- `/data/gateway.key` の内容
+- `gateway.key` の内容
 - `ENC[...]` の全文
 
 エラーログには「フィールド名」「ファイルパス」「エラー種別」のみ含める。
@@ -295,6 +305,11 @@ github_client_secret の値を確認:
    → env var も無い → 明確なエラーで起動失敗
      slog.Error("github_client_secret is required: set GITHUB_MCP_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
      os.Exit(1)
+
+      ⚠️ #12 Setup Wizard との連携（将来対応）:
+         #12 実装時は「secret 未設定 = セットアップ未完了」状態として
+         os.Exit(1) の代わりにセットアップモードへ遷移する。
+         現時点（#11 単独実装）では #12 との結合は行わない。
 ```
 
 > **シークレットのローテーション手順**
@@ -334,7 +349,10 @@ gateway:
 
 #### サブタスク
 
-- [x] 暗号化ライブラリ・キー管理方針・追加制約の技術選択（完了）
+- [x] 暗号化ライブラリ選定（`filippo.io/age` 採用確定）・キー管理方針・追加制約の方針決定（完了）
+- [ ] キー導出方式の確定（PoC 必須・未完了）
+  - 候補 A: `age.NewScryptIdentity(masterKey)` — 決定論的・標準 API だが AGE-SECRET-KEY-1... 形式で保存不可
+  - 候補 B: HKDF → 32 bytes → bech32 エンコード → `age.ParseX25519Identity()` — X25519 標準形式だが raw bytes 操作を伴う
 - [ ] `filippo.io/age` を go.mod に追加（`go get filippo.io/age`）と PoC
   - age の公開 API で X25519 identity を master key から決定論的に生成する方法を確認
   - bech32 フォーマット経由が最適か `age.NewScryptIdentity` 系か検討
@@ -345,18 +363,34 @@ gateway:
     4. gateway.key が不正形式・空・存在するが読み取り不能の場合に起動エラーになること（上書きしないこと）
 - [ ] `internal/config/` パッケージ新設
   - Config 構造体・YAML 読み書き（`gopkg.in/yaml.v3`）
-  - `LoadKey(keyPath, masterKey string) (age.Identity, error)` — 優先順位でキーを解決・保存（戻り値は PoC 結果に応じて X25519Identity or ScryptIdentity）
+  - `LoadKey(keyPath, masterKey string) (KeyMaterial, error)` — 優先順位でキーを解決・保存
+
+    ```go
+    // KeyMaterial は復号 + 暗号化の両 interface を保持する。
+    // age.Identity は復号のみ、age.Recipient は暗号化のみのため両方必要。
+    type KeyMaterial struct {
+        Decrypt age.Identity   // DecryptField, EncryptField(age.Encrypt) 引数
+        Encrypt age.Recipient  // EncryptField で使う暗号化側
+    }
+    // PoC 結果に応じた具体型:
+    //   候補 B: Decrypt = *X25519Identity, Encrypt = identity.Recipient()
+    //   候補 A: Decrypt = *ScryptIdentity, Encrypt = *ScryptRecipient(masterKey)
+    ```
+
     - gateway.key 破損時は `errKeyCorrupt` 系エラーを返し、呼び出し元で `os.Exit(1)`
     - MCP_GATEWAY_MASTER_KEY の長さが 32 bytes 未満の場合はエラー
-  - `EncryptField(identity, plaintext string) (string, error)` — `ENC[age:]<base64-ciphertext>` 形式（正確なフォーマットは PoC で確定）
-  - `DecryptField(identity, ciphertext string) (string, error)` — フィールド復号
-  - `MigrateSecret(cfg *Config, identity) error` — 移行ロジック（上記 3 ケース）
+  - `EncryptField(km KeyMaterial, plaintext string) (string, error)` — `ENC[age:]<base64-ciphertext>` 形式（正確なフォーマットは PoC で確定）
+  - `DecryptField(km KeyMaterial, ciphertext string) (string, error)` — フィールド復号
+  - `MigrateSecret(cfg *Config, km KeyMaterial) error` — 移行ロジック（上記 3 ケース）
   - env override マージ（12-factor 互換）
   - 0600 ファイル保存・Windows ベストエフォート警告
   - ログ出力禁止ルールに従うこと（シークレット値を一切 slog に渡さない）
 - [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > `./config.yaml`）
   - Docker Compose では `MCP_CONFIG_FILE=/data/config.yaml` を明示指定する
   - `/data/config.yaml` をデフォルトにすると非 Docker 環境（`go run`・bare binary）で起動失敗するため、デフォルトはカレントディレクトリ
+- [ ] キーファイルパス解決（`MCP_GATEWAY_KEY_PATH` env > `./gateway.key`）
+  - Docker Compose では `MCP_GATEWAY_KEY_PATH=/data/gateway.key` を明示指定する
+  - `/data/gateway.key` をデフォルトにすると非 Docker 環境で起動失敗するため、デフォルトはカレントディレクトリ
 - [ ] `cmd/server/main.go` の `mustEnv` を config ロードに置き換え
   - `MCP_GATEWAY_MASTER_KEY` / `MCP_MASTER_KEY` alias の読み込み
 - [ ] `internal/router/router.go` の `ParseEnv()` を config ベース実装に切り替え

--- a/tasks.md
+++ b/tasks.md
@@ -125,21 +125,21 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
 
 #### サブタスク
 
-- [ ] `internal/middleware/auth.go` に `AuthMode` 分岐追加（+20〜30行）
-- [ ] `cmd/server/main.go` の `AUTH_MODE` 読み込みと条件分岐（+20行）
-- [ ] `AUTH_MODE=gateway` 時の `GITHUB_CLIENT_ID/SECRET` を optional に変更
-- [ ] テスト追加（gateway モード単体テスト）
-- [ ] README / CHANGELOG 更新
+- [x] `internal/middleware/auth.go` に `AuthMode` 分岐追加（+20〜30行）
+- [x] `cmd/server/main.go` の `AUTH_MODE` 読み込みと条件分岐（+20行）
+- [x] `AUTH_MODE=gateway` 時の `GITHUB_CLIENT_ID/SECRET` を optional に変更
+- [x] テスト追加（gateway モード単体テスト）
+- [x] README / CHANGELOG 更新
 
 ---
 
 ### [#15 feat: ホワイトリストによるアクセス制限（認証済みユーザーのフィルタリング）](https://github.com/scottlz0310/mcp-gateway/issues/15)
 
-**状態**: 保留
-**依存**: #11（Config Persistence）
+**状態**: ⏭️ SKIP（ローカル Docker 運用継続のため当面スキップ。ホスティング移行時に再評価）
+**依存**: #11（Config Persistence）— #11 完了後に設定方式を再決定する
 
-> **保留理由（2026-04-30）**: env var 設計か YAML config 設計かで方針が未確定。
-> #11（Config Persistence）の方向性が固まってから実装する。Docker 運用継続中は緊急度低。
+> **スキップ理由（2026-05-04）**: ホスティング環境での運用を当面行わないため優先度外とする。
+> #11（Config Persistence）で YAML config 方式が確定した後、設計を見直して着手する。
 
 #### サブタスク
 
@@ -192,11 +192,30 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
       ★ 新規生成してよいのは「gateway.key が存在しない」場合だけ。
 
 2. 存在しない + MCP_GATEWAY_MASTER_KEY が設定されている
-   → age のネイティブ API / 標準フォーマットに従って X25519 identity を
+   → age のネイティブ API / 標準フォーマットに従って identity を
      決定論的に導出 → /data/gateway.key（age 標準 identity 文字列形式）として保存
      ※ HKDF 出力を雑に private key として扱う独自実装は行わない
-     ※ filippo.io/age の公開 API・bech32 フォーマットに沿った実装とする
-     ※ PoC で API を確認してから実装方法を確定する
+     ※ filippo.io/age の公開 API に沿った実装とする
+     ※ PoC で API を確認してから実装方法を確定する（以下参照）
+
+   ⚠️  filippo.io/age は任意バイト列から X25519Identity を決定論的に生成する
+       公開 API を提供していない（ParseX25519Identity はテキスト形式専用）。
+       以下の 2 候補を PoC で検証してから採用方式を確定すること:
+
+   候補 A: age.NewScryptIdentity(masterKey)
+     → パスフレーズベース（X25519 でなく scrypt ラッパー）
+     → 同一パスフレーズ → 同一復号キー（決定論的✅）
+     → AGE-SECRET-KEY-1 形式では保存不可（scrypt identity は別フォーマット）
+     → gateway.key の形式設計が変わる可能性あり
+
+   候補 B: HKDF で 32 bytes 導出 → bech32(AGE-SECRET-KEY-1...) エンコード
+          → age.ParseX25519Identity() でパース → X25519 identity
+     → age 標準テキスト形式（AGE-SECRET-KEY-1...）で保存可能（✅）
+     → HKDF → raw key の操作を含むため、PoC で age の利用規約・API 意図を確認する
+
+   PoC で「どちらが age API の意図に沿っているか」「両者の interop」を確認し、
+   採用方式を tasks.md に追記してから internal/config/ の実装に進む。
+
      ※ 同じ master key からは毎回同じ identity が生成されること（決定論的性の保証）
      ※ 別の master key では復号できないこと（PoC で検証する）
      ※ MCP_GATEWAY_MASTER_KEY は最低 32 bytes 相当の長さを要求する
@@ -268,7 +287,7 @@ README に以下を明記する：
 ```
 github_client_secret の値を確認:
 
-1. "ENC[age1...]" 形式 → age で復号して使用
+1. "ENC[age:]..." 形式 → age で復号して使用
 2. 平文が config.yaml にある → age で暗号化して config.yaml に書き戻し、再起動なしで続行
 3. config.yaml にキー自体が無い or 空
    → GITHUB_MCP_CLIENT_SECRET env var を確認
@@ -278,12 +297,22 @@ github_client_secret の値を確認:
      os.Exit(1)
 ```
 
+> **シークレットのローテーション手順**
+>
+> `ENC[...]` が config.yaml に保存された後、`GITHUB_MCP_CLIENT_SECRET` を更新するには:
+> 1. config.yaml の `github_client_secret:` 行を削除またはコメントアウト
+> 2. 新しい値を `GITHUB_MCP_CLIENT_SECRET` env var にセット
+> 3. 再起動 → 移行ロジックのステップ 3 が新値を暗号化保存する
+>
+> ⚠️ 一度 `ENC[...]` が保存されると env var は **再起動時に再読み込みされない**（意図的な設計）。
+> 上書き変更は必ず上記手順で行うこと。
+
 **ファイルレイアウト（/data/ volume）**
 
 ```
 /data/
-  gateway.key    ← age X25519 秘密鍵（mode 0600）← 必ず volume mount 対象
-  config.yaml    ← github_client_secret: "ENC[age1...]" を含む YAML
+  gateway.key    ← age identity 秘密鍵（mode 0600）← 必ず volume mount 対象
+  config.yaml    ← github_client_secret: "ENC[age:]<base64-ciphertext>" を含む YAML
   tokens.json    ← 既存（変更なし・今回のスコープ外）
 ```
 
@@ -291,13 +320,17 @@ github_client_secret の値を確認:
 
 ```yaml
 auth:
-  github_client_id: "Ov23liXXXXXX"        # 平文
-  github_client_secret: "ENC[age1AAAA...]" # age 暗号化済み
+  github_client_id: "Ov23liXXXXXX"                     # 平文
+  github_client_secret: "ENC[age:]<base64-ciphertext>"  # age 暗号化済み（base64 バイナリ暗号文）
 gateway:
   base_url: "http://localhost:8080"
   port: "8080"
   oauth_scopes: "repo,user"
 ```
+
+> ⚠️ `age1...` は age の公開鍵（受信者）のプレフィックスであり、暗号文ではない。
+> `ENC[...]` の中身は age 暗号文（バイナリまたはアーマーテキスト）を base64 エンコードしたもの。
+> 正確なフォーマット（例: `ENC[age:]<base64>` vs アーマーテキスト直書き）は PoC で確定する。
 
 #### サブタスク
 
@@ -312,16 +345,18 @@ gateway:
     4. gateway.key が不正形式・空・存在するが読み取り不能の場合に起動エラーになること（上書きしないこと）
 - [ ] `internal/config/` パッケージ新設
   - Config 構造体・YAML 読み書き（`gopkg.in/yaml.v3`）
-  - `LoadKey(keyPath, masterKey string) (*age.X25519Identity, error)` — 優先順位でキーを解決・保存
+  - `LoadKey(keyPath, masterKey string) (age.Identity, error)` — 優先順位でキーを解決・保存（戻り値は PoC 結果に応じて X25519Identity or ScryptIdentity）
     - gateway.key 破損時は `errKeyCorrupt` 系エラーを返し、呼び出し元で `os.Exit(1)`
     - MCP_GATEWAY_MASTER_KEY の長さが 32 bytes 未満の場合はエラー
-  - `EncryptField(identity, plaintext string) (string, error)` — `ENC[age1...]` 形式
+  - `EncryptField(identity, plaintext string) (string, error)` — `ENC[age:]<base64-ciphertext>` 形式（正確なフォーマットは PoC で確定）
   - `DecryptField(identity, ciphertext string) (string, error)` — フィールド復号
   - `MigrateSecret(cfg *Config, identity) error` — 移行ロジック（上記 3 ケース）
   - env override マージ（12-factor 互換）
   - 0600 ファイル保存・Windows ベストエフォート警告
   - ログ出力禁止ルールに従うこと（シークレット値を一切 slog に渡さない）
-- [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > `/data/config.yaml`）
+- [ ] 設定ファイルパス解決（`MCP_CONFIG_FILE` env > `./config.yaml`）
+  - Docker Compose では `MCP_CONFIG_FILE=/data/config.yaml` を明示指定する
+  - `/data/config.yaml` をデフォルトにすると非 Docker 環境（`go run`・bare binary）で起動失敗するため、デフォルトはカレントディレクトリ
 - [ ] `cmd/server/main.go` の `mustEnv` を config ロードに置き換え
   - `MCP_GATEWAY_MASTER_KEY` / `MCP_MASTER_KEY` alias の読み込み
 - [ ] `internal/router/router.go` の `ParseEnv()` を config ベース実装に切り替え

--- a/tasks.md
+++ b/tasks.md
@@ -1,4 +1,4 @@
-# Tasks
+﻿# Tasks
 
 `mcp-gateway` の継続的なタスク管理ファイル。各 issue の状態とサブタスク、依存関係を記録する。
 
@@ -199,30 +199,28 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
      ※ PoC で API を確認してから実装方法を確定する（以下参照）
 
    ⚠️  filippo.io/age は任意バイト列から X25519Identity を決定論的に生成する
-       公開 API を提供していない（ParseX25519Identity はテキスト形式専用）。
-       以下の 2 候補を PoC で検証してから採用方式を確定すること:
+        公開 API を提供していない（ParseX25519Identity はテキスト形式専用）。
+        X25519 方式に統一する方針のため、PoC での検証は以下に絞る:
 
-   候補 A: age.NewScryptIdentity(masterKey)
-     → パスフレーズベース（X25519 でなく scrypt ラッパー）
-     → 同一パスフレーズ → 同一復号キー（決定論的✅）
-     → AGE-SECRET-KEY-1 形式では保存不可（scrypt identity は別フォーマット）
-     → gateway.key の形式設計が変わる可能性あり
+   採用方式（X25519 統一・PoC 確認中）:
+     HKDF で 32 bytes 導出 → bech32(AGE-SECRET-KEY-1...) エンコード
+     → age.ParseX25519Identity() でパース → X25519 identity
+     → age 標準テキスト形式（AGE-SECRET-KEY-1...）で gateway.key に保存
+     → age CLI / age-keygen と互換
 
-   候補 B: HKDF で 32 bytes 導出 → bech32(AGE-SECRET-KEY-1...) エンコード
-          → age.ParseX25519Identity() でパース → X25519 identity
-     → age 標準テキスト形式（AGE-SECRET-KEY-1...）で保存可能（✅）
-     → HKDF → raw key の操作を含むため、PoC で age の利用規約・API 意図を確認する
+   PoC 確認事項:
+     - HKDF → bech32 → ParseX25519Identity の往復が正常に動作すること
+     - 同じ master key から毎回同じ identity が得られること（決定論的性）
+     - 別の master key では復号できないこと
 
-   PoC で「どちらが age API の意図に沿っているか」「両者の interop」を確認し、
-   採用方式を tasks.md に追記してから internal/config/ の実装に進む。
+   ⛔ ScryptIdentity（候補 A）は採用しない:
+      AGE-SECRET-KEY-1 形式で保存できず、key file 方式と passphrase 方式が
+      混在して設計が濁るため #11 スコープから除外する。
 
-     ※ 同じ master key からは毎回同じ identity が生成されること（決定論的性の保証）
-     ※ 別の master key では復号できないこと（PoC で検証する）
-     ※ MCP_GATEWAY_MASTER_KEY は最低 32 bytes 相当の長さを要求する
-       → 短い値・空文字・最低長未満はエラーにする
-       slog.Error("MCP_GATEWAY_MASTER_KEY must be at least 32 bytes")
-       os.Exit(1)
-       （厳密な強度判定は不要。長さチェックのみ）
+   MCP_GATEWAY_MASTER_KEY からの決定論的生成が難しいと判明した場合:
+     → その機能のみ別 issue / 別 PR に切り出す
+     → #11 ではランダム生成（age.GenerateX25519Identity()）した gateway.key を
+        volume に保存する方式で先行実装する
 
 3. どちらも無い → age.GenerateX25519Identity() で新規生成 → gateway.key 保存
 
@@ -233,27 +231,19 @@ copilot-review-mcp 側のコード変更ゼロで、`ROUTE_COPILOT_REVIEW=/mcp/c
     → README に「キーファイルのバックアップは Docker volume のバックアップと同義」と明記する。
 ```
 
+
 **gateway.key のファイル形式**
 
 ```
-PoC での採用方式が確定するまで形式は未確定。候補:
-
-候補 B（X25519）採用時:
-  age の標準 identity 文字列形式（AGE-SECRET-KEY-1...）でテキスト保存。
-  age-keygen の出力と同じ形式:
-    # created: 2026-05-04T22:00:00+09:00
-    # public key: age1xxxx...
-    AGE-SECRET-KEY-1XXXX...
-  → age CLI ツールとの互換性あり、手動での確認・バックアップが容易。
-
-候補 A（Scrypt）採用時:
-  ScryptIdentity はパスフレーズそのものが「キー」であるため、
-  MCP_GATEWAY_MASTER_KEY が存在する限り gateway.key を保存する必要がない。
-  ただし、PoC で gateway.key としての保存形式（テキスト or JSON）を確認する。
-
-どちらの形式であれ、独自バイナリ形式・独自 JSON 形式・独自 Base64 形式は使わない。
-最終的な形式は PoC 完了後に tasks.md を更新して確定する。
+age の標準 identity 文字列形式（AGE-SECRET-KEY-1...）でテキスト保存（X25519 方式に統一）。
+age-keygen の出力と同じ形式:
+  # created: 2026-05-04T22:00:00+09:00
+  # public key: age1xxxx...
+  AGE-SECRET-KEY-1XXXX...
+→ age CLI ツールとの互換性あり、手動での確認・バックアップが容易。
+独自バイナリ形式・独自 JSON 形式・独自 Base64 形式は使わない。
 ```
+
 
 **env var 命名**
 
@@ -350,16 +340,16 @@ gateway:
 #### サブタスク
 
 - [x] 暗号化ライブラリ選定（`filippo.io/age` 採用確定）・キー管理方針・追加制約の方針決定（完了）
-- [ ] キー導出方式の確定（PoC 必須・未完了）
-  - 候補 A: `age.NewScryptIdentity(masterKey)` — 決定論的・標準 API だが AGE-SECRET-KEY-1... 形式で保存不可
-  - 候補 B: HKDF → 32 bytes → bech32 エンコード → `age.ParseX25519Identity()` — X25519 標準形式だが raw bytes 操作を伴う
+- [ ] キー導出方式の確定（X25519 統一・PoC 必須）
+  - HKDF → 32 bytes → bech32 エンコード → `age.ParseX25519Identity()` で X25519 identity 生成
+  - ScryptIdentity は不採用（AGE-SECRET-KEY-1 形式で保存不可のため #11 スコープ外）
+  - 決定論的生成が困難と判明した場合は別 issue 化し、#11 はランダム生成で先行実装
 - [ ] `filippo.io/age` を go.mod に追加（`go get filippo.io/age`）と PoC
-  - age の公開 API で X25519 identity を master key から決定論的に生成する方法を確認
-  - bech32 フォーマット経由が最適か `age.NewScryptIdentity` 系か検討
+  - HKDF → bech32 → `age.ParseX25519Identity()` の往復が動作するか確認
   - **PoC で検証すること（運用事故チェックリスト）**:
     1. 同じ master key から毎回同じ identity が得られること（決定論的性）
     2. 別の master key では復号できないこと
-    3. gateway.key の標準 age identity 文字列形式での保存・読み込みが往復で一致すること
+    3. gateway.key の AGE-SECRET-KEY-1... 形式での保存・読み込みが往復で一致すること
     4. gateway.key が不正形式・空・存在するが読み取り不能の場合に起動エラーになること（上書きしないこと）
 - [ ] `internal/config/` パッケージ新設
   - Config 構造体・YAML 読み書き（`gopkg.in/yaml.v3`）
@@ -372,9 +362,8 @@ gateway:
         Decrypt age.Identity   // DecryptField, EncryptField(age.Encrypt) 引数
         Encrypt age.Recipient  // EncryptField で使う暗号化側
     }
-    // PoC 結果に応じた具体型:
-    //   候補 B: Decrypt = *X25519Identity, Encrypt = identity.Recipient()
-    //   候補 A: Decrypt = *ScryptIdentity, Encrypt = *ScryptRecipient(masterKey)
+    // PoC 結果に応じた具体型（X25519 統一）:
+    //   Decrypt = *X25519Identity, Encrypt = identity.Recipient()
     ```
 
     - gateway.key 破損時は `errKeyCorrupt` 系エラーを返し、呼び出し元で `os.Exit(1)`


### PR DESCRIPTION
## 概要

ph2 の完了状況を反映し、ph3-6（#11 Config Persistence Layer）の実装設計をドキュメント化した。

## 変更内容

### フェーズ状態の更新
- ph2-4（copilot-review-mcp #12 AUTH_MODE=gateway）→ ✅ 完了
- ph2-5（#15 ユーザーホワイトリスト）→ ⏭️ SKIP（ローカル Docker 運用継続）
- ph3-6（#11 Config Persistence）→ 🎯 次ターゲットに昇格

### #11 設計方針の確定

**暗号化ライブラリ**: \ilippo.io/age\（X25519）  
**暗号化対象**: \GITHUB_MCP_CLIENT_SECRET\ のみ（CLIENT_ID は平文、tokens.json は対象外）

**キー解決の優先順位**:
1. \/data/gateway.key\ が存在 → そのまま使用（env var は無視）
2. 存在しない + \MCP_GATEWAY_MASTER_KEY\ あり → 決定論的に導出・保存
3. どちらもない → \ge.GenerateX25519Identity()\ で新規生成

**安全ルール（重要）**:
- \gateway.key\ が存在するが不正（破損・空・形式エラー）→ **自動上書き禁止**、エラーで起動停止
- \MCP_GATEWAY_MASTER_KEY\ は最低 32 bytes を要求
- \gateway.key\ の形式は age 標準 identity 文字列形式のみ（独自形式禁止）
- シークレット値・復号値・key 内容をログに出力しない

**secret 移行ロジック**:
1. \ENC[age1...]\ → 復号して使用
2. 平文が config.yaml にある → 暗号化して書き戻し
3. config.yaml になく env var あり → 暗号化保存
4. どこにもない → エラーで起動停止

## PoC チェックリスト（実装着手前に確認）
- 同じ master key → 同じ identity（決定論的性）
- 別の master key → 復号不可
- gateway.key 往復（保存→読み込み）が一致
- gateway.key 不正時に上書きせずエラー

## テストマトリックス（10 ケース）
tasks.md 内に記載済み。