### PR TITLE
feat: separate bind_addr from public_url (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Migration notes
 
-Docker Compose users **must** add `MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080` so the container
+Docker Compose users **must** add `MCP_GATEWAY_BIND_ADDR: 0.0.0.0:<port>` (replacing
+`<port>` with the port your gateway uses, typically `8080`) so the container
 binds on all interfaces and Docker port-forwarding continues to work. See
 [`docs/operations.md`](docs/operations.md) for the full cutover procedure.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-05-05
+## [0.3.0] - 2026-05-20
+
+### Added
+
+- `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` — canonical URL used for OAuth callbacks, discovery metadata, and PRM ([#48](https://github.com/scottlz0310/mcp-gateway/issues/48))
+- `MCP_GATEWAY_BIND_ADDR` / `gateway.bind_addr` — HTTP listener bind address, separate from the public URL ([#48](https://github.com/scottlz0310/mcp-gateway/issues/48))
+- `docs/operations.md` — migration guide: `bind_addr` vs `public_url`, GitHub OAuth App callback URL update, Docker and bare-binary deployment notes
+
+### Changed
+
+- Default bind address changed from `localhost:8080` to `127.0.0.1:8080` (loopback-only; Docker users must set `MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080`)
+- Default public URL changed from `http://localhost:8080` to `http://127.0.0.1:8080`
+
+### Deprecated
+
+- `MCP_GATEWAY_BASE_URL` / `gateway.base_url` — replaced by `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url`. A startup warning is emitted when the deprecated setting is detected. The alias will be removed in a future release.
+
+### Migration notes
+
+Docker Compose users **must** add `MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080` so the container
+binds on all interfaces and Docker port-forwarding continues to work. See
+[`docs/operations.md`](docs/operations.md) for the full cutover procedure.
+
+## [0.2.0]- 2026-05-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Default bind address changed from `localhost:8080` to `127.0.0.1:8080` (loopback-only; Docker users must set `MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080`)
+- Default bind address changed from all interfaces (`:<port>`) to loopback-only (`127.0.0.1:8080`); Docker users must set `MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080`
 - Default public URL changed from `http://localhost:8080` to `http://127.0.0.1:8080`
 
 ### Deprecated
@@ -30,7 +30,7 @@ Docker Compose users **must** add `MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080` so the c
 binds on all interfaces and Docker port-forwarding continues to work. See
 [`docs/operations.md`](docs/operations.md) for the full cutover procedure.
 
-## [0.2.0]- 2026-05-05
+## [0.2.0] - 2026-05-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ binds on all interfaces and Docker port-forwarding continues to work. See
 - Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
 - Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/mcp-gateway/releases/tag/v0.1.0

--- a/README.ja.md
+++ b/README.ja.md
@@ -230,7 +230,7 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | OAuth コールバック・discovery メタデータ・PRM に使用する外部公開 URL（`MCP_GATEWAY_BASE_URL` の後継） |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker デプロイでは `0.0.0.0:<port>` に変更する。同一ホスト上のリバースプロキシ経由の場合はデフォルト `127.0.0.1:<port>` のままで良い |
 | `MCP_GATEWAY_BASE_URL` | — | **非推奨** — `MCP_GATEWAY_PUBLIC_URL` のエイリアス。将来のリリースで削除予定 |
-| `MCP_GATEWAY_PORT` | `8080` | リスンポート |
+| `MCP_GATEWAY_PORT` | `8080` | `bind_addr` と `public_url` のデフォルト値を導出する際のポート番号。実際の待受アドレスは `MCP_GATEWAY_BIND_ADDR` で制御する |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
 | `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |

--- a/README.ja.md
+++ b/README.ja.md
@@ -228,7 +228,7 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 | `MCP_CONFIG_FILE` | `./config.yaml` | 永続設定を格納する `config.yaml` のパス |
 | `MCP_GATEWAY_MASTER_KEY` | — | 決定論的キー導出に使用するマスターキー（≥32 バイト; [シークレット暗号化](#シークレット暗号化) 参照） |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | OAuth コールバック・discovery メタデータ・PRM に使用する外部公開 URL（`MCP_GATEWAY_BASE_URL` の後継） |
-| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker やリバースプロキシ経由では `0.0.0.0:<port>` に変更する |
+| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker デプロイでは `0.0.0.0:<port>` に変更する。同一ホスト上のリバースプロキシ経由の場合はデフォルト `127.0.0.1:<port>` のままで良い |
 | `MCP_GATEWAY_BASE_URL` | — | **非推奨** — `MCP_GATEWAY_PUBLIC_URL` のエイリアス。将来のリリースで削除予定 |
 | `MCP_GATEWAY_PORT` | `8080` | リスンポート |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,7 @@ mcp-gateway (:8080)
 2. ワンタイムセットアップトークン（TTL 15 分）が標準出力に出力されます:
    ```
    {"level":"warn","msg":"mcp-gateway starting in setup mode — configure via /setup",
-    "setup_url":"http://localhost:8080/setup?token=<TOKEN>",
+    "setup_url":"http://127.0.0.1:8080/setup?token=<TOKEN>",
     "token":"<TOKEN>"}
    ```
 3. `/setup` 以外のすべてのルートは `503 {"error":"setup_required","setup_url":"..."}` を返します。
@@ -51,11 +51,11 @@ mcp-gateway (:8080)
 
 ```bash
 # 1. 不足している設定項目を確認
-curl "http://localhost:8080/setup?token=<TOKEN>"
+curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
 # → {"missing":["client_id","client_secret","routes"],"hint":"POST /setup ..."}
 
 # 2. 設定を送信
-curl -X POST "http://localhost:8080/setup?token=<TOKEN>" \
+curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "Ov23liXXXXXXXXXX",
@@ -168,7 +168,7 @@ auth:
   github_client_id: "Ov23liXXXX"
   github_client_secret: "ENC[age:]<base64-ciphertext>"
 gateway:
-  base_url: "http://localhost:8080"
+  public_url: "http://127.0.0.1:8080"
   port: "8080"
   oauth_scopes: "repo,user"
 ```
@@ -227,7 +227,9 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | X25519 暗号化キーファイルのパス（[シークレット暗号化](#シークレット暗号化) 参照） |
 | `MCP_CONFIG_FILE` | `./config.yaml` | 永続設定を格納する `config.yaml` のパス |
 | `MCP_GATEWAY_MASTER_KEY` | — | 決定論的キー導出に使用するマスターキー（≥32 バイト; [シークレット暗号化](#シークレット暗号化) 参照） |
-| `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | OAuth コールバック等に使用するベース URL |
+| `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | OAuth コールバック・discovery メタデータ・PRM に使用する外部公開 URL（`MCP_GATEWAY_BASE_URL` の後継） |
+| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker やリバースプロキシ経由では `0.0.0.0:<port>` に変更する |
+| `MCP_GATEWAY_BASE_URL` | — | **非推奨** — `MCP_GATEWAY_PUBLIC_URL` のエイリアス。将来のリリースで削除予定 |
 | `MCP_GATEWAY_PORT` | `8080` | リスンポート |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
@@ -287,7 +289,7 @@ MCP_GATEWAY_TOKEN_STORE_PATH=                   # 永続化を無効化（非推
 
 **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App** から:
 
-- **Authorization callback URL**: `http://localhost:8080/callback` (または `MCP_GATEWAY_BASE_URL` + `/callback`)
+- **Authorization callback URL**: `http://127.0.0.1:8080/callback` (または `MCP_GATEWAY_PUBLIC_URL` + `/callback`)
 
 ### 2. Docker Compose で起動
 
@@ -300,7 +302,8 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: <your-client-id>
       GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BASE_URL: http://localhost:8080
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
     depends_on:
       - github-mcp
@@ -320,7 +323,8 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: <your-client-id>
       GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BASE_URL: http://localhost:8080
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
       ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
     depends_on:
@@ -339,11 +343,11 @@ MCP クライアント設定ファイル（例: `claude_desktop_config.json`）�
 {
   "mcpServers": {
     "github": {
-      "url": "http://localhost:8080/mcp/github",
+      "url": "http://127.0.0.1:8080/mcp/github",
       "transport": "http"
     },
     "copilot-review": {
-      "url": "http://localhost:8080/mcp/copilot-review",
+      "url": "http://127.0.0.1:8080/mcp/copilot-review",
       "transport": "http"
     }
   }

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | Canonical base URL for OAuth callback, discovery metadata, and PRM (replaces `MCP_GATEWAY_BASE_URL`) |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker deployments. For reverse-proxy on the same host, keep the default `127.0.0.1:<port>` |
 | `MCP_GATEWAY_BASE_URL` | — | **Deprecated** — alias for `MCP_GATEWAY_PUBLIC_URL`; will be removed in a future release |
-| `MCP_GATEWAY_PORT` | `8080` | Listen port |
+| `MCP_GATEWAY_PORT` | `8080` | Default port used when deriving `bind_addr` and `public_url`. The actual listen address is controlled by `MCP_GATEWAY_BIND_ADDR` |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
 | `LOG_LEVEL` | `info` | Log level: `debug` / `info` / `warn` / `error` |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If any required value (`GITHUB_MCP_CLIENT_ID`, `GITHUB_MCP_CLIENT_SECRET`, or at
 2. A one-time setup token (15-min TTL) is printed to stdout:
    ```
    {"level":"warn","msg":"mcp-gateway starting in setup mode — configure via /setup",
-    "setup_url":"http://localhost:8080/setup?token=<TOKEN>",
+    "setup_url":"http://127.0.0.1:8080/setup?token=<TOKEN>",
     "token":"<TOKEN>"}
    ```
 3. All routes except `/setup` return `503 {"error":"setup_required","setup_url":"..."}`.
@@ -51,11 +51,11 @@ If any required value (`GITHUB_MCP_CLIENT_ID`, `GITHUB_MCP_CLIENT_SECRET`, or at
 
 ```bash
 # 1. Check what fields are missing
-curl "http://localhost:8080/setup?token=<TOKEN>"
+curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
 # → {"missing":["client_id","client_secret","routes"],"hint":"POST /setup ..."}
 
 # 2. Submit your configuration
-curl -X POST "http://localhost:8080/setup?token=<TOKEN>" \
+curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "Ov23liXXXXXXXXXX",
@@ -168,7 +168,7 @@ auth:
   github_client_id: "Ov23liXXXX"
   github_client_secret: "ENC[age:]<base64-ciphertext>"
 gateway:
-  base_url: "http://localhost:8080"
+  public_url: "http://127.0.0.1:8080"
   port: "8080"
   oauth_scopes: "repo,user"
 ```
@@ -220,7 +220,9 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the X25519 encryption key file (see [Secret Encryption](#secret-encryption)) |
 | `MCP_CONFIG_FILE` | `./config.yaml` | Path to `config.yaml` for persisted configuration |
 | `MCP_GATEWAY_MASTER_KEY` | — | Master key for deterministic key derivation (≥32 bytes; see [Secret Encryption](#secret-encryption)) |
-| `MCP_GATEWAY_BASE_URL` | `http://localhost:8080` | Base URL used for OAuth callback and discovery metadata |
+| `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | Canonical base URL for OAuth callback, discovery metadata, and PRM (replaces `MCP_GATEWAY_BASE_URL`) |
+| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker or reverse-proxy deployments |
+| `MCP_GATEWAY_BASE_URL` | — | **Deprecated** — alias for `MCP_GATEWAY_PUBLIC_URL`; will be removed in a future release |
 | `MCP_GATEWAY_PORT` | `8080` | Listen port |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
 | `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
@@ -311,7 +313,7 @@ Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`) are stripp
 
 Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**:
 
-- **Authorization callback URL**: `http://localhost:8080/callback` (or your `MCP_GATEWAY_BASE_URL` + `/callback`)
+- **Authorization callback URL**: `http://127.0.0.1:8080/callback` (or your `MCP_GATEWAY_PUBLIC_URL` + `/callback`)
 
 ### 2. Run with Docker Compose
 
@@ -324,7 +326,8 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: <your-client-id>
       GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BASE_URL: http://localhost:8080
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
     depends_on:
       - github-mcp
@@ -347,7 +350,8 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: <your-client-id>
       GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BASE_URL: http://localhost:8080
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
       ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
     depends_on:
@@ -367,11 +371,11 @@ Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 {
   "mcpServers": {
     "github": {
-      "url": "http://localhost:8080/mcp/github",
+      "url": "http://127.0.0.1:8080/mcp/github",
       "transport": "http"
     },
     "copilot-review": {
-      "url": "http://localhost:8080/mcp/copilot-review",
+      "url": "http://127.0.0.1:8080/mcp/copilot-review",
       "transport": "http"
     }
   }

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 | `MCP_CONFIG_FILE` | `./config.yaml` | Path to `config.yaml` for persisted configuration |
 | `MCP_GATEWAY_MASTER_KEY` | — | Master key for deterministic key derivation (≥32 bytes; see [Secret Encryption](#secret-encryption)) |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | Canonical base URL for OAuth callback, discovery metadata, and PRM (replaces `MCP_GATEWAY_BASE_URL`) |
-| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker or reverse-proxy deployments |
+| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker deployments. For reverse-proxy on the same host, keep the default `127.0.0.1:<port>` |
 | `MCP_GATEWAY_BASE_URL` | — | **Deprecated** — alias for `MCP_GATEWAY_PUBLIC_URL`; will be removed in a future release |
 | `MCP_GATEWAY_PORT` | `8080` | Listen port |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,13 +68,34 @@ func main() {
 	envClientID := os.Getenv("GITHUB_MCP_CLIENT_ID")
 	envSecret := os.Getenv("GITHUB_MCP_CLIENT_SECRET")
 
-	// Apply config.yaml gateway overrides before setup wizard so the printed
-	// URL uses the correct base_url/port (priority: env var > config.yaml > default).
-	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" && strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
-		cfg.baseURL = appCfg.Gateway.BaseURL
+	// Deprecation warning: MCP_GATEWAY_BASE_URL is superseded by MCP_GATEWAY_PUBLIC_URL.
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) != "" &&
+		strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" {
+		slog.Warn("MCP_GATEWAY_BASE_URL is deprecated; use MCP_GATEWAY_PUBLIC_URL instead",
+			"hint", "MCP_GATEWAY_PUBLIC_URL will be removed in a future release")
+	}
+
+	// Apply config.yaml gateway overrides (priority: env var > config.yaml > loadConfig default).
+	// publicURL: MCP_GATEWAY_PUBLIC_URL > MCP_GATEWAY_BASE_URL > yaml public_url > yaml base_url > default
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" &&
+		strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" {
+		if strings.TrimSpace(appCfg.Gateway.PublicURL) != "" {
+			cfg.publicURL = appCfg.Gateway.PublicURL
+		} else if strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
+			cfg.publicURL = appCfg.Gateway.BaseURL
+			slog.Warn("gateway.base_url in config.yaml is deprecated; use gateway.public_url instead")
+		}
 	}
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PORT")) == "" && strings.TrimSpace(appCfg.Gateway.Port) != "" {
 		cfg.port = appCfg.Gateway.Port
+	}
+	// bindAddr: MCP_GATEWAY_BIND_ADDR > yaml bind_addr > 127.0.0.1:<resolved port>
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BIND_ADDR")) == "" {
+		if strings.TrimSpace(appCfg.Gateway.BindAddr) != "" {
+			cfg.bindAddr = appCfg.Gateway.BindAddr
+		} else {
+			cfg.bindAddr = "127.0.0.1:" + cfg.port
+		}
 	}
 	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
 		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
@@ -129,7 +150,7 @@ func main() {
 		Kind:         "github",
 		ClientID:     cfg.githubClientID,
 		ClientSecret: cfg.githubClientSecret,
-		RedirectURI:  strings.TrimRight(cfg.baseURL, "/") + "/callback",
+		RedirectURI:  strings.TrimRight(cfg.publicURL, "/") + "/callback",
 		Scopes:       cfg.oauthScopes,
 	})
 	if err != nil {
@@ -138,7 +159,7 @@ func main() {
 	}
 
 	oauthHandler, err := auth.NewHandler(auth.Config{
-		BaseURL:        cfg.baseURL,
+		BaseURL:        cfg.publicURL,
 		SessionTTL:     time.Duration(cfg.sessionTTLMin) * time.Minute,
 		CacheTTL:       time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
 		ExpiresIn:      time.Duration(cfg.tokenExpiresInSec) * time.Second,
@@ -149,7 +170,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authMiddleware := middleware.Auth(oauthHandler, middleware.WithBaseURL(cfg.baseURL))
+	authMiddleware := middleware.Auth(oauthHandler, middleware.WithBaseURL(cfg.publicURL))
 
 	mux := http.NewServeMux()
 
@@ -187,16 +208,15 @@ func main() {
 		)
 	}
 
-	addr := ":" + cfg.port
 	slog.Info("mcp-gateway starting",
-		"addr", addr,
-		"base_url", cfg.baseURL,
+		"bind_addr", cfg.bindAddr,
+		"public_url", cfg.publicURL,
 		"provider", prov.Name(),
 		"routes", len(routes),
 	)
 
 	server := &http.Server{
-		Addr:              addr,
+		Addr:              cfg.bindAddr,
 		Handler:           middleware.Logger()(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
@@ -219,8 +239,7 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 		return
 	}
 
-	addr := ":" + cfg.port
-	setupURL := strings.TrimRight(cfg.baseURL, "/") + "/setup?token=" + mgr.Token()
+	setupURL := strings.TrimRight(cfg.publicURL, "/") + "/setup?token=" + mgr.Token()
 
 	slog.Warn("mcp-gateway starting in setup mode — configure via /setup",
 		"setup_url", setupURL,
@@ -238,14 +257,14 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 	mux.Handle("/", setup.UnconfiguredHandler(setupURL))
 
 	server := &http.Server{
-		Addr:              addr,
+		Addr:              cfg.bindAddr,
 		Handler:           middleware.Logger()(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	slog.Info("setup wizard listening", "addr", addr)
+	slog.Info("setup wizard listening", "bind_addr", cfg.bindAddr)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		slog.Error("setup server error", "err", err)
 	}
@@ -254,7 +273,11 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 type config struct {
 	githubClientID     string
 	githubClientSecret string
-	baseURL            string
+	// publicURL is the canonical base URL visible to OAuth / MCP clients.
+	// Replaces the deprecated baseURL / MCP_GATEWAY_BASE_URL.
+	publicURL          string
+	// bindAddr is the TCP address the HTTP listener binds to (host:port).
+	bindAddr           string
 	oauthScopes        string
 	port               string
 	logLevel           string
@@ -268,11 +291,22 @@ type config struct {
 }
 
 func loadConfig() config {
+	port := getEnv("MCP_GATEWAY_PORT", "8080")
+
+	// publicURL resolution: MCP_GATEWAY_PUBLIC_URL > MCP_GATEWAY_BASE_URL > default.
+	// Deprecation warning for MCP_GATEWAY_BASE_URL is emitted in main() after logger init.
+	publicURL := getEnv("MCP_GATEWAY_PUBLIC_URL",
+		getEnv("MCP_GATEWAY_BASE_URL", "http://127.0.0.1:"+port))
+
+	// bindAddr defaults to loopback; Docker deployments should set MCP_GATEWAY_BIND_ADDR=0.0.0.0:<port>.
+	bindAddr := getEnv("MCP_GATEWAY_BIND_ADDR", "127.0.0.1:"+port)
+
 	return config{
 		// githubClientID and githubClientSecret are resolved after key/config loading in main().
-		baseURL:           getEnv("MCP_GATEWAY_BASE_URL", "http://localhost:8080"),
+		publicURL:         publicURL,
+		bindAddr:          bindAddr,
+		port:              port,
 		oauthScopes:       getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
-		port:              getEnv("MCP_GATEWAY_PORT", "8080"),
 		logLevel:          getEnv("LOG_LEVEL", "info"),
 		upstreamURL:       getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
 		sessionTTLMin:     getEnvInt("SESSION_TTL_MIN", 10),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -77,13 +78,15 @@ func main() {
 
 	// Apply config.yaml gateway overrides (priority: env var > config.yaml > loadConfig default).
 	// publicURL: MCP_GATEWAY_PUBLIC_URL > MCP_GATEWAY_BASE_URL > yaml public_url > yaml base_url > default
+	if strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
+		slog.Warn("gateway.base_url in config.yaml is deprecated; use gateway.public_url instead")
+	}
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" &&
 		strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" {
 		if strings.TrimSpace(appCfg.Gateway.PublicURL) != "" {
 			cfg.publicURL = appCfg.Gateway.PublicURL
 		} else if strings.TrimSpace(appCfg.Gateway.BaseURL) != "" {
 			cfg.publicURL = appCfg.Gateway.BaseURL
-			slog.Warn("gateway.base_url in config.yaml is deprecated; use gateway.public_url instead")
 		}
 	}
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PORT")) == "" && strings.TrimSpace(appCfg.Gateway.Port) != "" {
@@ -97,14 +100,19 @@ func main() {
 			cfg.bindAddr = "127.0.0.1:" + cfg.port
 		}
 	}
-	// If publicURL was not explicitly set (no env, no yaml), recompute the default using the
-	// resolved port so that a yaml-only port override is reflected in OAuth redirects and
-	// discovery metadata.
+	// If publicURL was not explicitly set (no env, no yaml), recompute the default from the
+	// resolved bind address so that a non-default port in BIND_ADDR or gateway.bind_addr is
+	// reflected in OAuth redirects and discovery metadata.
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" &&
 		strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" &&
 		strings.TrimSpace(appCfg.Gateway.PublicURL) == "" &&
 		strings.TrimSpace(appCfg.Gateway.BaseURL) == "" {
-		cfg.publicURL = "http://127.0.0.1:" + cfg.port
+		_, bindPort, err := net.SplitHostPort(cfg.bindAddr)
+		if err == nil && strings.TrimSpace(bindPort) != "" {
+			cfg.publicURL = "http://127.0.0.1:" + bindPort
+		} else {
+			cfg.publicURL = "http://127.0.0.1:" + cfg.port
+		}
 	}
 	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
 		cfg.oauthScopes = appCfg.Gateway.OAuthScopes

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,10 +69,10 @@ func main() {
 	envSecret := os.Getenv("GITHUB_MCP_CLIENT_SECRET")
 
 	// Deprecation warning: MCP_GATEWAY_BASE_URL is superseded by MCP_GATEWAY_PUBLIC_URL.
-	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) != "" &&
-		strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" {
+	// Warn whenever BASE_URL is set, regardless of whether PUBLIC_URL is also present.
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) != "" {
 		slog.Warn("MCP_GATEWAY_BASE_URL is deprecated; use MCP_GATEWAY_PUBLIC_URL instead",
-			"hint", "MCP_GATEWAY_PUBLIC_URL will be removed in a future release")
+			"hint", "MCP_GATEWAY_BASE_URL will be removed in a future release")
 	}
 
 	// Apply config.yaml gateway overrides (priority: env var > config.yaml > loadConfig default).
@@ -96,6 +96,15 @@ func main() {
 		} else {
 			cfg.bindAddr = "127.0.0.1:" + cfg.port
 		}
+	}
+	// If publicURL was not explicitly set (no env, no yaml), recompute the default using the
+	// resolved port so that a yaml-only port override is reflected in OAuth redirects and
+	// discovery metadata.
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_PUBLIC_URL")) == "" &&
+		strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" &&
+		strings.TrimSpace(appCfg.Gateway.PublicURL) == "" &&
+		strings.TrimSpace(appCfg.Gateway.BaseURL) == "" {
+		cfg.publicURL = "http://127.0.0.1:" + cfg.port
 	}
 	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
 		cfg.oauthScopes = appCfg.Gateway.OAuthScopes

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -13,7 +13,9 @@ mcp-gateway v0.3.0 separates the **listen address** from the **public URL**:
 | Bind address | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | Network interface/port the HTTP server listens on |
 | Public URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | Canonical URL used in OAuth callbacks, discovery metadata, and PRM |
 
-Before v0.3.0 a single `MCP_GATEWAY_BASE_URL` / `gateway.base_url` setting filled both roles.
+Before v0.3.0, `MCP_GATEWAY_BASE_URL` / `gateway.base_url` controlled only the **public URL**
+(OAuth callbacks and discovery metadata). The server always listened on all interfaces
+(`:<port>`) regardless of this setting.
 That setting is now **deprecated** and will be removed in a future release.
 
 ### Why the split matters
@@ -23,9 +25,9 @@ reach it via port-forwarding, but the OAuth callback URL registered with GitHub 
 address that the **user's browser** can reach—typically `http://127.0.0.1:8080` on the
 developer's machine.
 
-Before v0.3.0 there was no clean way to express this difference: setting `BASE_URL` to
-`0.0.0.0` broke OAuth; setting it to `127.0.0.1` worked for OAuth but didn't help when
-the gateway needed to bind on all interfaces.
+Before v0.3.0 there was no clean way to express this difference: the server always
+listened on all interfaces (`:<port>`), but `BASE_URL` only influenced the public URL
+advertised to OAuth clients—there was no way to configure the bind address independently.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,7 +36,7 @@ the gateway needed to bind on all interfaces.
 | Old | New |
 |-----|-----|
 | `MCP_GATEWAY_BASE_URL=http://localhost:8080` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080` |
-| *(implicit: listen on `localhost:8080`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080` (local) or `0.0.0.0:8080` (Docker) |
+| *(implicit: bind on all interfaces `:8080`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080` (local) or `0.0.0.0:8080` (Docker) |
 
 ### 2. Update config.yaml (if used)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,132 @@
+# Operations Guide
+
+This guide covers deployment, migration, and operational considerations for mcp-gateway.
+
+---
+
+## bind_addr vs public_url
+
+mcp-gateway v0.3.0 separates the **listen address** from the **public URL**:
+
+| Config | Env var | YAML key | Default | Purpose |
+|--------|---------|----------|---------|---------|
+| Bind address | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | Network interface/port the HTTP server listens on |
+| Public URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | Canonical URL used in OAuth callbacks, discovery metadata, and PRM |
+
+Before v0.3.0 a single `MCP_GATEWAY_BASE_URL` / `gateway.base_url` setting filled both roles.
+That setting is now **deprecated** and will be removed in a future release.
+
+### Why the split matters
+
+In Docker deployments the gateway binds to `0.0.0.0:8080` (all interfaces) so the host can
+reach it via port-forwarding, but the OAuth callback URL registered with GitHub must be an
+address that the **user's browser** can reach—typically `http://127.0.0.1:8080` on the
+developer's machine.
+
+Before v0.3.0 there was no clean way to express this difference: setting `BASE_URL` to
+`0.0.0.0` broke OAuth; setting it to `127.0.0.1` worked for OAuth but didn't help when
+the gateway needed to bind on all interfaces.
+
+---
+
+## Migrating from MCP_GATEWAY_BASE_URL
+
+### 1. Update your environment variables
+
+| Old | New |
+|-----|-----|
+| `MCP_GATEWAY_BASE_URL=http://localhost:8080` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080` |
+| *(implicit: listen on `localhost:8080`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080` (local) or `0.0.0.0:8080` (Docker) |
+
+### 2. Update config.yaml (if used)
+
+```yaml
+# Before
+gateway:
+  base_url: "http://localhost:8080"
+
+# After
+gateway:
+  public_url: "http://127.0.0.1:8080"
+  bind_addr: "127.0.0.1:8080"   # omit for Docker; set to 0.0.0.0:8080 there
+```
+
+### 3. Update the GitHub OAuth App callback URL
+
+Go to **GitHub → Settings → Developer settings → OAuth Apps → [your app] → Edit**:
+
+| Field | Old value | New value |
+|-------|-----------|-----------|
+| Authorization callback URL | `http://localhost:8080/callback` | `http://127.0.0.1:8080/callback` |
+
+> **Note:** `localhost` and `127.0.0.1` are treated the same by most browsers, but GitHub
+> OAuth validates the exact callback URL, so the registered URL must match what the gateway
+> sends in the OAuth redirect.
+
+### 4. Cutover procedure
+
+1. Merge or deploy the updated gateway binary / image.
+2. Update the GitHub OAuth App callback URL (step 3 above).
+3. Update your `docker-compose.yml` or systemd unit / `.env` file (steps 1–2 above).
+4. Restart the gateway.
+5. Existing tokens remain valid—clients do **not** need to re-authenticate unless the
+   token store was cleared.
+
+---
+
+## Docker deployment
+
+The gateway default bind address is `127.0.0.1:8080` (loopback only).
+Docker port-forwarding requires binding on all interfaces:
+
+```yaml
+services:
+  mcp-gateway:
+    image: ghcr.io/scottlz0310/mcp-gateway:latest
+    ports:
+      - "8080:8080"
+    environment:
+      GITHUB_MCP_CLIENT_ID: <your-client-id>
+      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      # Bind on all interfaces so Docker port-forwarding works
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      # Public URL is what the user's browser (and GitHub OAuth) will call
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+    depends_on:
+      - github-mcp
+```
+
+If you are deploying behind a reverse proxy (nginx, Caddy, etc.) and exposing the gateway
+on a public domain, set `MCP_GATEWAY_PUBLIC_URL` to the full public URL, e.g.:
+
+```
+MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
+MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
+```
+
+---
+
+## Non-Docker / bare binary
+
+When running the binary directly (not in Docker) the `/data` directory may not exist.
+Override the storage paths to writable locations:
+
+```bash
+export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
+export MCP_CONFIG_FILE=./config.yaml
+export MCP_GATEWAY_KEY_PATH=./gateway.key
+```
+
+Or disable token persistence entirely (not recommended for production):
+
+```bash
+export MCP_GATEWAY_TOKEN_STORE_PATH=
+```
+
+---
+
+## Token store persistence
+
+See [README.md — Authentication state persistence](../README.md#authentication-state-persistence)
+for full details on the token store, refresh token store, and how to reset auth state.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -37,20 +37,22 @@ advertised to OAuth clients—there was no way to configure the bind address ind
 
 | Old | New |
 |-----|-----|
-| `MCP_GATEWAY_BASE_URL=http://localhost:8080` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080` |
-| *(implicit: bind on all interfaces `:8080`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080` (local) or `0.0.0.0:8080` (Docker) |
+| `MCP_GATEWAY_BASE_URL=http://localhost:<port>` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:<port>` |
+| *(implicit: bind on all interfaces `:<port>`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:<port>` (local) or `0.0.0.0:<port>` (Docker) |
+
+> Replace `<port>` with the port your gateway uses (default: `8080`).
 
 ### 2. Update config.yaml (if used)
 
 ```yaml
 # Before
 gateway:
-  base_url: "http://localhost:8080"
+  base_url: "http://localhost:<port>"   # replace <port> with your actual port
 
 # After
 gateway:
-  public_url: "http://127.0.0.1:8080"
-  bind_addr: "127.0.0.1:8080"   # omit for Docker; set to 0.0.0.0:8080 there
+  public_url: "http://127.0.0.1:<port>"
+  bind_addr: "127.0.0.1:<port>"   # omit for Docker; set to 0.0.0.0:<port> there
 ```
 
 ### 3. Update the GitHub OAuth App callback URL
@@ -59,7 +61,7 @@ Go to **GitHub → Settings → Developer settings → OAuth Apps → [your app]
 
 | Field | Old value | New value |
 |-------|-----------|-----------|
-| Authorization callback URL | `http://localhost:8080/callback` | `http://127.0.0.1:8080/callback` |
+| Authorization callback URL | `http://localhost:<port>/callback` | `http://127.0.0.1:<port>/callback` |
 
 > **Note:** `localhost` and `127.0.0.1` are treated the same by most browsers, but GitHub
 > OAuth validates the exact callback URL, so the registered URL must match what the gateway

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,8 +39,17 @@ type AuthConfig struct {
 
 // GatewayConfig holds gateway-level settings that can be persisted in config.yaml.
 type GatewayConfig struct {
-	BaseURL     string `yaml:"base_url,omitempty"`
-	Port        string `yaml:"port,omitempty"`
+	// BindAddr is the TCP address the HTTP listener binds to (e.g. "127.0.0.1:8080").
+	// When empty, the runtime derives it from PublicURL or Port.
+	BindAddr string `yaml:"bind_addr,omitempty"`
+	// PublicURL is the canonical base URL visible to OAuth clients and MCP clients
+	// (e.g. "http://127.0.0.1:8080"). Used for redirect URIs, PRM, and discovery.
+	PublicURL string `yaml:"public_url,omitempty"`
+	// BaseURL is a deprecated alias for PublicURL. Use PublicURL for new deployments.
+	// If set (and PublicURL is absent), BaseURL is copied to PublicURL with a warning.
+	BaseURL string `yaml:"base_url,omitempty"`
+	Port    string `yaml:"port,omitempty"`
+	// OAuthScopes is the GitHub OAuth scope list forwarded to the provider.
 	OAuthScopes string `yaml:"oauth_scopes,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ type AuthConfig struct {
 // GatewayConfig holds gateway-level settings that can be persisted in config.yaml.
 type GatewayConfig struct {
 	// BindAddr is the TCP address the HTTP listener binds to (e.g. "127.0.0.1:8080").
-	// When empty, the runtime derives it from PublicURL or Port.
+	// When empty, the runtime defaults to 127.0.0.1 with the resolved port.
 	BindAddr string `yaml:"bind_addr,omitempty"`
 	// PublicURL is the canonical base URL visible to OAuth clients and MCP clients
 	// (e.g. "http://127.0.0.1:8080"). Used for redirect URIs, PRM, and discovery.


### PR DESCRIPTION
Closes #48

## Summary

Separates the HTTP listener bind address from the OAuth/discovery public URL, changes defaults from \localhost\ to \127.0.0.1\, and deprecates \MCP_GATEWAY_BASE_URL\.

## Changes

### New config
| Env var | YAML key | Default | Purpose |
|---------|----------|---------|---------|
| \MCP_GATEWAY_PUBLIC_URL\ | \gateway.public_url\ | \http://127.0.0.1:8080\ | Canonical URL for OAuth callbacks, discovery metadata, PRM |
| \MCP_GATEWAY_BIND_ADDR\ | \gateway.bind_addr\ | \127.0.0.1:8080\ | HTTP server listen address |

### Deprecated
- \MCP_GATEWAY_BASE_URL\ / \gateway.base_url\ → replaced by \MCP_GATEWAY_PUBLIC_URL\. Startup warning emitted when detected.

### Breaking change for Docker users
Default \ind_addr\ is now \127.0.0.1:8080\ (loopback only). Docker users **must** add:
\\\yaml
MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
\\\

### Files changed
- \internal/config/config.go\ — added \BindAddr\, \PublicURL\ fields
- \cmd/server/main.go\ — resolution logic, deprecation warnings, bind addr change
- \README.md\ / \README.ja.md\ — env vars table, Docker Compose examples, MCP client JSON
- \docs/operations.md\ — new migration guide
- \CHANGELOG.md\ — v0.3.0 entry