### PR TITLE
fix(examples): add MCP_GATEWAY_BIND_ADDR and migrate to PUBLIC_URL

### DIFF
--- a/examples/copilot-review-routing/.env.example
+++ b/examples/copilot-review-routing/.env.example
@@ -19,8 +19,16 @@ GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # copilot-review-mcp runs behind mcp-gateway by default and trusts
 # X-Authenticated-User. Set COPILOT_REVIEW_AUTH_MODE=standalone only when
-# testing direct copilot-review-mcp OAuth validation.
+# testing direct copilot-review-mcp OAuth validation (requires its own OAuth
+# App credentials: GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET below).
 COPILOT_REVIEW_AUTH_MODE=gateway
+
+# ---- copilot-review-mcp standalone mode credentials (optional) ----
+# Required only when COPILOT_REVIEW_AUTH_MODE=standalone. In gateway mode,
+# copilot-review-mcp reuses mcp-gateway's OAuth token; these are not needed.
+# Can point to the same GitHub OAuth App as GITHUB_MCP_CLIENT_ID/SECRET.
+# GITHUB_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+# GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ---- mcp-gateway ----
 # Public URL: what the user's browser and GitHub OAuth see (must match GitHub OAuth App callback URL).

--- a/examples/copilot-review-routing/.env.example
+++ b/examples/copilot-review-routing/.env.example
@@ -10,8 +10,8 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ---- GitHub OAuth App credentials ----
 # Create at: https://github.com/settings/applications/new
-#   Homepage URL:              http://localhost:8080
-#   Authorization callback URL: http://localhost:8080/callback
+#   Homepage URL:              http://127.0.0.1:8080
+#   Authorization callback URL: http://127.0.0.1:8080/callback
 #
 # mcp-gateway uses GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET.
 GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
@@ -21,11 +21,12 @@ GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # X-Authenticated-User. Set COPILOT_REVIEW_AUTH_MODE=standalone only when
 # testing direct copilot-review-mcp OAuth validation.
 COPILOT_REVIEW_AUTH_MODE=gateway
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
 
 # ---- mcp-gateway ----
-MCP_GATEWAY_BASE_URL=http://localhost:8080
+# Public URL: what the user's browser and GitHub OAuth see (must match GitHub OAuth App callback URL).
+MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080
+# Bind address: 0.0.0.0 is required for Docker port-forwarding.
+MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080
 # MCP_GATEWAY_PORT=8080
 # MCP_GATEWAY_KEY_PATH=/data/gateway.key
 # MCP_CONFIG_FILE=/data/config.yaml

--- a/examples/copilot-review-routing/README.md
+++ b/examples/copilot-review-routing/README.md
@@ -6,8 +6,8 @@ This example shows how to route both `github-mcp-server` and `copilot-review-mcp
 
 ```
 MCP Client
-    │  url: http://localhost:8080/mcp/github          (github-mcp-server)
-    │  url: http://localhost:8080/mcp/copilot-review  (copilot-review-mcp)
+    │  url: http://127.0.0.1:8080/mcp/github          (github-mcp-server)
+    │  url: http://127.0.0.1:8080/mcp/copilot-review  (copilot-review-mcp)
     ▼
 mcp-gateway :8080  ← single OAuth façade + routing
     ├── /mcp/github          → http://github-mcp:8082          (Docker-internal)
@@ -22,8 +22,8 @@ changes** to copilot-review-mcp.
 
 - Docker & Docker Compose v2
 - A GitHub OAuth App (create at https://github.com/settings/applications/new)
-  - **Homepage URL**: `http://localhost:8080`
-  - **Authorization callback URL**: `http://localhost:8080/callback`
+  - **Homepage URL**: `http://127.0.0.1:8080`
+  - **Authorization callback URL**: `http://127.0.0.1:8080/callback`
 - A GitHub Personal Access Token (for `github-mcp-server`)
 
 ## Quick Start
@@ -48,11 +48,11 @@ Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 {
   "mcpServers": {
     "github": {
-      "url": "http://localhost:8080/mcp/github",
+      "url": "http://127.0.0.1:8080/mcp/github",
       "transport": "http"
     },
     "copilot-review": {
-      "url": "http://localhost:8080/mcp/copilot-review",
+      "url": "http://127.0.0.1:8080/mcp/copilot-review",
       "transport": "http"
     }
   }
@@ -61,21 +61,13 @@ Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 
 ## Notes
 
-### Token double-validation
+### Gateway mode (AUTH_MODE=gateway)
 
-Currently, `mcp-gateway` **and** `copilot-review-mcp` each validate the Bearer token
-against the GitHub API independently. Both services have an in-memory cache, so repeated
-requests hit the cache after the first validation.
+`copilot-review-mcp` runs in `AUTH_MODE=gateway` by default. In this mode it trusts the
+`X-Authenticated-User` header injected by mcp-gateway and skips its own GitHub API call,
+so there is only one token validation per request (in mcp-gateway).
 
-A future `AUTH_MODE=gateway` option for `copilot-review-mcp`
-([copilot-review-mcp#12](https://github.com/scottlz0310/copilot-review-mcp/issues/12))
-will trust the `X-Authenticated-User` header from mcp-gateway and skip the second
-GitHub API call.
-
-### Backward compatibility
-
-Direct access to `copilot-review-mcp` (`http://localhost:8083`) continues to work — simply
-uncomment the `ports` section in `docker-compose.yml`. No code changes required.
+Standalone mode (direct access without mcp-gateway) is no longer supported.
 
 ### Shared OAuth App credentials
 

--- a/examples/copilot-review-routing/README.md
+++ b/examples/copilot-review-routing/README.md
@@ -67,10 +67,13 @@ Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 `X-Authenticated-User` header injected by mcp-gateway and skips its own GitHub API call,
 so there is only one token validation per request (in mcp-gateway).
 
-Standalone mode (direct access without mcp-gateway) is no longer supported.
+To run `copilot-review-mcp` in standalone mode (direct access without mcp-gateway), set
+`COPILOT_REVIEW_AUTH_MODE=standalone` in `.env`. Standalone mode requires its own OAuth App
+credentials (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` for copilot-review-mcp) in addition
+to the mcp-gateway credentials. See `.env.example` for details.
 
 ### Shared OAuth App credentials
 
 `GITHUB_MCP_CLIENT_ID`/`GITHUB_MCP_CLIENT_SECRET` (mcp-gateway) and
-`GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` (copilot-review-mcp) can point to the **same**
-GitHub OAuth App.
+`GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` (copilot-review-mcp, standalone mode only)
+can point to the **same** GitHub OAuth App.

--- a/examples/copilot-review-routing/docker-compose.yml
+++ b/examples/copilot-review-routing/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       GITHUB_MCP_CLIENT_ID: ${GITHUB_MCP_CLIENT_ID}
       GITHUB_MCP_CLIENT_SECRET: ${GITHUB_MCP_CLIENT_SECRET}
       # Bind on all interfaces so Docker port-forwarding works (container → host).
+      # Port in MCP_GATEWAY_BIND_ADDR must match MCP_GATEWAY_PORT (both default to 8080).
       MCP_GATEWAY_BIND_ADDR: ${MCP_GATEWAY_BIND_ADDR:-0.0.0.0:8080}
       # Public URL is what the user's browser (and GitHub OAuth) calls.
       MCP_GATEWAY_PUBLIC_URL: ${MCP_GATEWAY_PUBLIC_URL:-http://127.0.0.1:8080}

--- a/examples/copilot-review-routing/docker-compose.yml
+++ b/examples/copilot-review-routing/docker-compose.yml
@@ -5,8 +5,8 @@
 #
 # MCP client endpoints (single OAuth façade via the gateway; backend services still
 # require their own credentials/configuration in this Compose setup):
-#   github-mcp:      http://localhost:8080/mcp/github
-#   copilot-review:  http://localhost:8080/mcp/copilot-review
+#   github-mcp:      http://127.0.0.1:8080/mcp/github
+#   copilot-review:  http://127.0.0.1:8080/mcp/copilot-review
 
 services:
   mcp-gateway:
@@ -18,7 +18,10 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: ${GITHUB_MCP_CLIENT_ID}
       GITHUB_MCP_CLIENT_SECRET: ${GITHUB_MCP_CLIENT_SECRET}
-      MCP_GATEWAY_BASE_URL: ${MCP_GATEWAY_BASE_URL:-http://localhost:8080}
+      # Bind on all interfaces so Docker port-forwarding works (container → host).
+      MCP_GATEWAY_BIND_ADDR: ${MCP_GATEWAY_BIND_ADDR:-0.0.0.0:8080}
+      # Public URL is what the user's browser (and GitHub OAuth) calls.
+      MCP_GATEWAY_PUBLIC_URL: ${MCP_GATEWAY_PUBLIC_URL:-http://127.0.0.1:8080}
       MCP_GATEWAY_PORT: ${MCP_GATEWAY_PORT:-8080}
       MCP_GATEWAY_KEY_PATH: ${MCP_GATEWAY_KEY_PATH:-/data/gateway.key}
       MCP_CONFIG_FILE: ${MCP_CONFIG_FILE:-/data/config.yaml}
@@ -87,9 +90,6 @@ services:
       # gateway mode trusts X-Authenticated-User injected by mcp-gateway and
       # avoids a second GitHub token validation in copilot-review-mcp.
       AUTH_MODE: ${COPILOT_REVIEW_AUTH_MODE:-gateway}
-      # Required only when COPILOT_REVIEW_AUTH_MODE=standalone.
-      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
-      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
       BASE_URL: ${COPILOT_REVIEW_BASE_URL:-http://localhost:8083}
       MCP_PORT: ${COPILOT_REVIEW_MCP_PORT:-8083}
       GITHUB_OAUTH_SCOPES: ${GITHUB_MCP_OAUTH_SCOPES:-repo,user}


### PR DESCRIPTION
## 問題

#48（bind_addr / public_url 分離）と copilot-review-mcp #17（gateway 必須化）完了後にコンテナを入れ替えたところ、再認証できなくなった。

### 根本原因

\xamples/copilot-review-routing/docker-compose.yml\ に \MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080\ が設定されていなかった。

v0.3.0 でデフォルトの bind address が \:<port>\（全インターフェース）から \127.0.0.1:<port>\（ループバックのみ）に変更されたため、Docker port-forwarding がコンテナのループバックに到達できず、すべての認証リクエストが失敗する。

## 修正内容

### \docker-compose.yml\
- \MCP_GATEWAY_BIND_ADDR: \\ を追加（Docker 必須）
- 非推奨の \MCP_GATEWAY_BASE_URL\ を \MCP_GATEWAY_PUBLIC_URL\ に置き換え
- copilot-review-mcp の \GITHUB_CLIENT_ID/SECRET\（standalone モード削除済み）を除去

### \.env.example\
- \MCP_GATEWAY_BASE_URL\ → \MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080\
- \MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080\ を追加
- GitHub OAuth App コールバック URL を \localhost\ → \127.0.0.1\ に更新
- \GITHUB_CLIENT_ID/SECRET\（copilot-review-mcp standalone 削除済み）を除去

### \README.md\
- OAuth App コールバック URL・MCP クライアント URL を \127.0.0.1\ に更新
- トークン二重検証の注記を gateway モードの説明に置き換え

## コンテナ入れ替え後の対処手順（既存ユーザー向け）

1. \.env\ を更新:\MCP_GATEWAY_BASE_URL\ → \MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:8080\、\MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080\ を追加
2. GitHub OAuth App の Authorization callback URL を \http://127.0.0.1:8080/callback\ に更新（Settings → Developer settings → OAuth Apps → Edit）
3. \docker compose up -d\ で再起動
4. \curl http://localhost:8080/health\ でヘルスチェック

既存トークンはそのまま有効です（token store を消していなければ再認証不要）。

Closes #50