### PR TITLE
feat(observability): HTTP request logger middleware and slog field normalization

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -197,7 +197,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           middleware.Logger()(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      0, // unlimited: MCP streaming responses may be long-lived
@@ -239,7 +239,7 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           middleware.Logger()(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -374,7 +374,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		h.store.DenyDevice(deviceCode)
 		oauthError(w, "access_denied", "user denied authorization", http.StatusBadRequest)
 	default:
-		slog.Warn("unexpected GitHub device poll error", "error", result.Error)
+		slog.Warn("unexpected GitHub device poll error", "err", result.Error)
 		oauthError(w, "server_error", "unexpected upstream error: "+result.Error, http.StatusBadGateway)
 	}
 }

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -1,16 +1,18 @@
 package middleware
 
 import (
+	"bufio"
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
 
 // statusWriter wraps http.ResponseWriter to capture the written HTTP status
-// code. It implements Unwrap so that http.NewResponseController can reach the
-// underlying writer and use its optional interfaces (Flush, Hijack, etc.),
-// preserving streaming behaviour through the Logger middleware.
+// code. It explicitly implements http.Flusher and http.Hijacker by delegating
+// to the underlying writer, so that both direct type-assertions and
+// http.NewResponseController can reach those capabilities through the wrapper.
 type statusWriter struct {
 	http.ResponseWriter
 	status int
@@ -33,10 +35,27 @@ func (sw *statusWriter) Write(b []byte) (int, error) {
 	return sw.ResponseWriter.Write(b)
 }
 
-// Unwrap returns the underlying ResponseWriter so that http.ResponseController
-// and direct Flusher/Hijacker type-assertions continue to work through the wrapper.
+// Unwrap returns the underlying ResponseWriter so http.NewResponseController
+// can find optional interfaces beyond Flusher and Hijacker.
 func (sw *statusWriter) Unwrap() http.ResponseWriter {
 	return sw.ResponseWriter
+}
+
+// Flush implements http.Flusher, delegating to the underlying writer when
+// it supports flushing (e.g. for Server-Sent Events or chunked responses).
+func (sw *statusWriter) Flush() {
+	if f, ok := sw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker, delegating to the underlying writer when
+// it supports connection hijacking (e.g. for WebSocket upgrades).
+func (sw *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := sw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
 }
 
 // statusCode returns the captured status, defaulting to 200 when no status was
@@ -54,8 +73,7 @@ func (sw *statusWriter) statusCode() int {
 // Log level is chosen by status range:
 //
 //	5xx → Error
-//	4xx → Warn
-//	2xx/3xx → Info
+//	2xx/3xx/4xx → Info
 func Logger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,12 +96,8 @@ func Logger() func(http.Handler) http.Handler {
 type logFunc func(ctx context.Context, msg string, args ...any)
 
 func logFuncForStatus(status int) logFunc {
-	switch {
-	case status >= 500:
+	if status >= 500 {
 		return slog.ErrorContext
-	case status >= 400:
-		return slog.WarnContext
-	default:
-		return slog.InfoContext
 	}
+	return slog.InfoContext
 }

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -50,10 +50,17 @@ func (sw *statusWriter) Flush() {
 }
 
 // Hijack implements http.Hijacker, delegating to the underlying writer when
-// it supports connection hijacking (e.g. for WebSocket upgrades).
+// it supports connection hijacking (e.g. for WebSocket upgrades). On success
+// the status is recorded as 101 Switching Protocols so that the access log
+// reflects the real protocol-upgrade response rather than the default 200.
 func (sw *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := sw.ResponseWriter.(http.Hijacker); ok {
-		return h.Hijack()
+		conn, rw, err := h.Hijack()
+		if err == nil && !sw.wrote {
+			sw.status = http.StatusSwitchingProtocols
+			sw.wrote = true
+		}
+		return conn, rw, err
 	}
 	return nil, nil, http.ErrNotSupported
 }
@@ -74,21 +81,27 @@ func (sw *statusWriter) statusCode() int {
 //
 //	5xx → Error
 //	2xx/3xx/4xx → Info
+//
+// The log line is written in a deferred call so it is always emitted even if
+// a downstream handler panics (net/http recovers the panic after the deferred
+// functions run).
 func Logger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			sw := &statusWriter{ResponseWriter: w}
+			defer func() {
+				latency := time.Since(start).Milliseconds()
+				logFn := logFuncForStatus(sw.statusCode())
+				logFn(r.Context(), "http request",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"status", sw.statusCode(),
+					"latency_ms", latency,
+					"remote_addr", r.RemoteAddr,
+				)
+			}()
 			next.ServeHTTP(sw, r)
-			latency := time.Since(start).Milliseconds()
-			logFn := logFuncForStatus(sw.statusCode())
-			logFn(r.Context(), "http request",
-				"method", r.Method,
-				"path", r.URL.Path,
-				"status", sw.statusCode(),
-				"latency_ms", latency,
-				"remote_addr", r.RemoteAddr,
-			)
 		})
 	}
 }

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bufio"
 	"context"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -65,8 +66,20 @@ func (sw *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, http.ErrNotSupported
 }
 
-// statusCode returns the captured status, defaulting to 200 when no status was
-// explicitly written (implicit 200 OK from the first Write).
+// ReadFrom implements io.ReaderFrom to preserve the optimised ReadFrom fast
+// path (e.g. sendfile via net.Conn) when the underlying ResponseWriter supports
+// it. Without this, httputil.ReverseProxy falls back to a generic buffered copy
+// which adds avoidable CPU and memory overhead for large or streaming responses.
+func (sw *statusWriter) ReadFrom(src io.Reader) (int64, error) {
+	if !sw.wrote {
+		sw.status = http.StatusOK
+		sw.wrote = true
+	}
+	if rf, ok := sw.ResponseWriter.(io.ReaderFrom); ok {
+		return rf.ReadFrom(src)
+	}
+	return io.Copy(sw.ResponseWriter, src)
+}
 func (sw *statusWriter) statusCode() int {
 	if !sw.wrote {
 		return http.StatusOK
@@ -82,24 +95,34 @@ func (sw *statusWriter) statusCode() int {
 //	5xx → Error
 //	2xx/3xx/4xx → Info
 //
-// The log line is written in a deferred call so it is always emitted even if
-// a downstream handler panics (net/http recovers the panic after the deferred
-// functions run).
+// The log is written inside a deferred function that also recovers panics:
+// if a downstream handler panics before writing any headers the status is
+// set to 500 and the access log is emitted before re-panicking so that
+// net/http's own recover can send a 500 response to the client.
 func Logger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			sw := &statusWriter{ResponseWriter: w}
 			defer func() {
+				p := recover()
+				// Downstream panicked before writing headers: record 500 so the
+				// access log is not misleadingly shown as 200 OK.
+				if p != nil && !sw.wrote {
+					sw.status = http.StatusInternalServerError
+					sw.wrote = true
+				}
 				latency := time.Since(start).Milliseconds()
-				logFn := logFuncForStatus(sw.statusCode())
-				logFn(r.Context(), "http request",
+				logFuncForStatus(sw.statusCode())(r.Context(), "http request",
 					"method", r.Method,
 					"path", r.URL.Path,
 					"status", sw.statusCode(),
 					"latency_ms", latency,
 					"remote_addr", r.RemoteAddr,
 				)
+				if p != nil {
+					panic(p) // re-panic so net/http can recover and send 500
+				}
 			}()
 			next.ServeHTTP(sw, r)
 		})

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// statusWriter wraps http.ResponseWriter to capture the written HTTP status
+// code. It implements Unwrap so that http.NewResponseController can reach the
+// underlying writer and use its optional interfaces (Flush, Hijack, etc.),
+// preserving streaming behaviour through the Logger middleware.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+	wrote  bool
+}
+
+func (sw *statusWriter) WriteHeader(code int) {
+	if !sw.wrote {
+		sw.status = code
+		sw.wrote = true
+	}
+	sw.ResponseWriter.WriteHeader(code)
+}
+
+func (sw *statusWriter) Write(b []byte) (int, error) {
+	if !sw.wrote {
+		sw.status = http.StatusOK
+		sw.wrote = true
+	}
+	return sw.ResponseWriter.Write(b)
+}
+
+// Unwrap returns the underlying ResponseWriter so that http.ResponseController
+// and direct Flusher/Hijacker type-assertions continue to work through the wrapper.
+func (sw *statusWriter) Unwrap() http.ResponseWriter {
+	return sw.ResponseWriter
+}
+
+// statusCode returns the captured status, defaulting to 200 when no status was
+// explicitly written (implicit 200 OK from the first Write).
+func (sw *statusWriter) statusCode() int {
+	if !sw.wrote {
+		return http.StatusOK
+	}
+	return sw.status
+}
+
+// Logger returns a middleware that emits one structured log line per HTTP
+// request containing: method, path, status, latency_ms, remote_addr.
+//
+// Log level is chosen by status range:
+//
+//	5xx → Error
+//	4xx → Warn
+//	2xx/3xx → Info
+func Logger() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			sw := &statusWriter{ResponseWriter: w}
+			next.ServeHTTP(sw, r)
+			latency := time.Since(start).Milliseconds()
+			logFn := logFuncForStatus(sw.statusCode())
+			logFn(r.Context(), "http request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", sw.statusCode(),
+				"latency_ms", latency,
+				"remote_addr", r.RemoteAddr,
+			)
+		})
+	}
+}
+
+type logFunc func(ctx context.Context, msg string, args ...any)
+
+func logFuncForStatus(status int) logFunc {
+	switch {
+	case status >= 500:
+		return slog.ErrorContext
+	case status >= 400:
+		return slog.WarnContext
+	default:
+		return slog.InfoContext
+	}
+}

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -91,8 +91,8 @@ func TestLogger4xx(t *testing.T) {
 	h.ServeHTTP(w, r)
 
 	entry := parseLastLog(t, &buf)
-	if entry["level"] != "WARN" {
-		t.Errorf("level: got %q, want WARN", entry["level"])
+	if entry["level"] != "INFO" {
+		t.Errorf("level: got %q, want INFO", entry["level"])
 	}
 	if entry["status"] != float64(401) {
 		t.Errorf("status: got %v, want 401", entry["status"])
@@ -143,5 +143,42 @@ func TestLoggerUnwrap(t *testing.T) {
 	sw := &statusWriter{ResponseWriter: inner}
 	if sw.Unwrap() != inner {
 		t.Error("Unwrap should return the underlying ResponseWriter")
+	}
+}
+
+func TestStatusWriterFlush(t *testing.T) {
+	// httptest.ResponseRecorder implements http.Flusher, so Flush() must be
+	// forwarded without panicking and must set the Flushed flag.
+	inner := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: inner}
+
+	// statusWriter itself must satisfy http.Flusher via direct type assertion.
+	flusher, ok := any(sw).(http.Flusher)
+	if !ok {
+		t.Fatal("statusWriter does not implement http.Flusher")
+	}
+	flusher.Flush()
+	if !inner.Flushed {
+		t.Error("Flush did not propagate to underlying ResponseRecorder")
+	}
+}
+
+func TestStatusWriterHijackNotSupported(t *testing.T) {
+	// httptest.ResponseRecorder does NOT implement http.Hijacker, so Hijack()
+	// must return http.ErrNotSupported and statusWriter must still satisfy the
+	// http.Hijacker interface via direct type assertion.
+	inner := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: inner}
+
+	hijacker, ok := any(sw).(http.Hijacker)
+	if !ok {
+		t.Fatal("statusWriter does not implement http.Hijacker")
+	}
+	conn, rw, err := hijacker.Hijack()
+	if err == nil {
+		t.Error("expected error from Hijack when underlying writer does not support it")
+	}
+	if conn != nil || rw != nil {
+		t.Error("Hijack should return nil conn and rw on error")
 	}
 }

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -1,9 +1,11 @@
 package middleware
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -183,9 +185,37 @@ func TestStatusWriterHijackNotSupported(t *testing.T) {
 	}
 }
 
+// mockHijackWriter wraps ResponseRecorder and implements http.Hijacker.
+type mockHijackWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (m *mockHijackWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	client, server := net.Pipe()
+	_ = server
+	return client, bufio.NewReadWriter(bufio.NewReader(client), bufio.NewWriter(client)), nil
+}
+
+func TestStatusWriterHijackSuccess(t *testing.T) {
+	// When the underlying writer supports Hijack and the call succeeds,
+	// statusWriter must record status 101 Switching Protocols.
+	inner := &mockHijackWriter{httptest.NewRecorder()}
+	sw := &statusWriter{ResponseWriter: inner}
+
+	conn, _, err := sw.Hijack()
+	if err != nil {
+		t.Fatalf("Hijack failed: %v", err)
+	}
+	defer conn.Close()
+
+	if sw.statusCode() != http.StatusSwitchingProtocols {
+		t.Errorf("statusCode after Hijack: got %d, want 101", sw.statusCode())
+	}
+}
+
 func TestLoggerPanic(t *testing.T) {
-	// Even if the downstream handler panics, the deferred log line must still
-	// be emitted (net/http recovers the panic after deferred functions run).
+	// A downstream handler panic must emit a log line with status 500 and
+	// level ERROR. The middleware re-panics so net/http can still recover.
 	var buf bytes.Buffer
 	t.Cleanup(captureLogs(t, &buf))
 
@@ -206,5 +236,11 @@ func TestLoggerPanic(t *testing.T) {
 	entry := parseLastLog(t, &buf)
 	if entry["path"] != "/crash" {
 		t.Errorf("path: got %v, want /crash", entry["path"])
+	}
+	if entry["status"] != float64(500) {
+		t.Errorf("status on panic: got %v, want 500", entry["status"])
+	}
+	if entry["level"] != "ERROR" {
+		t.Errorf("level on panic: got %q, want ERROR", entry["level"])
 	}
 }

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -1,0 +1,147 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureLogs redirects the default slog logger to a buffer and returns a
+// function that restores the original logger (suitable for t.Cleanup).
+func captureLogs(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return func() { slog.SetDefault(old) }
+}
+
+// parseLastLog parses the last complete JSON line from buf as a map.
+func parseLastLog(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte("\n"))
+	last := lines[len(lines)-1]
+	var m map[string]any
+	if err := json.Unmarshal(last, &m); err != nil {
+		t.Fatalf("failed to parse log line %q: %v", last, err)
+	}
+	return m
+}
+
+func TestLoggerImplicit200(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	if entry["level"] != "INFO" {
+		t.Errorf("level: got %q, want INFO", entry["level"])
+	}
+	if entry["status"] != float64(200) {
+		t.Errorf("status: got %v, want 200", entry["status"])
+	}
+	if entry["method"] != "GET" {
+		t.Errorf("method: got %v, want GET", entry["method"])
+	}
+	if entry["path"] != "/health" {
+		t.Errorf("path: got %v, want /health", entry["path"])
+	}
+	if _, ok := entry["latency_ms"]; !ok {
+		t.Error("latency_ms field missing")
+	}
+}
+
+func TestLoggerExplicit200(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := httptest.NewRequest(http.MethodPost, "/token", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	if entry["level"] != "INFO" {
+		t.Errorf("level: got %q, want INFO", entry["level"])
+	}
+	if entry["status"] != float64(200) {
+		t.Errorf("status: got %v, want 200", entry["status"])
+	}
+}
+
+func TestLogger4xx(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	if entry["level"] != "WARN" {
+		t.Errorf("level: got %q, want WARN", entry["level"])
+	}
+	if entry["status"] != float64(401) {
+		t.Errorf("status: got %v, want 401", entry["status"])
+	}
+}
+
+func TestLogger5xx(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	if entry["level"] != "ERROR" {
+		t.Errorf("level: got %q, want ERROR", entry["level"])
+	}
+	if entry["status"] != float64(503) {
+		t.Errorf("status: got %v, want 503", entry["status"])
+	}
+}
+
+func TestLoggerFieldsPresent(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/mcp/v1/resource", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	for _, field := range []string{"method", "path", "status", "latency_ms", "remote_addr"} {
+		if _, ok := entry[field]; !ok {
+			t.Errorf("expected field %q to be present in log entry", field)
+		}
+	}
+}
+
+func TestLoggerUnwrap(t *testing.T) {
+	inner := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: inner}
+	if sw.Unwrap() != inner {
+		t.Error("Unwrap should return the underlying ResponseWriter")
+	}
+}

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -243,4 +245,62 @@ func TestLoggerPanic(t *testing.T) {
 	if entry["level"] != "ERROR" {
 		t.Errorf("level on panic: got %q, want ERROR", entry["level"])
 	}
+}
+
+// mockReaderFromWriter is a ResponseWriter that also implements io.ReaderFrom,
+// capturing the data it received via ReadFrom for assertion.
+type mockReaderFromWriter struct {
+	*httptest.ResponseRecorder
+	readFromCalled bool
+	received       bytes.Buffer
+}
+
+func (m *mockReaderFromWriter) ReadFrom(src io.Reader) (int64, error) {
+	m.readFromCalled = true
+	return io.Copy(&m.received, src)
+}
+
+func TestStatusWriterReadFrom(t *testing.T) {
+	t.Run("delegates to underlying io.ReaderFrom", func(t *testing.T) {
+		inner := &mockReaderFromWriter{ResponseRecorder: httptest.NewRecorder()}
+		sw := &statusWriter{ResponseWriter: inner}
+
+		payload := "hello from ReadFrom"
+		n, err := sw.ReadFrom(strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("ReadFrom returned error: %v", err)
+		}
+		if n != int64(len(payload)) {
+			t.Errorf("ReadFrom returned %d bytes, want %d", n, len(payload))
+		}
+		if !inner.readFromCalled {
+			t.Error("expected underlying ReadFrom to be called, but it was not")
+		}
+		if inner.received.String() != payload {
+			t.Errorf("underlying received %q, want %q", inner.received.String(), payload)
+		}
+		if sw.statusCode() != http.StatusOK {
+			t.Errorf("statusCode after ReadFrom: got %d, want 200", sw.statusCode())
+		}
+	})
+
+	t.Run("falls back to io.Copy when underlying does not implement io.ReaderFrom", func(t *testing.T) {
+		inner := httptest.NewRecorder()
+		sw := &statusWriter{ResponseWriter: inner}
+
+		payload := "hello via fallback"
+		n, err := sw.ReadFrom(strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("ReadFrom (fallback) returned error: %v", err)
+		}
+		if n != int64(len(payload)) {
+			t.Errorf("ReadFrom (fallback) returned %d bytes, want %d", n, len(payload))
+		}
+		if inner.Body.String() != payload {
+			t.Errorf("response body via fallback: got %q, want %q", inner.Body.String(), payload)
+		}
+		if sw.statusCode() != http.StatusOK {
+			t.Errorf("statusCode after ReadFrom fallback: got %d, want 200", sw.statusCode())
+		}
+	})
 }

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -182,3 +182,29 @@ func TestStatusWriterHijackNotSupported(t *testing.T) {
 		t.Error("Hijack should return nil conn and rw on error")
 	}
 }
+
+func TestLoggerPanic(t *testing.T) {
+	// Even if the downstream handler panics, the deferred log line must still
+	// be emitted (net/http recovers the panic after deferred functions run).
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	h := Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("simulated handler panic")
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/crash", nil)
+	w := httptest.NewRecorder()
+
+	func() {
+		defer func() { recover() }() //nolint:errcheck
+		h.ServeHTTP(w, r)
+	}()
+
+	if buf.Len() == 0 {
+		t.Error("expected a log line even after handler panic, got none")
+	}
+	entry := parseLastLog(t, &buf)
+	if entry["path"] != "/crash" {
+		t.Errorf("path: got %v, want /crash", entry["path"])
+	}
+}

--- a/tasks.md
+++ b/tasks.md
@@ -41,13 +41,13 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 
 ### v0.3.0 へ向けて（次フェーズ）
 
-| 優先 | 項目 | 種別 | 状態 |
-|---|---|---|---|
-| 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | 🗒️ 計画段階 |
-| 2 | **CI 強化**（カバレッジ計測・lint 強化） | infra | 🗒️ 計画段階 |
-| 3 | **ドキュメント整備**（README 構造見直し・運用手順統合） | docs | 🗒️ 計画段階 |
-| 4 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | 🗒️ 計画段階 |
-| 5 | **v0.3.0 リリース** | release | 上記完了後 |
+| 優先 | 項目 | 種別 | Issue | 状態 |
+|---|---|---|---|---|
+| 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
+| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🗒️ 計画段階 |
+| 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
+| 4 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | 🗒️ 計画段階 |
+| 5 | **v0.3.0 リリース** | release | — | 上記完了後 |
 
 ### 保留維持
 


### PR DESCRIPTION
## 概要

RM1 (#42) の必須スコープを実装。

## 変更内容

### 新規: `internal/middleware/logger.go`

`Logger()` ミドルウェアを追加。全 HTTP リクエストに対して1行の構造化ログを出力:

- **ステータスによるログレベル自動選択**: 5xx→Error / 2xx・3xx・4xx→Info
  - 4xx を Info に設定: OAuth デバイスフロー正常ポーリング (400 authorization_pending/slow_down) が Warn を大量生成するのを防ぐ
- **statusWriter**: http.Flusher と http.Hijacker を明示実装（直接型アサーション対応）; Hijack 成功時は status=101 を記録; ログは defer で記録しパニック時も漏れなし
- **Unwrap()**: http.NewResponseController 経由でのその他オプション機能を維持（MCP ストリーミング互換）

### 新規: `internal/middleware/logger_test.go`

9テスト: implicit 200・explicit 200・4xx (Info)・5xx (Error)・全フィールド存在確認・Unwrap・Flush・Hijack（未対応時エラー）・パニック時ログ出力

### 変更: `cmd/server/main.go`

メインサーバー・セットアップウィザードサーバー双方で最外ラッパーとして middleware.Logger()(mux) を適用。

### 修正: `internal/auth/handler.go`

slog フィールドキー統一: "error" → "err"（コードベース全体で "err" を使用、この1箇所だけ異なっていた）

## テスト

全パッケージ pass (go test ./...)

Closes #42
