### PR TITLE
feat(config): implement age X25519 secret encryption (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Secret encryption at rest via `filippo.io/age` X25519 ([#11](https://github.com/scottlz0310/mcp-gateway/issues/11))
+  - `GITHUB_MCP_CLIENT_SECRET` can now be stored as `ENC[age:]<base64>` in `config.yaml` instead of as a plain env var
+  - `internal/config` package: `LoadKey`, `EncryptField`, `DecryptField`, `MigrateSecret`, `LoadConfig`, `SaveConfig`
+  - Key file (`gateway.key`) uses the standard `age-keygen` identity format (`AGE-SECRET-KEY-1...`), compatible with `age` CLI
+  - Key generation priority: existing `gateway.key` > HKDF-SHA256 derivation from `MCP_GATEWAY_MASTER_KEY` > random generation
+  - Migration on startup: `ENC[age:]` in config → decrypt; plaintext in config → encrypt+rewrite; `GITHUB_MCP_CLIENT_SECRET` env → encrypt+save; absent → fatal error
+  - Corrupt/empty/unreadable `gateway.key` causes a hard stop — no auto-regeneration (prevents permanent loss of encrypted secrets)
+  - `MCP_GATEWAY_MASTER_KEY` requires ≥ 32 bytes; `MCP_MASTER_KEY` accepted as a legacy alias
+  - Key contents, plaintext secret, `ENC[...]` ciphertext, and env var values are never written to logs
+
 - Device Flow per-device polling serialization ([#16](https://github.com/scottlz0310/mcp-gateway/issues/16))
   - `AcquireDevicePolling` / `ReleaseDevicePolling` added to `internal/auth.Store` to serialize concurrent GitHub polling per `device_code`
   - Concurrent requests presenting the same `device_code` while one is already polling GitHub receive `authorization_pending` immediately, preventing `slow_down` / rate-limit responses from GitHub (RFC 8628 §3.5)

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,12 +22,107 @@ mcp-gateway (:8080)
 
 ## 設定
 
+### GitHub OAuth 認証情報
+
+起動時、ゲートウェイは GitHub OAuth 認証情報を以下の優先順位で解決します:
+
+| 認証情報 | 優先ソース | フォールバック |
+|---------|------------|--------------|
+| `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` 環境変数 | `config.yaml` の `auth.github_client_id` |
+| `GITHUB_MCP_CLIENT_SECRET` | `config.yaml` の `auth.github_client_secret`（`ENC[age:]...` 形式も可） | `GITHUB_MCP_CLIENT_SECRET` 環境変数 *(初回起動時のシードのみ — config.yaml に値が存在する場合は無視)* |
+
+また、`ROUTE_<NAME>` によるルート設定が最低1つ必要です（未設定の場合は起動時にエラー終了）。
+
+### シークレット暗号化
+
+ゲートウェイは GitHub OAuth クライアントシークレットを [age](https://age-encryption.org/) X25519 暗号化を用いて `config.yaml` に**暗号化して保存**できます。
+
+#### 動作の仕組み
+
+起動時に以下を実行します:
+
+1. `gateway.key`（パス: `MCP_GATEWAY_KEY_PATH`、デフォルト `./gateway.key`）から X25519 キーをロード（または生成）
+2. `config.yaml`（`MCP_CONFIG_FILE`、デフォルト `./config.yaml`）が存在すれば読み込む
+3. 以下の優先順位で `github_client_secret` を解決:
+   - `config.yaml` に `ENC[age:]...` が存在 → 復号して使用
+   - `config.yaml` に平文が存在 → 暗号化してファイルを書き換え、平文を使用
+   - config に値なし + `GITHUB_MCP_CLIENT_SECRET` 環境変数あり → 暗号化して config に保存し使用
+   - いずれもなし → 明確なエラーメッセージで起動失敗
+
+シークレットは**絶対にログに出力されません**（平文・`ENC[...]` 暗号文・キー内容のいずれも）。
+
+#### キーファイル (`gateway.key`)
+
+キーファイルには `age-keygen` 互換の X25519 identity 文字列（`AGE-SECRET-KEY-1...`）が保存されます。
+
+**生成優先順位:**
+
+| 条件 | 結果 |
+|------|------|
+| `gateway.key` が存在する | そのままロード; `MCP_GATEWAY_MASTER_KEY` は**無視** |
+| `gateway.key` なし + `MCP_GATEWAY_MASTER_KEY` 設定済み | HKDF-SHA256 で X25519 キーを決定論的に導出; ファイルに保存 |
+| `gateway.key` なし + マスターキーなし | ランダムな X25519 キーを生成; ファイルに保存 |
+
+> **⚠ 破損は致命的エラー。** `gateway.key` が存在するが空・読み取り不能・形式不正の場合、ゲートウェイは再生成**しません** — 即座に終了します。これは意図しない上書きによる暗号化シークレットの永久消失を防ぐためです。復旧するには `gateway.key` をバックアップから復元するか、既知のキーで `config.yaml` を再暗号化してください。
+
+ファイルは `0600` パーミッションで書き込まれます。`chmod` が期待通り動作しない Windows ボリュームでは警告をログ出力します。
+
+**`gateway.key` を安全にバックアップしてください。** キーファイルを紛失し `MCP_GATEWAY_MASTER_KEY` を使用していなかった場合（ランダム生成時）、`config.yaml` の暗号化シークレットは復元不能になります。
+
+#### `MCP_GATEWAY_MASTER_KEY`
+
+設定されている場合、マスターキーを用いて X25519 キーを決定論的に導出（HKDF-SHA256）します。これにより、別途キーファイルのバックアップなしでシークレット暗号化が可能になります — 同じマスターキーは常に同じ `gateway.key` を生成します。
+
+**要件:**
+- 最低 **32 バイト** — 短い値は起動時に拒否されます
+- 十分にランダムな値を使用してください（例: `openssl rand -hex 32` の出力）
+- **マスターキーの漏えい = 導出キーの漏えい = 暗号化シークレットが復号可能** — シークレットとして厳重に管理してください
+
+> `gateway.key` が存在する場合、`MCP_GATEWAY_MASTER_KEY` は無視されます。キーファイルの初回生成時のみ使用されます。
+
+`MCP_MASTER_KEY` は `MCP_GATEWAY_MASTER_KEY` の後方互換エイリアスとして受け付けます。
+
+#### `config.yaml` の例
+
+```yaml
+auth:
+  github_client_id: "Ov23liXXXX"
+  github_client_secret: "ENC[age:]<base64-ciphertext>"
+gateway:
+  base_url: "http://localhost:8080"
+  port: "8080"
+  oauth_scopes: "repo,user"
+```
+
+`gateway:` 配下はすべてオプションで、対応する環境変数またはデフォルト値にフォールバックします。
+
+#### Docker Compose の設定例
+
+```yaml
+services:
+  mcp-gateway:
+    volumes:
+      - ./data:/data
+    environment:
+      MCP_GATEWAY_KEY_PATH: /data/gateway.key
+      MCP_CONFIG_FILE: /data/config.yaml
+      # 初回のみ — gateway.key が存在すれば省略可:
+      # MCP_GATEWAY_MASTER_KEY: "${MCP_GATEWAY_MASTER_KEY}"
+      GITHUB_MCP_CLIENT_ID: "${GITHUB_MCP_CLIENT_ID}"
+      # GITHUB_MCP_CLIENT_SECRET は初回起動時に config.yaml へシードする場合のみ必要:
+      # GITHUB_MCP_CLIENT_SECRET: "${GITHUB_MCP_CLIENT_SECRET}"
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+```
+
 ### 必須環境変数
 
 | 変数 | 説明 |
 |------|------|
 | `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App の Client ID |
-| `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App の Client Secret |
+| `ROUTE_<NAME>` | ルーティング設定（最低1件必要、下記参照） |
+
+> `GITHUB_MCP_CLIENT_SECRET` は、`config.yaml` に暗号化済みシークレット (`ENC[age:]...`) が存在する場合は不要です。
+> 存在しない場合は、初回起動時のシードとしてこの環境変数が必要です（詳細は「シークレット暗号化」を参照）。
 
 ### ルーティング設定
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,95 @@ mcp-gateway  :8080
 
 ### Required Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App Client ID |
-| `GITHUB_MCP_CLIENT_SECRET` | GitHub OAuth App Client Secret |
+At startup, the gateway resolves the GitHub OAuth credentials using the following priority:
+
+| Source | `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_SECRET` |
+|--------|------------------------|---------------------------|
+| **env var** | `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_SECRET` |
+| **config.yaml** | `auth.github_client_id` | `auth.github_client_secret` (may be `ENC[age:]...`) |
 
 At least one route must also be configured via `ROUTE_<NAME>` (see below) — the server exits on startup if no routes are defined.
+
+### Secret Encryption
+
+The gateway can store the GitHub OAuth client secret **encrypted at rest** in `config.yaml` using [age](https://age-encryption.org/) X25519 encryption.
+
+#### How it works
+
+On startup, the gateway:
+
+1. Loads (or generates) an X25519 key from `gateway.key` (path: `MCP_GATEWAY_KEY_PATH`, default `./gateway.key`)
+2. Reads `config.yaml` (`MCP_CONFIG_FILE`, default `./config.yaml`) if it exists
+3. Resolves `github_client_secret` using this priority:
+   - `ENC[age:]...` in `config.yaml` → decrypts and uses the plaintext
+   - Plaintext in `config.yaml` → encrypts it, rewrites the file, uses the plaintext
+   - No secret in config + `GITHUB_MCP_CLIENT_SECRET` env var → encrypts it, writes to config, uses the plaintext
+   - Neither → startup fails with a clear error message
+
+Secrets are **never logged** — neither the plaintext value, nor the `ENC[...]` ciphertext, nor the key contents.
+
+#### Key file (`gateway.key`)
+
+The key file stores a standard `age-keygen`-compatible X25519 identity string (`AGE-SECRET-KEY-1...`).
+
+**Generation priority:**
+
+| Condition | Result |
+|-----------|--------|
+| `gateway.key` exists | Load and use as-is; `MCP_GATEWAY_MASTER_KEY` is **ignored** |
+| `gateway.key` absent + `MCP_GATEWAY_MASTER_KEY` set | Deterministically derive X25519 key via HKDF-SHA256; save to file |
+| `gateway.key` absent + no master key | Generate a random X25519 key; save to file |
+
+> **⚠ Corruption is fatal.** If `gateway.key` exists but is empty, unreadable, or malformed, the gateway will **not** regenerate it — it will exit immediately. This protects against accidental data loss (overwriting the key would permanently destroy any encrypted secrets in `config.yaml`). To recover, restore `gateway.key` from backup or re-encrypt `config.yaml` with a known key.
+
+The file is written with `0600` permissions. On Windows volumes where `chmod` is not supported, a warning is logged.
+
+**Back up `gateway.key` securely.** If the key file is lost and `MCP_GATEWAY_MASTER_KEY` was not used (random generation), the encrypted secrets in `config.yaml` cannot be recovered.
+
+#### `MCP_GATEWAY_MASTER_KEY`
+
+When set, the master key is used to deterministically derive the X25519 key (HKDF-SHA256). This enables secret encryption without a separate key file backup — the same master key always produces the same `gateway.key`.
+
+**Requirements:**
+- Minimum **32 bytes** — shorter values are rejected at startup
+- Use a sufficiently random value (e.g. output of `openssl rand -hex 32`)
+- **Leaked master key = leaked derived key = encrypted secrets can be decrypted** — treat it as a secret
+
+> Once `gateway.key` exists, `MCP_GATEWAY_MASTER_KEY` is ignored. It is only used when generating the key file for the first time.
+
+`MCP_MASTER_KEY` is accepted as a legacy alias for `MCP_GATEWAY_MASTER_KEY`.
+
+#### Example `config.yaml`
+
+```yaml
+auth:
+  github_client_id: "Ov23liXXXX"
+  github_client_secret: "ENC[age:]<base64-ciphertext>"
+gateway:
+  base_url: "http://localhost:8080"
+  port: "8080"
+  oauth_scopes: "repo,user"
+```
+
+All `gateway:` fields are optional — values fall back to the corresponding env vars and then to the built-in defaults.
+
+#### Docker Compose setup
+
+```yaml
+services:
+  mcp-gateway:
+    volumes:
+      - ./data:/data
+    environment:
+      MCP_GATEWAY_KEY_PATH: /data/gateway.key
+      MCP_CONFIG_FILE: /data/config.yaml
+      # On first run only — omit once gateway.key exists:
+      # MCP_GATEWAY_MASTER_KEY: "${MCP_GATEWAY_MASTER_KEY}"
+      GITHUB_MCP_CLIENT_ID: "${GITHUB_MCP_CLIENT_ID}"
+      # GITHUB_MCP_CLIENT_SECRET only needed on first run to seed config.yaml:
+      # GITHUB_MCP_CLIENT_SECRET: "${GITHUB_MCP_CLIENT_SECRET}"
+```
+
 
 ### Route Configuration
 
@@ -65,6 +148,9 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the X25519 encryption key file (see [Secret Encryption](#secret-encryption)) |
+| `MCP_CONFIG_FILE` | `./config.yaml` | Path to `config.yaml` for persisted configuration |
+| `MCP_GATEWAY_MASTER_KEY` | — | Master key for deterministic key derivation (≥32 bytes; see [Secret Encryption](#secret-encryption)) |
 | `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | Base URL used for OAuth callback and discovery metadata |
 | `MCP_GATEWAY_PORT` | `8080` | Listen port |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ services:
       GITHUB_MCP_CLIENT_ID: "${GITHUB_MCP_CLIENT_ID}"
       # GITHUB_MCP_CLIENT_SECRET only needed on first run to seed config.yaml:
       # GITHUB_MCP_CLIENT_SECRET: "${GITHUB_MCP_CLIENT_SECRET}"
+      # At least one ROUTE_* is required — the gateway will fail to start without routes:
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mcp-gateway  :8080
 
 ## Configuration
 
-### Required Environment Variables
+### GitHub OAuth Credentials
 
 At startup, the gateway resolves the GitHub OAuth credentials as follows:
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ mcp-gateway  :8080
 
 ### Required Environment Variables
 
-At startup, the gateway resolves the GitHub OAuth credentials using the following priority:
+At startup, the gateway resolves the GitHub OAuth credentials as follows:
 
-| Source | `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_SECRET` |
-|--------|------------------------|---------------------------|
-| **env var** | `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_SECRET` |
-| **config.yaml** | `auth.github_client_id` | `auth.github_client_secret` (may be `ENC[age:]...`) |
+| Credential | Primary source | Fallback |
+|-----------|----------------|---------|
+| `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` env var | `auth.github_client_id` in `config.yaml` |
+| `GITHUB_MCP_CLIENT_SECRET` | `auth.github_client_secret` in `config.yaml` (may be `ENC[age:]...`) | `GITHUB_MCP_CLIENT_SECRET` env var *(first-startup seeding only — ignored once a value exists in config.yaml)* |
 
 At least one route must also be configured via `ROUTE_<NAME>` (see below) — the server exits on startup if no routes are defined.
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth"
 	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
+	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 	"github.com/scottlz0310/mcp-gateway/internal/proxy"
 	"github.com/scottlz0310/mcp-gateway/internal/router"
@@ -24,6 +25,40 @@ func main() {
 	})))
 
 	cfg := loadConfig()
+
+	// Load or generate the encryption key.
+	masterKey := []byte(getEnv("MCP_GATEWAY_MASTER_KEY", os.Getenv("MCP_MASTER_KEY")))
+	if len(strings.TrimSpace(string(masterKey))) == 0 {
+		masterKey = nil
+	}
+	km, err := appconfig.LoadKey(cfg.keyPath, masterKey)
+	if err != nil {
+		slog.Error("failed to load gateway encryption key", "path", cfg.keyPath, "err", err)
+		os.Exit(1)
+	}
+
+	// Load YAML config and resolve the GitHub client secret.
+	appCfg, err := appconfig.LoadConfig(cfg.configPath)
+	if err != nil {
+		slog.Error("failed to load config file", "path", cfg.configPath, "err", err)
+		os.Exit(1)
+	}
+
+	githubClientSecret, err := appconfig.MigrateSecret(cfg.configPath, appCfg, km)
+	if err != nil {
+		slog.Error("github_client_secret is unavailable", "err", err)
+		os.Exit(1)
+	}
+
+	// GitHub client ID: env var takes precedence over config file.
+	githubClientID := getEnv("GITHUB_MCP_CLIENT_ID", appCfg.Auth.GitHubClientID)
+	if strings.TrimSpace(githubClientID) == "" {
+		slog.Error("required value not set: provide GITHUB_MCP_CLIENT_ID env var or auth.github_client_id in config.yaml")
+		os.Exit(1)
+	}
+
+	cfg.githubClientID = githubClientID
+	cfg.githubClientSecret = githubClientSecret
 
 	routes, err := router.ParseEnv()
 	if err != nil {
@@ -151,31 +186,25 @@ type config struct {
 	tokenCacheTTLMin   int
 	tokenExpiresInSec  int
 	tokenStorePath     string
+	keyPath            string
+	configPath         string
 }
 
 func loadConfig() config {
 	return config{
-		githubClientID:     mustEnv("GITHUB_MCP_CLIENT_ID"),
-		githubClientSecret: mustEnv("GITHUB_MCP_CLIENT_SECRET"),
-		baseURL:            getEnv("MCP_GATEWAY_BASE_URL", "http://localhost:8080"),
-		oauthScopes:        getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
-		port:               getEnv("MCP_GATEWAY_PORT", "8080"),
-		logLevel:           getEnv("LOG_LEVEL", "info"),
-		upstreamURL:        getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
-		sessionTTLMin:      getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:   getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
-		tokenExpiresInSec:  getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
-		tokenStorePath:     lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
+		// githubClientID and githubClientSecret are resolved after key/config loading in main().
+		baseURL:           getEnv("MCP_GATEWAY_BASE_URL", "http://localhost:8080"),
+		oauthScopes:       getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
+		port:              getEnv("MCP_GATEWAY_PORT", "8080"),
+		logLevel:          getEnv("LOG_LEVEL", "info"),
+		upstreamURL:       getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
+		sessionTTLMin:     getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:  getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
+		tokenExpiresInSec: getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		tokenStorePath:    lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
+		keyPath:           getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
+		configPath:        getEnv("MCP_CONFIG_FILE", "./config.yaml"),
 	}
-}
-
-func mustEnv(key string) string {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		slog.Error("required environment variable not set", "key", key)
-		os.Exit(1)
-	}
-	return v
 }
 
 func getEnv(key, fallback string) string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,38 +37,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Load YAML config and resolve the GitHub client secret.
+	// Load YAML config.
 	appCfg, err := appconfig.LoadConfig(cfg.configPath)
 	if err != nil {
 		slog.Error("failed to load config file", "path", cfg.configPath, "err", err)
 		os.Exit(1)
 	}
 
-	githubClientSecret, err := appconfig.MigrateSecret(cfg.configPath, appCfg, km)
-	if err != nil {
-		slog.Error("github_client_secret is unavailable", "err", err)
-		os.Exit(1)
-	}
+	// Validate required startup inputs before any config writes.
+	// This prevents a mistyped env var from being encrypted and saved to config.yaml
+	// on a first boot that would otherwise fail (e.g. missing CLIENT_ID or routes).
 
 	// GitHub client ID: env var takes precedence over config file.
 	githubClientID := getEnv("GITHUB_MCP_CLIENT_ID", appCfg.Auth.GitHubClientID)
 	if strings.TrimSpace(githubClientID) == "" {
 		slog.Error("required value not set: provide GITHUB_MCP_CLIENT_ID env var or auth.github_client_id in config.yaml")
 		os.Exit(1)
-	}
-
-	cfg.githubClientID = githubClientID
-	cfg.githubClientSecret = githubClientSecret
-
-	// Apply config.yaml gateway overrides (priority: env var > config.yaml > built-in default).
-	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" && strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
-		cfg.baseURL = appCfg.Gateway.BaseURL
-	}
-	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PORT")) == "" && strings.TrimSpace(appCfg.Gateway.Port) != "" {
-		cfg.port = appCfg.Gateway.Port
-	}
-	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
-		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
 	}
 
 	routes, err := router.ParseEnv()
@@ -99,6 +83,28 @@ func main() {
 	if len(routes) == 0 {
 		slog.Error("no routes configured: set ROUTE_<NAME>=<prefix>|<upstream_url>")
 		os.Exit(1)
+	}
+
+	// Resolve the GitHub client secret (and persist it encrypted if sourced from env).
+	// Only runs after the above validations pass to avoid making a wrong value sticky.
+	githubClientSecret, err := appconfig.MigrateSecret(cfg.configPath, appCfg, km)
+	if err != nil {
+		slog.Error("github_client_secret is unavailable", "err", err)
+		os.Exit(1)
+	}
+
+	cfg.githubClientID = githubClientID
+	cfg.githubClientSecret = githubClientSecret
+
+	// Apply config.yaml gateway overrides (priority: env var > config.yaml > built-in default).
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" && strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
+		cfg.baseURL = appCfg.Gateway.BaseURL
+	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PORT")) == "" && strings.TrimSpace(appCfg.Gateway.Port) != "" {
+		cfg.port = appCfg.Gateway.Port
+	}
+	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
+		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
 	}
 
 	prov, err := provider.New(provider.Config{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,6 +60,17 @@ func main() {
 	cfg.githubClientID = githubClientID
 	cfg.githubClientSecret = githubClientSecret
 
+	// Apply config.yaml gateway overrides (priority: env var > config.yaml > built-in default).
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" && strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
+		cfg.baseURL = appCfg.Gateway.BaseURL
+	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PORT")) == "" && strings.TrimSpace(appCfg.Gateway.Port) != "" {
+		cfg.port = appCfg.Gateway.Port
+	}
+	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
+		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
+	}
+
 	routes, err := router.ParseEnv()
 	if err != nil {
 		slog.Error("invalid route configuration", "err", err)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        # cmd/ entrypoints are not unit-testable; the threshold reflects
+        # intentionally-untested OS-specific branches (e.g. Windows rename fallback).
+        target: 70%
+        threshold: 5%
+    project:
+      default:
+        threshold: 5%
+
+ignore:
+  - "cmd/"   # main package entrypoints are not unit-tested by design

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/scottlz0310/mcp-gateway
 go 1.26.2
 
 require (
-	filippo.io/age v1.3.1 // indirect
+	filippo.io/age v1.3.1
+	golang.org/x/crypto v0.45.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	filippo.io/hpke v0.4.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/scottlz0310/mcp-gateway
 
 go 1.26.2
+
+require (
+	filippo.io/age v1.3.1 // indirect
+	filippo.io/hpke v0.4.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
 filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
 filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
 filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
@@ -6,6 +8,7 @@ golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
+filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
+filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
+filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// writeFileAtomic writes data to path atomically using a temp-file + rename pattern.
+// perm is applied to the temp file before rename on non-Windows systems (permissions
+// are preserved through the rename on most POSIX filesystems).
+// On Windows, chmod is not applied; callers should log a warning if needed.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpPath, perm); err != nil {
+			return fmt.Errorf("setting permissions on %s: %w", path, err)
+		}
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("atomically replacing %s: %w", path, err)
+	}
+	ok = true
+	return nil
+}

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -40,11 +40,25 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	if err := os.Rename(tmpPath, path); err != nil {
 		if runtime.GOOS == "windows" {
 			// On Windows, MoveFileEx can fail when the destination is open by another
-			// handle. Fall back to a remove-then-rename, accepting the brief window
-			// where the file is absent (safe during gateway startup).
-			_ = os.Remove(path)
-			if err2 := os.Rename(tmpPath, path); err2 != nil {
-				return fmt.Errorf("atomically replacing %s: %w (Windows fallback also failed: %v)", path, err, err2)
+			// handle. Use a backup-and-restore approach: rename the existing file to a
+			// .bak first, rename the temp file to the target, then remove the .bak.
+			// If the second rename also fails, restore the backup so no data is lost.
+			bakPath := path + ".bak"
+			if _, statErr := os.Stat(path); statErr == nil {
+				if renErr := os.Rename(path, bakPath); renErr != nil {
+					// Cannot create backup; return original rename error.
+					return fmt.Errorf("atomically replacing %s: %w", path, err)
+				}
+				if err2 := os.Rename(tmpPath, path); err2 != nil {
+					_ = os.Rename(bakPath, path) // restore backup on failure
+					return fmt.Errorf("atomically replacing %s: %w (Windows fallback also failed: %v)", path, err, err2)
+				}
+				_ = os.Remove(bakPath)
+			} else {
+				// Target does not exist yet; simple rename suffices.
+				if err2 := os.Rename(tmpPath, path); err2 != nil {
+					return fmt.Errorf("atomically replacing %s: %w (Windows fallback also failed: %v)", path, err, err2)
+				}
 			}
 			ok = true
 			return nil

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -38,6 +38,17 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		}
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
+		if runtime.GOOS == "windows" {
+			// On Windows, MoveFileEx can fail when the destination is open by another
+			// handle. Fall back to a remove-then-rename, accepting the brief window
+			// where the file is absent (safe during gateway startup).
+			_ = os.Remove(path)
+			if err2 := os.Rename(tmpPath, path); err2 != nil {
+				return fmt.Errorf("atomically replacing %s: %w (Windows fallback also failed: %v)", path, err, err2)
+			}
+			ok = true
+			return nil
+		}
 		return fmt.Errorf("atomically replacing %s: %w", path, err)
 	}
 	ok = true

--- a/internal/config/bech32.go
+++ b/internal/config/bech32.go
@@ -1,0 +1,92 @@
+// Package config provides configuration management with age-encrypted secrets.
+//
+// The bech32 encoding logic in this file is derived from
+// filippo.io/age/internal/bech32, which is based on the BIP-0173 reference
+// implementation by Takatoshi Nakagawa.
+//
+// Copyright (c) 2017 Takatoshi Nakagawa
+// Copyright (c) 2019 The age Authors
+// Licensed under the MIT License.
+package config
+
+import "strings"
+
+const bech32Charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+var bech32Generator = []uint32{0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3}
+
+func bech32Polymod(values []byte) uint32 {
+	chk := uint32(1)
+	for _, v := range values {
+		top := chk >> 25
+		chk = (chk & 0x1ffffff) << 5
+		chk ^= uint32(v)
+		for i := range 5 {
+			if (top>>i)&1 == 1 {
+				chk ^= bech32Generator[i]
+			}
+		}
+	}
+	return chk
+}
+
+func bech32HrpExpand(hrp string) []byte {
+	h := []byte(strings.ToLower(hrp))
+	ret := make([]byte, 0, len(h)*2+1)
+	for _, c := range h {
+		ret = append(ret, c>>5)
+	}
+	ret = append(ret, 0)
+	for _, c := range h {
+		ret = append(ret, c&31)
+	}
+	return ret
+}
+
+func bech32CreateChecksum(hrp string, data []byte) []byte {
+	values := append(bech32HrpExpand(hrp), data...)
+	values = append(values, 0, 0, 0, 0, 0, 0)
+	mod := bech32Polymod(values) ^ 1
+	ret := make([]byte, 6)
+	for p := range 6 {
+		ret[p] = byte(mod>>(5*(5-p))) & 31
+	}
+	return ret
+}
+
+// bech32ConvertBits converts a byte slice from frombits-bit groups to tobits-bit groups.
+func bech32ConvertBits(data []byte, frombits, tobits byte, pad bool) []byte {
+	var ret []byte
+	acc := uint32(0)
+	bits := byte(0)
+	maxv := byte(1<<tobits - 1)
+	for _, value := range data {
+		acc = acc<<frombits | uint32(value)
+		bits += frombits
+		for bits >= tobits {
+			bits -= tobits
+			ret = append(ret, byte(acc>>bits)&maxv)
+		}
+	}
+	if pad && bits > 0 {
+		ret = append(ret, byte(acc<<(tobits-bits))&maxv)
+	}
+	return ret
+}
+
+// encodeAGESecretKey encodes a 32-byte Curve25519 scalar as an
+// "AGE-SECRET-KEY-1..." bech32 string compatible with age.ParseX25519Identity.
+func encodeAGESecretKey(scalar []byte) string {
+	const hrp = "age-secret-key-"
+	values := bech32ConvertBits(scalar, 8, 5, true)
+	var sb strings.Builder
+	sb.WriteString(hrp)
+	sb.WriteByte('1')
+	for _, p := range values {
+		sb.WriteByte(bech32Charset[p])
+	}
+	for _, p := range bech32CreateChecksum(hrp, values) {
+		sb.WriteByte(bech32Charset[p])
+	}
+	return strings.ToUpper(sb.String())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, 
 	default:
 		envSecret, ok := os.LookupEnv("GITHUB_MCP_CLIENT_SECRET")
 		if ok && strings.TrimSpace(envSecret) != "" {
+			envSecret = strings.TrimSpace(envSecret)
 			slog.Info("encrypting GITHUB_MCP_CLIENT_SECRET from env and saving to config")
 			encrypted, err := EncryptField(km, envSecret)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AppConfig is the application configuration stored in config.yaml.
+type AppConfig struct {
+	Auth    AuthConfig    `yaml:"auth,omitempty"`
+	Gateway GatewayConfig `yaml:"gateway,omitempty"`
+}
+
+// AuthConfig holds OAuth client credentials.
+type AuthConfig struct {
+	GitHubClientID     string `yaml:"github_client_id,omitempty"`
+	GitHubClientSecret string `yaml:"github_client_secret,omitempty"`
+}
+
+// GatewayConfig holds gateway-level settings that can be persisted in config.yaml.
+type GatewayConfig struct {
+	BaseURL     string `yaml:"base_url,omitempty"`
+	Port        string `yaml:"port,omitempty"`
+	OAuthScopes string `yaml:"oauth_scopes,omitempty"`
+}
+
+// LoadConfig reads AppConfig from path.
+// If the file does not exist, an empty AppConfig is returned (not an error).
+func LoadConfig(path string) (*AppConfig, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &AppConfig{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config file %q: %w", path, err)
+	}
+	var cfg AppConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file %q: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// SaveConfig writes cfg to path with 0600 permissions.
+func SaveConfig(path string, cfg *AppConfig) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// MigrateSecret resolves the GitHub OAuth client secret, following this priority:
+//
+//  1. cfg.Auth.GitHubClientSecret is "ENC[age:]..." → decrypt and return plaintext
+//  2. cfg.Auth.GitHubClientSecret is non-empty plaintext → encrypt, write back, return plaintext
+//  3. field empty/absent + GITHUB_MCP_CLIENT_SECRET env var set → encrypt, save to config, return
+//  4. field empty + env var absent → return error
+//
+// The config file at configPath is updated in cases 2 and 3.
+// The returned plaintext is never written to the log.
+func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, error) {
+	secret := cfg.Auth.GitHubClientSecret
+
+	switch {
+	case IsEncrypted(secret):
+		plaintext, err := DecryptField(km, secret)
+		if err != nil {
+			return "", fmt.Errorf("decrypting github_client_secret: %w", err)
+		}
+		return plaintext, nil
+
+	case strings.TrimSpace(secret) != "":
+		slog.Info("plaintext github_client_secret found in config; encrypting and rewriting")
+		encrypted, err := EncryptField(km, secret)
+		if err != nil {
+			return "", fmt.Errorf("encrypting github_client_secret from config: %w", err)
+		}
+		cfg.Auth.GitHubClientSecret = encrypted
+		if err := SaveConfig(configPath, cfg); err != nil {
+			return "", fmt.Errorf("saving config after encrypting github_client_secret: %w", err)
+		}
+		return secret, nil
+
+	default:
+		envSecret, ok := os.LookupEnv("GITHUB_MCP_CLIENT_SECRET")
+		if ok && strings.TrimSpace(envSecret) != "" {
+			slog.Info("encrypting GITHUB_MCP_CLIENT_SECRET from env and saving to config")
+			encrypted, err := EncryptField(km, envSecret)
+			if err != nil {
+				return "", fmt.Errorf("encrypting GITHUB_MCP_CLIENT_SECRET from env: %w", err)
+			}
+			cfg.Auth.GitHubClientSecret = encrypted
+			if err := SaveConfig(configPath, cfg); err != nil {
+				return "", fmt.Errorf("saving config after encrypting GITHUB_MCP_CLIENT_SECRET: %w", err)
+			}
+			return envSecret, nil
+		}
+		return "", fmt.Errorf("github_client_secret is required: set GITHUB_MCP_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -45,13 +46,24 @@ func LoadConfig(path string) (*AppConfig, error) {
 	return &cfg, nil
 }
 
-// SaveConfig writes cfg to path with 0600 permissions.
+// SaveConfig writes cfg to path with 0600 permissions using an atomic temp-file+rename.
+//
+// Note: because AppConfig is a narrow struct, any YAML fields not defined in AppConfig
+// (unknown keys, user-added comments) will be lost on rewrite. SaveConfig is only called
+// during secret migration (first startup with a plaintext or env-var secret), so manual
+// edits to config.yaml should be made after the initial migration run.
 func SaveConfig(path string, cfg *AppConfig) error {
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(path, data, 0600)
+	if err := writeFileAtomic(path, data, 0600); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		slog.Warn("running on Windows: cannot guarantee 0600 permissions on config file", "path", path)
+	}
+	return nil
 }
 
 // MigrateSecret resolves the GitHub OAuth client secret, following this priority:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMigrateSecret_EncryptedValue decrypts an ENC[age:] value from config.
+func TestMigrateSecret_EncryptedValue(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	plaintext := "my-github-client-secret"
+
+	enc, err := EncryptField(km, plaintext)
+	if err != nil {
+		t.Fatalf("EncryptField: %v", err)
+	}
+
+	cfg := &AppConfig{Auth: AuthConfig{GitHubClientSecret: enc}}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	cfg2, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg2, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+
+	// Config file should still have the ENC[...] value (no double-encryption).
+	reloaded, _ := LoadConfig(configPath)
+	if !IsEncrypted(reloaded.Auth.GitHubClientSecret) {
+		t.Error("config should still hold the encrypted value")
+	}
+}
+
+// TestMigrateSecret_PlaintextRewritten verifies that a plaintext secret is
+// encrypted and written back to the config file.
+func TestMigrateSecret_PlaintextRewritten(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	plaintext := "plain-secret-in-config"
+
+	cfg := &AppConfig{Auth: AuthConfig{GitHubClientSecret: plaintext}}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+
+	// Config file should now hold an encrypted value.
+	reloaded, _ := LoadConfig(configPath)
+	if !IsEncrypted(reloaded.Auth.GitHubClientSecret) {
+		t.Error("config file should have been rewritten with encrypted value")
+	}
+	if strings.Contains(reloaded.Auth.GitHubClientSecret, plaintext) {
+		t.Error("plaintext must not remain in config file after migration")
+	}
+}
+
+// TestMigrateSecret_FromEnvVar verifies that GITHUB_MCP_CLIENT_SECRET is
+// encrypted and saved when the config field is absent.
+func TestMigrateSecret_FromEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	envSecret := "secret-from-env-var-xyz"
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", envSecret)
+
+	cfg := &AppConfig{} // no secret in config
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if got != envSecret {
+		t.Errorf("got %q, want %q", got, envSecret)
+	}
+
+	// Config file should now hold an encrypted value.
+	reloaded, _ := LoadConfig(configPath)
+	if !IsEncrypted(reloaded.Auth.GitHubClientSecret) {
+		t.Error("config file should have been written with encrypted value from env")
+	}
+}
+
+// TestMigrateSecret_NoSecretAnywhere verifies that an error is returned
+// when neither config nor env var has the secret.
+func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+
+	cfg := &AppConfig{}
+	_, err := MigrateSecret(configPath, cfg, km)
+	if err == nil {
+		t.Fatal("expected error when no secret is available")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should indicate requirement, got: %v", err)
+	}
+}
+
+// TestMigrateSecret_NoSecretInLogs verifies that secrets don't leak to logs.
+func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
+	logBuf := captureLogs(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	secretValue := "ultrasecret-do-not-log-me-abc123"
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", secretValue)
+
+	cfg := &AppConfig{}
+	enc, err := MigrateSecret(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+
+	output := logBuf.String()
+	if strings.Contains(output, secretValue) {
+		t.Error("secret value leaked to log output")
+	}
+	if strings.Contains(output, enc) {
+		t.Error("returned encrypted value leaked to log output")
+	}
+}
+
+// TestLoadConfig_MissingFile verifies that a missing config returns empty AppConfig.
+func TestLoadConfig_MissingFile(t *testing.T) {
+	cfg, err := LoadConfig("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil AppConfig")
+	}
+	if cfg.Auth.GitHubClientSecret != "" {
+		t.Errorf("expected empty secret, got: %q", cfg.Auth.GitHubClientSecret)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,12 +142,21 @@ func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
 
+	// Also exercise the LoadConfig path (restart scenario) while still capturing logs.
+	if _, err := LoadConfig(configPath); err != nil {
+		t.Fatalf("LoadConfig with encrypted config: %v", err)
+	}
+
 	output := logBuf.String()
 	if strings.Contains(output, secretValue) {
-		t.Error("secret value leaked to log output")
+		t.Error("plaintext secret leaked to log output")
 	}
 	if strings.Contains(output, enc) {
-		t.Error("returned encrypted value leaked to log output")
+		t.Error("full ENC[age:...] ciphertext leaked to log output")
+	}
+	// Catch any partial logging of the encrypted prefix from either path.
+	if strings.Contains(output, "ENC[age:]") {
+		t.Error("ENC[age:] prefix leaked to log output")
 	}
 }
 

--- a/internal/config/crypto.go
+++ b/internal/config/crypto.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+
+	"filippo.io/age"
+)
+
+// encPrefix is the prefix for encrypted field values stored in config.yaml.
+const encPrefix = "ENC[age:]"
+
+// EncryptField encrypts plaintext using the key material's recipient and
+// returns "ENC[age:]<base64-ciphertext>".
+// The plaintext is never written to the log.
+func EncryptField(km *KeyMaterial, plaintext string) (string, error) {
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, km.Encrypt)
+	if err != nil {
+		return "", fmt.Errorf("initializing age encryptor: %w", err)
+	}
+	if _, err := io.WriteString(w, plaintext); err != nil {
+		_ = w.Close()
+		return "", fmt.Errorf("writing to age encryptor: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("finalizing age encryption: %w", err)
+	}
+	return encPrefix + base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// DecryptField decrypts a "ENC[age:]<base64-ciphertext>" value and returns
+// the plaintext. The plaintext and ciphertext are never written to the log.
+func DecryptField(km *KeyMaterial, ciphertext string) (string, error) {
+	if !strings.HasPrefix(ciphertext, encPrefix) {
+		return "", fmt.Errorf("ciphertext does not start with %q", encPrefix)
+	}
+	b64 := ciphertext[len(encPrefix):]
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", fmt.Errorf("base64 decode: %w", err)
+	}
+	r, err := age.Decrypt(bytes.NewReader(data), km.Decrypt)
+	if err != nil {
+		return "", fmt.Errorf("age decryption failed: %w", err)
+	}
+	plaintext, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("reading decrypted data: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+// IsEncrypted reports whether s is an ENC[age:] ciphertext value.
+func IsEncrypted(s string) bool {
+	return strings.HasPrefix(s, encPrefix)
+}

--- a/internal/config/crypto_test.go
+++ b/internal/config/crypto_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// testKeyMaterial returns a fresh random KeyMaterial for use in tests.
+func testKeyMaterial(t *testing.T) *KeyMaterial {
+	t.Helper()
+	dir := t.TempDir()
+	km, err := LoadKey(dir+"/gateway.key", nil)
+	if err != nil {
+		t.Fatalf("testKeyMaterial: %v", err)
+	}
+	return km
+}
+
+// TestEncryptDecryptRoundtrip verifies the full ENC[age:] encrypt/decrypt cycle.
+func TestEncryptDecryptRoundtrip(t *testing.T) {
+	km := testKeyMaterial(t)
+	plaintext := "super-secret-value"
+
+	enc, err := EncryptField(km, plaintext)
+	if err != nil {
+		t.Fatalf("EncryptField: %v", err)
+	}
+
+	if !IsEncrypted(enc) {
+		t.Errorf("expected ENC prefix, got: %q", enc)
+	}
+	if strings.Contains(enc, plaintext) {
+		t.Error("plaintext must not appear in ciphertext")
+	}
+
+	got, err := DecryptField(km, enc)
+	if err != nil {
+		t.Fatalf("DecryptField: %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("decrypted %q, want %q", got, plaintext)
+	}
+}
+
+// TestDecryptField_WrongKey verifies that decrypting with a different key returns an error.
+func TestDecryptField_WrongKey(t *testing.T) {
+	km1 := testKeyMaterial(t)
+	km2 := testKeyMaterial(t)
+
+	enc, err := EncryptField(km1, "secret")
+	if err != nil {
+		t.Fatalf("EncryptField: %v", err)
+	}
+
+	_, err = DecryptField(km2, enc)
+	if err == nil {
+		t.Fatal("expected decryption error with wrong key")
+	}
+}
+
+// TestDecryptField_BadPrefix verifies that a value without ENC[age:] returns an error.
+func TestDecryptField_BadPrefix(t *testing.T) {
+	km := testKeyMaterial(t)
+	_, err := DecryptField(km, "not-encrypted")
+	if err == nil {
+		t.Fatal("expected error for bad prefix")
+	}
+}
+
+// TestIsEncrypted confirms correct detection.
+func TestIsEncrypted(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"ENC[age:]abc123==", true},
+		{"ENC[age:]", true},
+		{"plaintext", false},
+		{"", false},
+		{"ENC[scrypt:]something", false},
+	}
+	for _, tc := range tests {
+		if got := IsEncrypted(tc.s); got != tc.want {
+			t.Errorf("IsEncrypted(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+// TestEncryptField_NoPlaintextInLogs verifies that the plaintext value
+// does not appear in any log output during encryption.
+func TestEncryptField_NoPlaintextInLogs(t *testing.T) {
+	logBuf := captureLogs(t)
+	km := testKeyMaterial(t)
+	plaintext := "my-very-secret-value-xyz987"
+
+	enc, err := EncryptField(km, plaintext)
+	if err != nil {
+		t.Fatalf("EncryptField: %v", err)
+	}
+
+	output := logBuf.String()
+	if strings.Contains(output, plaintext) {
+		t.Error("plaintext leaked to log")
+	}
+	// The full ENC[...] value must also not appear in logs.
+	if strings.Contains(output, enc) {
+		t.Error("ENC ciphertext leaked to log")
+	}
+}

--- a/internal/config/key.go
+++ b/internal/config/key.go
@@ -102,17 +102,13 @@ func loadKeyFile(keyPath string) (*KeyMaterial, error) {
 	return nil, fmt.Errorf("%w: no AGE-SECRET-KEY-1 line found in %s", ErrKeyCorrupt, keyPath)
 }
 
-// saveKeyFile writes the identity string to keyPath with 0600 permissions.
+// saveKeyFile writes the identity string to keyPath atomically with 0600 permissions.
 // The key content is never written to the log.
 func saveKeyFile(keyPath string, identity *age.X25519Identity) error {
-	if err := os.WriteFile(keyPath, []byte(identity.String()+"\n"), 0600); err != nil {
+	if err := writeFileAtomic(keyPath, []byte(identity.String()+"\n"), 0600); err != nil {
 		return err
 	}
-	if runtime.GOOS != "windows" {
-		if err := os.Chmod(keyPath, 0600); err != nil {
-			slog.Warn("could not set restrictive permissions on key file", "path", keyPath, "err", err)
-		}
-	} else {
+	if runtime.GOOS == "windows" {
 		slog.Warn("running on Windows: cannot guarantee 0600 permissions on key file", "path", keyPath)
 	}
 	return nil

--- a/internal/config/key.go
+++ b/internal/config/key.go
@@ -101,6 +101,12 @@ func loadKeyFile(keyPath string) (*KeyMaterial, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid key in %s: %v", ErrKeyCorrupt, keyPath, err)
 			}
+			// Best-effort tighten permissions on existing key files (e.g. operator-restored keys).
+			if runtime.GOOS != "windows" {
+				if chErr := os.Chmod(keyPath, 0600); chErr != nil {
+					slog.Warn("could not set 0600 permissions on key file", "path", keyPath, "err", chErr)
+				}
+			}
 			return identityToKeyMaterial(identity)
 		}
 	}

--- a/internal/config/key.go
+++ b/internal/config/key.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+
+	"filippo.io/age"
+	"golang.org/x/crypto/hkdf"
+)
+
+// KeyMaterial holds both the decryption identity and encryption recipient
+// for use with EncryptField and DecryptField.
+type KeyMaterial struct {
+	Decrypt age.Identity  // X25519Identity — used by DecryptField (decryption only)
+	Encrypt age.Recipient // X25519Recipient — used by EncryptField (encryption only)
+}
+
+// ErrKeyCorrupt indicates that the key file exists but cannot be used.
+// The caller must NOT regenerate or overwrite the file.
+var ErrKeyCorrupt = errors.New("gateway.key is corrupt or unreadable")
+
+const (
+	// minMasterKeyLen is the minimum byte length of MCP_GATEWAY_MASTER_KEY.
+	minMasterKeyLen = 32
+
+	// hkdfInfo is the HKDF context label for deterministic key derivation.
+	hkdfInfo = "mcp-gateway-key-v1"
+)
+
+// LoadKey loads or generates the X25519 key material, following this priority:
+//
+//  1. keyPath file exists → parse and validate; corrupt file = ErrKeyCorrupt (never overwrite)
+//  2. keyPath absent + masterKey non-empty (≥32 bytes) → deterministic HKDF derivation → save
+//  3. keyPath absent + no masterKey → random generation → save
+//
+// A corrupt, empty, unreadable, or malformed key file always returns ErrKeyCorrupt.
+// The caller should log the path/error and call os.Exit(1) — never regenerate the key.
+func LoadKey(keyPath string, masterKey []byte) (*KeyMaterial, error) {
+	_, err := os.Stat(keyPath)
+	if err == nil {
+		// File exists: load and validate. Any failure is fatal.
+		return loadKeyFile(keyPath)
+	}
+	if !os.IsNotExist(err) {
+		// Cannot stat — permission error, broken symlink, etc.
+		return nil, fmt.Errorf("%w: cannot access %s: %v", ErrKeyCorrupt, keyPath, err)
+	}
+
+	// File does not exist — generate.
+	var identity *age.X25519Identity
+	if len(masterKey) > 0 {
+		if len(masterKey) < minMasterKeyLen {
+			return nil, fmt.Errorf("MCP_GATEWAY_MASTER_KEY must be at least %d bytes (got %d)", minMasterKeyLen, len(masterKey))
+		}
+		identity, err = deriveIdentityFromMasterKey(masterKey)
+		if err != nil {
+			return nil, fmt.Errorf("deriving X25519 identity from master key: %w", err)
+		}
+		slog.Info("derived X25519 identity from MCP_GATEWAY_MASTER_KEY", "key_path", keyPath)
+	} else {
+		identity, err = age.GenerateX25519Identity()
+		if err != nil {
+			return nil, fmt.Errorf("generating X25519 identity: %w", err)
+		}
+		slog.Info("generated new random X25519 identity", "key_path", keyPath)
+	}
+
+	if err := saveKeyFile(keyPath, identity); err != nil {
+		return nil, fmt.Errorf("saving gateway key to %s: %w", keyPath, err)
+	}
+	return identityToKeyMaterial(identity)
+}
+
+// loadKeyFile reads, parses, and validates an existing key file.
+// Any failure (empty, unreadable, invalid format) returns ErrKeyCorrupt.
+// The key content is never written to the log.
+func loadKeyFile(keyPath string) (*KeyMaterial, error) {
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cannot read %s: %v", ErrKeyCorrupt, keyPath, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("%w: file is empty: %s", ErrKeyCorrupt, keyPath)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "AGE-SECRET-KEY-") {
+			identity, err := age.ParseX25519Identity(line)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid key in %s: %v", ErrKeyCorrupt, keyPath, err)
+			}
+			return identityToKeyMaterial(identity)
+		}
+	}
+	return nil, fmt.Errorf("%w: no AGE-SECRET-KEY-1 line found in %s", ErrKeyCorrupt, keyPath)
+}
+
+// saveKeyFile writes the identity string to keyPath with 0600 permissions.
+// The key content is never written to the log.
+func saveKeyFile(keyPath string, identity *age.X25519Identity) error {
+	if err := os.WriteFile(keyPath, []byte(identity.String()+"\n"), 0600); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(keyPath, 0600); err != nil {
+			slog.Warn("could not set restrictive permissions on key file", "path", keyPath, "err", err)
+		}
+	} else {
+		slog.Warn("running on Windows: cannot guarantee 0600 permissions on key file", "path", keyPath)
+	}
+	return nil
+}
+
+// identityToKeyMaterial converts an X25519Identity into a KeyMaterial.
+func identityToKeyMaterial(identity *age.X25519Identity) (*KeyMaterial, error) {
+	return &KeyMaterial{
+		Decrypt: identity,
+		Encrypt: identity.Recipient(),
+	}, nil
+}
+
+// deriveIdentityFromMasterKey deterministically derives an X25519Identity
+// using HKDF-SHA256 over masterKey, then encodes the 32-byte output as the
+// age-standard "AGE-SECRET-KEY-1..." bech32 format before parsing.
+// The same masterKey always yields the same identity.
+func deriveIdentityFromMasterKey(masterKey []byte) (*age.X25519Identity, error) {
+	h := hkdf.New(sha256.New, masterKey, nil, []byte(hkdfInfo))
+	scalar := make([]byte, 32)
+	if _, err := io.ReadFull(h, scalar); err != nil {
+		return nil, fmt.Errorf("HKDF derivation failed: %w", err)
+	}
+	keyStr := encodeAGESecretKey(scalar)
+	return age.ParseX25519Identity(keyStr)
+}

--- a/internal/config/key.go
+++ b/internal/config/key.go
@@ -75,7 +75,12 @@ func LoadKey(keyPath string, masterKey []byte) (*KeyMaterial, error) {
 	if err := saveKeyFile(keyPath, identity); err != nil {
 		return nil, fmt.Errorf("saving gateway key to %s: %w", keyPath, err)
 	}
-	return identityToKeyMaterial(identity)
+	// Re-read the file that was just written so the in-memory identity always
+	// matches what is on disk. This also handles the unlikely but possible race
+	// where two processes both observe gateway.key as absent, generate different
+	// random identities, and one overwrites the other via atomic rename: after
+	// both writes settle, both processes will load the same on-disk key.
+	return loadKeyFile(keyPath)
 }
 
 // loadKeyFile reads, parses, and validates an existing key file.

--- a/internal/config/key_test.go
+++ b/internal/config/key_test.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+)
+
+// captureLogs redirects slog to a buffer and returns a cleanup function.
+// Call cleanup() (or use defer) to restore the original logger.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return &buf
+}
+
+// writeKeyFile writes a valid age secret key to a temp file and returns the path.
+func writeKeyFile(t *testing.T, dir string, identity *age.X25519Identity) string {
+	t.Helper()
+	path := filepath.Join(dir, "gateway.key")
+	if err := os.WriteFile(path, []byte(identity.String()+"\n"), 0600); err != nil {
+		t.Fatalf("writeKeyFile: %v", err)
+	}
+	return path
+}
+
+// TestLoadKey_ExistingFileWins verifies that an existing gateway.key takes
+// precedence over MCP_GATEWAY_MASTER_KEY.
+func TestLoadKey_ExistingFileWins(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a known identity and write it to disk.
+	original, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	keyPath := writeKeyFile(t, dir, original)
+
+	// Provide a master key — should be ignored.
+	masterKey := bytes.Repeat([]byte("k"), 32)
+	km, err := LoadKey(keyPath, masterKey)
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+
+	// The loaded key must match the original (compare recipient public key via String).
+	loaded, ok := km.Decrypt.(*age.X25519Identity)
+	if !ok {
+		t.Fatal("Decrypt is not *X25519Identity")
+	}
+	if loaded.Recipient().String() != original.Recipient().String() {
+		t.Errorf("key mismatch: got %s, want %s", loaded.Recipient(), original.Recipient())
+	}
+}
+
+// TestLoadKey_DeterministicFromMasterKey verifies that the same master key
+// always produces the same identity, and a different key produces a different one.
+func TestLoadKey_DeterministicFromMasterKey(t *testing.T) {
+	masterKey := []byte("a-sufficiently-long-master-key-1234")
+
+	// First derivation.
+	dir1 := t.TempDir()
+	km1, err := LoadKey(filepath.Join(dir1, "gateway.key"), masterKey)
+	if err != nil {
+		t.Fatalf("first LoadKey: %v", err)
+	}
+
+	// Second derivation with the same key (different temp dir, no existing file).
+	dir2 := t.TempDir()
+	km2, err := LoadKey(filepath.Join(dir2, "gateway.key"), masterKey)
+	if err != nil {
+		t.Fatalf("second LoadKey: %v", err)
+	}
+
+	id1 := km1.Decrypt.(*age.X25519Identity)
+	id2 := km2.Decrypt.(*age.X25519Identity)
+	if id1.Recipient().String() != id2.Recipient().String() {
+		t.Error("same master key must produce the same identity")
+	}
+
+	// Different master key must produce a different identity.
+	dir3 := t.TempDir()
+	otherKey := []byte("a-different-master-key-for-testing!")
+	km3, err := LoadKey(filepath.Join(dir3, "gateway.key"), otherKey)
+	if err != nil {
+		t.Fatalf("third LoadKey: %v", err)
+	}
+	id3 := km3.Decrypt.(*age.X25519Identity)
+	if id1.Recipient().String() == id3.Recipient().String() {
+		t.Error("different master keys must produce different identities")
+	}
+}
+
+// TestLoadKey_RandomGenerationNoMasterKey verifies that without a master key
+// a random identity is generated and saved.
+func TestLoadKey_RandomGenerationNoMasterKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "gateway.key")
+
+	km, err := LoadKey(keyPath, nil)
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if km.Decrypt == nil || km.Encrypt == nil {
+		t.Fatal("KeyMaterial fields must not be nil")
+	}
+
+	// The file must have been created.
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Errorf("key file not created: %v", err)
+	}
+
+	// Re-loading must return the same key.
+	km2, err := LoadKey(keyPath, nil)
+	if err != nil {
+		t.Fatalf("second LoadKey: %v", err)
+	}
+	id1 := km.Decrypt.(*age.X25519Identity).Recipient().String()
+	id2 := km2.Decrypt.(*age.X25519Identity).Recipient().String()
+	if id1 != id2 {
+		t.Error("re-loading key file must return the same identity")
+	}
+}
+
+// TestLoadKey_CorruptFile_Empty verifies that an empty key file returns
+// ErrKeyCorrupt and does not overwrite the file.
+func TestLoadKey_CorruptFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "gateway.key")
+	if err := os.WriteFile(keyPath, []byte(""), 0600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+
+	_, err := LoadKey(keyPath, nil)
+	if !errors.Is(err, ErrKeyCorrupt) {
+		t.Errorf("expected ErrKeyCorrupt, got: %v", err)
+	}
+
+	// File must still be the empty file (not overwritten).
+	data, _ := os.ReadFile(keyPath)
+	if len(data) != 0 {
+		t.Errorf("corrupt file must not be overwritten; got %d bytes", len(data))
+	}
+}
+
+// TestLoadKey_CorruptFile_InvalidFormat verifies that a file with content
+// but no AGE-SECRET-KEY-1 line returns ErrKeyCorrupt.
+func TestLoadKey_CorruptFile_InvalidFormat(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "gateway.key")
+	if err := os.WriteFile(keyPath, []byte("not-a-valid-key\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := LoadKey(keyPath, nil)
+	if !errors.Is(err, ErrKeyCorrupt) {
+		t.Errorf("expected ErrKeyCorrupt, got: %v", err)
+	}
+}
+
+// TestLoadKey_CorruptFile_BadKeyLine verifies that a file with an
+// AGE-SECRET-KEY- prefix but invalid bech32 returns ErrKeyCorrupt.
+func TestLoadKey_CorruptFile_BadKeyLine(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "gateway.key")
+	// Looks like a key line but is truncated/mangled.
+	if err := os.WriteFile(keyPath, []byte("AGE-SECRET-KEY-INVALID\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := LoadKey(keyPath, nil)
+	if !errors.Is(err, ErrKeyCorrupt) {
+		t.Errorf("expected ErrKeyCorrupt, got: %v", err)
+	}
+}
+
+// TestLoadKey_MasterKeyTooShort verifies that a master key shorter than
+// minMasterKeyLen bytes returns an error.
+func TestLoadKey_MasterKeyTooShort(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "gateway.key")
+
+	_, err := LoadKey(keyPath, []byte("tooshort"))
+	if err == nil {
+		t.Fatal("expected error for short master key")
+	}
+	if !strings.Contains(err.Error(), "at least") {
+		t.Errorf("error should mention minimum length, got: %v", err)
+	}
+}
+
+// TestLoadKey_NoSecretInLogs verifies that the key content never appears
+// in log output.
+func TestLoadKey_NoSecretInLogs(t *testing.T) {
+	logBuf := captureLogs(t)
+	dir := t.TempDir()
+	masterKey := []byte("this-is-a-known-master-key-for-test!")
+
+	_, err := LoadKey(filepath.Join(dir, "gateway.key"), masterKey)
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+
+	output := logBuf.String()
+	// The master key raw value must not appear in log output.
+	if strings.Contains(output, "this-is-a-known-master-key-for-test!") {
+		t.Error("master key leaked to log output")
+	}
+	// AGE-SECRET-KEY- content must not appear in log output.
+	if strings.Contains(output, "AGE-SECRET-KEY-") {
+		t.Error("key content leaked to log output")
+	}
+}


### PR DESCRIPTION
Implements #11 — config persistence layer with secret encryption at rest.

## Changes

### New package: internal/config

- bech32.go: Inline bech32 encoding (MIT, from age internals) for HKDF to X25519 key derivation
- key.go: LoadKey, KeyMaterial, ErrKeyCorrupt, deriveIdentityFromMasterKey
- crypto.go: EncryptField, DecryptField, IsEncrypted — ENC[age:] format
- config.go: AppConfig, LoadConfig, SaveConfig, MigrateSecret
- *_test.go: 19 tests covering all spec scenarios

### cmd/server/main.go

- Removed mustEnv calls for GITHUB_MCP_CLIENT_ID and GITHUB_MCP_CLIENT_SECRET
- Added key loading, YAML config loading, and MigrateSecret call at startup
- New config fields: keyPath (MCP_GATEWAY_KEY_PATH), configPath (MCP_CONFIG_FILE)

### Docs
- README: new Secret Encryption section with key file format, generation priority, backup warning, master key requirements, and Docker Compose example
- CHANGELOG: Unreleased entry for #11

## Key design decisions

- X25519 only — no Scrypt; gateway.key is standard AGE-SECRET-KEY-1 (age-keygen compatible)
- Corrupt key = hard stop — gateway never auto-overwrites an existing but broken gateway.key
- HKDF-SHA256 derivation — same MCP_GATEWAY_MASTER_KEY always produces the same identity
- No secrets in logs — plaintext, ENC[...] value, key content, and env var values are never logged
- Encryption scope — GITHUB_MCP_CLIENT_SECRET only; tokens.json is out of scope

## Test coverage (all 10 spec scenarios from tasks.md)

- gateway.key exists + master key env → file wins (master key ignored)
- Same master key → deterministic identity (verified twice, different temp dirs)
- No master key → random key generated and saved
- Empty/invalid/mangled key file → ErrKeyCorrupt, no overwrite
- Master key < 32 bytes → startup error
- ENC[age:] in config → decrypted
- Plaintext in config → encrypted and rewritten
- No config + env var → encrypted and saved
- No config + no env → clear error
- No secrets or keys in log output

Closes #11