### PR TITLE
feat(auth): trusted reverse proxy headers (#49 PR-B)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- 信頼済みリバースプロキシヘッダ対応（[#56](https://github.com/scottlz0310/mcp-gateway/issues/56), #49 PR-B）
+  - `MCP_GATEWAY_TRUSTED_PROXIES` / `gateway.trusted_proxies` による CIDR allowlist を追加
+  - 信頼済み送信元からの `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-For` のみを後段 request に反映
+  - 未信頼送信元からの forwarded headers は削除し、spoofing を防止
+  - 不正な CIDR は起動時エラーとして扱う
+
 ## [0.2.0] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ and versioning follows [Semantic Versioning](https://semver.org/).
   - Root-prefix routes (`/`) intentionally skip per-route PRM registration and continue to use the gateway-wide `/.well-known/oauth-protected-resource`, since `resource == public_url` is identical and a per-route trailing-slash pattern would shadow other PRM URLs in `http.ServeMux`
   - The gateway-wide `GET /.well-known/oauth-protected-resource` is preserved for backward compatibility
   - `auth.Handler.RouteProtectedResourceMetadata(resource string) http.HandlerFunc` and `middleware.WithResourceMetadataURL(url string)` added
-  - **Note**: #49 spans three PRs and is intentionally not closed by PR-A alone. PR-B ([#56](https://github.com/scottlz0310/mcp-gateway/issues/56), reverse-proxy / `trusted_proxies` / `X-Forwarded-*`) and PR-C ([#57](https://github.com/scottlz0310/mcp-gateway/issues/57), token `aud` claim and grace period) follow in subsequent releases. #49 will be closed once all three PRs are merged.
+- Trusted reverse proxy header support — partial delivery of [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) (PR-B of 3, [#56](https://github.com/scottlz0310/mcp-gateway/issues/56))
+  - `MCP_GATEWAY_TRUSTED_PROXIES` / `gateway.trusted_proxies` accepts a CIDR allowlist for immediate reverse proxy peers
+  - `internal/middleware.ProxyHeaders` applies `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-For` only for trusted peers, and strips forwarded headers from untrusted requests
+  - Access logs and setup-mode HTTPS checks now see the trusted forwarded client IP / scheme when the middleware is enabled
+  - Invalid trusted proxy CIDRs fail startup instead of being ignored
+  - **Note**: #49 spans three PRs and is intentionally not closed by PR-A or PR-B alone. PR-C ([#57](https://github.com/scottlz0310/mcp-gateway/issues/57), token `aud` claim and grace period) follows in a subsequent release. #49 will be closed once all three PRs are merged.
 
 ### Changed
 
@@ -44,6 +49,12 @@ binds on all interfaces and Docker port-forwarding continues to work. See
 - Strict spec-2025-06-18 clients that fetch per-route PRM (`/.well-known/oauth-protected-resource{prefix}`) now receive a route-scoped `resource` value (`<public_url>{prefix}`) and should re-acquire tokens scoped to that resource if they previously cached gateway-wide tokens.
 - 401 responses on authenticated, non-root routes now advertise the route-scoped PRM in `WWW-Authenticate.resource_metadata`. Clients that follow this header to discover the AS endpoint will end up with route-scoped tokens automatically; no client-side configuration change is required.
 - No token invalidation is performed by this release. Audience checking will land in PR-C ([#57](https://github.com/scottlz0310/mcp-gateway/issues/57)) with a grace period for previously-issued tokens; review that PR's release notes when it ships.
+
+**Reverse proxy deployments (#49 PR-B)**
+
+- If TLS terminates before mcp-gateway, keep `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` set to the external origin clients use.
+- Add `MCP_GATEWAY_TRUSTED_PROXIES` or `gateway.trusted_proxies` with valid CIDR values for the immediate proxy peers (for example `127.0.0.1/32,10.0.0.0/8`).
+- Direct client-supplied `X-Forwarded-*` headers are ignored unless the immediate peer is trusted.
 
 ## [0.2.0] - 2026-05-05
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -258,6 +258,10 @@ MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 `X-Forwarded-For` を後段の request に反映できます。未信頼の送信元から届いた forwarded
 headers は削除されます。不正な CIDR は起動時エラーになります。
 
+信頼済みプロキシは、クライアント由来の `X-Forwarded-For` をそのまま渡さず、上書きまたは
+サニタイズしてください。gateway は XFF を右側から読みますが、このヘッダの所有者は
+プロキシに限定する前提です。
+
 ### 認証状態の永続化
 
 > **Docker デフォルト:** デフォルトのストアパス `/data/tokens.json` は Docker 運用向けです。Docker イメージは `/data` を適切なパーミッションで事前作成しています。Docker 以外（`go run` やバイナリ直接実行）では `/data` が存在しないため起動に失敗します。その場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を書き込み可能なパス（例: `./tokens.json`）に設定するか、永続化を無効にするため空文字を設定してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -171,6 +171,8 @@ gateway:
   public_url: "http://127.0.0.1:8080"
   port: "8080"
   oauth_scopes: "repo,user"
+  trusted_proxies:
+    - "127.0.0.1/32"
 ```
 
 `gateway:` 配下はすべてオプションで、対応する環境変数またはデフォルト値にフォールバックします。
@@ -229,6 +231,7 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 | `MCP_GATEWAY_MASTER_KEY` | — | 決定論的キー導出に使用するマスターキー（≥32 バイト; [シークレット暗号化](#シークレット暗号化) 参照） |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | OAuth コールバック・discovery メタデータ・PRM に使用する外部公開 URL（`MCP_GATEWAY_BASE_URL` の後継） |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker デプロイでは `0.0.0.0:<port>` に変更する。同一ホスト上のリバースプロキシ経由の場合はデフォルト `127.0.0.1:<port>` のままで良い |
+| `MCP_GATEWAY_TRUSTED_PROXIES` | — | `X-Forwarded-*` を信頼するリバースプロキシの CIDR リスト（カンマ区切り。例: `127.0.0.1/32,10.0.0.0/8`） |
 | `MCP_GATEWAY_BASE_URL` | — | **非推奨** — `MCP_GATEWAY_PUBLIC_URL` のエイリアス。将来のリリースで削除予定 |
 | `MCP_GATEWAY_PORT` | `8080` | `bind_addr` と `public_url` のデフォルト値を導出する際のポート番号。実際の待受アドレスは `MCP_GATEWAY_BIND_ADDR` で制御する |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
@@ -238,6 +241,22 @@ ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
 | `TOKEN_CACHE_TTL_MIN` | `30` | トークン検証キャッシュ TTL（分）— `MCP_GATEWAY_TOKEN_STORE_PATH` を空文字に明示設定した場合のみ使用 |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日）。永続ストアのエントリ TTL にも使用 |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
+
+### リバースプロキシヘッダ
+
+nginx / Caddy / fly.io edge proxy などで TLS を gateway の手前で終端する場合は、
+`MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` をクライアントから見える外部 URL に設定し、
+信頼するプロキシの CIDR を指定します。
+
+```bash
+MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
+MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
+MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
+```
+
+信頼済みプロキシからのリクエストだけが `X-Forwarded-Proto` / `X-Forwarded-Host` /
+`X-Forwarded-For` を後段の request に反映できます。未信頼の送信元から届いた forwarded
+headers は削除されます。不正な CIDR は起動時エラーになります。
 
 ### 認証状態の永続化
 

--- a/README.md
+++ b/README.md
@@ -265,11 +265,16 @@ request seen by downstream handlers:
 |--------|--------|
 | `X-Forwarded-Proto` | Sets the request scheme when the value is `http` or `https` |
 | `X-Forwarded-Host` | Sets `r.Host` after basic host validation |
-| `X-Forwarded-For` | Sets `r.RemoteAddr` to the rightmost valid IP appended by the trusted proxy |
+| `X-Forwarded-For` | Sets `r.RemoteAddr` to the rightmost valid IP supplied by the trusted proxy |
 
 If the peer is not trusted, incoming forwarded headers are stripped before later
 middleware and handlers run. `trusted_proxies` entries must be valid CIDR strings;
 invalid values cause startup to fail.
+
+Configure your reverse proxy to overwrite or sanitize `X-Forwarded-For` instead of
+passing client-provided values through unchanged. The gateway reads the header from the
+right as a defense against appended spoofed entries, but the proxy should still own this
+header.
 
 ### Persistent Auth State
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ gateway:
   public_url: "http://127.0.0.1:8080"
   port: "8080"
   oauth_scopes: "repo,user"
+  trusted_proxies:
+    - "127.0.0.1/32"
 ```
 
 All `gateway:` fields are optional — values fall back to the corresponding env vars and then to the built-in defaults.
@@ -222,6 +224,7 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 | `MCP_GATEWAY_MASTER_KEY` | — | Master key for deterministic key derivation (≥32 bytes; see [Secret Encryption](#secret-encryption)) |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | Canonical base URL for OAuth callback, discovery metadata, and PRM (replaces `MCP_GATEWAY_BASE_URL`) |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker deployments. For reverse-proxy on the same host, keep the default `127.0.0.1:<port>` |
+| `MCP_GATEWAY_TRUSTED_PROXIES` | — | Comma-separated CIDR allowlist for reverse proxies whose `X-Forwarded-*` headers are trusted (e.g. `127.0.0.1/32,10.0.0.0/8`) |
 | `MCP_GATEWAY_BASE_URL` | — | **Deprecated** — alias for `MCP_GATEWAY_PUBLIC_URL`; will be removed in a future release |
 | `MCP_GATEWAY_PORT` | `8080` | Default port used when deriving `bind_addr` and `public_url`. The actual listen address is controlled by `MCP_GATEWAY_BIND_ADDR` |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
@@ -231,6 +234,42 @@ ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
 | `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL in minutes — used only when `MCP_GATEWAY_TOKEN_STORE_PATH` is explicitly set to empty |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days). Also used as the TTL for persistent token entries |
 | `GITHUB_MCP_UPSTREAM_URL` | — | **Deprecated** — single upstream fallback when no `ROUTE_*` is set |
+
+### Reverse Proxy Headers
+
+When TLS terminates in front of mcp-gateway (nginx, Caddy, fly.io edge proxy, etc.),
+set `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` to the externally visible
+URL and configure trusted proxy CIDRs:
+
+```bash
+MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
+MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
+MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
+```
+
+Equivalent `config.yaml`:
+
+```yaml
+gateway:
+  public_url: "https://mcp.example.com"
+  bind_addr: "127.0.0.1:8080"
+  trusted_proxies:
+    - "127.0.0.1/32"
+    - "10.0.0.0/8"
+```
+
+Only requests whose immediate peer IP matches `trusted_proxies` may influence the
+request seen by downstream handlers:
+
+| Header | Effect |
+|--------|--------|
+| `X-Forwarded-Proto` | Sets the request scheme when the value is `http` or `https` |
+| `X-Forwarded-Host` | Sets `r.Host` after basic host validation |
+| `X-Forwarded-For` | Sets `r.RemoteAddr` to the leftmost client IP |
+
+If the peer is not trusted, incoming forwarded headers are stripped before later
+middleware and handlers run. `trusted_proxies` entries must be valid CIDR strings;
+invalid values cause startup to fail.
 
 ### Persistent Auth State
 
@@ -300,14 +339,15 @@ type Identity struct {
 }
 ```
 
-The proxy forwards two headers to upstream MCP servers:
+The proxy forwards two identity headers to upstream MCP servers:
 
 | Header | Value |
 |--------|-------|
 | `X-Authenticated-User` | `Identity.Subject` (canonical, provider-agnostic) |
 | `X-GitHub-Login` | same as `X-Authenticated-User` (legacy compatibility; both set from `Identity.Subject`) |
 
-Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`) are stripped before proxying.
+Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`, `Forwarded`,
+`X-Forwarded-*`, `X-Real-IP`) are stripped before proxying.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ request seen by downstream handlers:
 |--------|--------|
 | `X-Forwarded-Proto` | Sets the request scheme when the value is `http` or `https` |
 | `X-Forwarded-Host` | Sets `r.Host` after basic host validation |
-| `X-Forwarded-For` | Sets `r.RemoteAddr` to the leftmost client IP |
+| `X-Forwarded-For` | Sets `r.RemoteAddr` to the rightmost valid IP appended by the trusted proxy |
 
 If the peer is not trusted, incoming forwarded headers are stripped before later
 middleware and handlers run. `trusted_proxies` entries must be valid CIDR strings;

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"strconv"
@@ -117,9 +118,17 @@ func main() {
 	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
 		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
 	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")) == "" && len(appCfg.Gateway.TrustedProxies) > 0 {
+		cfg.trustedProxyCIDRs = appCfg.Gateway.TrustedProxies
+	}
+	trustedProxies, err := middleware.ParseTrustedProxyCIDRs(cfg.trustedProxyCIDRs)
+	if err != nil {
+		slog.Error("invalid trusted proxy configuration", "err", err)
+		os.Exit(1)
+	}
 
 	if setup.IsSetupRequired(appCfg, envClientID, envSecret, envRoutes) {
-		runSetupWizard(cfg, appCfg, km, envClientID, envSecret, len(envRoutes) > 0)
+		runSetupWizard(cfg, appCfg, km, envClientID, envSecret, len(envRoutes) > 0, trustedProxies)
 		// runSetupWizard only returns if the listener fails immediately.
 		os.Exit(1)
 	}
@@ -250,11 +259,12 @@ func main() {
 		"public_url", cfg.publicURL,
 		"provider", prov.Name(),
 		"routes", len(routes),
+		"trusted_proxies", len(trustedProxies),
 	)
 
 	server := &http.Server{
 		Addr:              cfg.bindAddr,
-		Handler:           middleware.Logger()(mux),
+		Handler:           serverMiddleware(mux, trustedProxies),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      0, // unlimited: MCP streaming responses may be long-lived
@@ -269,7 +279,7 @@ func main() {
 // runSetupWizard starts an HTTP server that serves only the /setup endpoint.
 // It blocks until a successful POST /setup causes the process to exit (so the
 // supervisor can restart in normal mode), or until the listener fails.
-func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMaterial, envClientID, envSecret string, hasEnvRoutes bool) {
+func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMaterial, envClientID, envSecret string, hasEnvRoutes bool, trustedProxies []netip.Prefix) {
 	mgr, err := setup.New()
 	if err != nil {
 		slog.Error("failed to create setup token", "err", err)
@@ -295,7 +305,7 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 
 	server := &http.Server{
 		Addr:              cfg.bindAddr,
-		Handler:           middleware.Logger()(mux),
+		Handler:           serverMiddleware(mux, trustedProxies),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
@@ -307,24 +317,29 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 	}
 }
 
+func serverMiddleware(h http.Handler, trustedProxies []netip.Prefix) http.Handler {
+	return middleware.ProxyHeaders(trustedProxies)(middleware.Logger()(h))
+}
+
 type config struct {
 	githubClientID     string
 	githubClientSecret string
 	// publicURL is the canonical base URL visible to OAuth / MCP clients.
 	// Replaces the deprecated baseURL / MCP_GATEWAY_BASE_URL.
-	publicURL          string
+	publicURL string
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
-	bindAddr           string
-	oauthScopes        string
-	port               string
-	logLevel           string
-	upstreamURL        string // deprecated; prefer ROUTE_* env vars
-	sessionTTLMin      int
-	tokenCacheTTLMin   int
-	tokenExpiresInSec  int
-	tokenStorePath     string
-	keyPath            string
-	configPath         string
+	bindAddr          string
+	oauthScopes       string
+	port              string
+	logLevel          string
+	upstreamURL       string // deprecated; prefer ROUTE_* env vars
+	trustedProxyCIDRs []string
+	sessionTTLMin     int
+	tokenCacheTTLMin  int
+	tokenExpiresInSec int
+	tokenStorePath    string
+	keyPath           string
+	configPath        string
 }
 
 func loadConfig() config {
@@ -346,6 +361,7 @@ func loadConfig() config {
 		oauthScopes:       getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
 		logLevel:          getEnv("LOG_LEVEL", "info"),
 		upstreamURL:       getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
+		trustedProxyCIDRs: splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
 		sessionTTLMin:     getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:  getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec: getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
@@ -353,6 +369,18 @@ func loadConfig() config {
 		keyPath:           getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
 		configPath:        getEnv("MCP_CONFIG_FILE", "./config.yaml"),
 	}
+}
+
+func splitCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func getEnv(key, fallback string) string {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,11 +135,15 @@ When the immediate peer IP matches `trusted_proxies`, mcp-gateway reflects:
 |--------|-------------------------|
 | `X-Forwarded-Proto` | `r.URL.Scheme` (`http` or `https` only) |
 | `X-Forwarded-Host` | `r.Host` |
-| `X-Forwarded-For` | `r.RemoteAddr` (rightmost valid IP appended by the trusted proxy) |
+| `X-Forwarded-For` | `r.RemoteAddr` (rightmost valid IP supplied by the trusted proxy) |
 
 When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are stripped
 before later middleware and handlers run. This prevents direct clients from spoofing the
 scheme, host, or client IP in logs and setup-mode HTTPS checks.
+
+Configure the reverse proxy to overwrite or sanitize `X-Forwarded-For` instead of passing
+client-provided values through unchanged. The gateway reads the header from the right as
+a defense against appended spoofed entries, but the proxy should still own this header.
 
 Example nginx location:
 
@@ -148,7 +152,7 @@ location / {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_pass http://127.0.0.1:8080;
 }
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -109,6 +109,53 @@ MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
 MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
 ```
 
+### Trusted proxy headers
+
+If the proxy terminates HTTPS or rewrites the externally visible host, also configure the
+proxy IP ranges that mcp-gateway may trust:
+
+```bash
+MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
+```
+
+Equivalent `config.yaml`:
+
+```yaml
+gateway:
+  public_url: "https://mcp.example.com"
+  bind_addr: "127.0.0.1:8080"
+  trusted_proxies:
+    - "127.0.0.1/32"
+    - "10.0.0.0/8"
+```
+
+When the immediate peer IP matches `trusted_proxies`, mcp-gateway reflects:
+
+| Header | Reflected request field |
+|--------|-------------------------|
+| `X-Forwarded-Proto` | `r.URL.Scheme` (`http` or `https` only) |
+| `X-Forwarded-Host` | `r.Host` |
+| `X-Forwarded-For` | `r.RemoteAddr` (leftmost client IP) |
+
+When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are stripped
+before later middleware and handlers run. This prevents direct clients from spoofing the
+scheme, host, or client IP in logs and setup-mode HTTPS checks.
+
+Example nginx location:
+
+```nginx
+location / {
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://127.0.0.1:8080;
+}
+```
+
+`MCP_GATEWAY_PUBLIC_URL` remains the canonical OAuth/discovery/PRM URL. Keep it set to
+the same external origin that clients use, for example `https://mcp.example.com`.
+
 ---
 
 ## Non-Docker / bare binary

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,7 +135,7 @@ When the immediate peer IP matches `trusted_proxies`, mcp-gateway reflects:
 |--------|-------------------------|
 | `X-Forwarded-Proto` | `r.URL.Scheme` (`http` or `https` only) |
 | `X-Forwarded-Host` | `r.Host` |
-| `X-Forwarded-For` | `r.RemoteAddr` (leftmost client IP) |
+| `X-Forwarded-For` | `r.RemoteAddr` (rightmost valid IP appended by the trusted proxy) |
 
 When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are stripped
 before later middleware and handlers run. This prevents direct clients from spoofing the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,9 @@ type GatewayConfig struct {
 	Port    string `yaml:"port,omitempty"`
 	// OAuthScopes is the GitHub OAuth scope list forwarded to the provider.
 	OAuthScopes string `yaml:"oauth_scopes,omitempty"`
+	// TrustedProxies is a CIDR allowlist for reverse proxies whose
+	// X-Forwarded-* headers may be reflected into downstream requests.
+	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
 }
 
 // LoadConfig reads AppConfig from path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,3 +173,28 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 		t.Errorf("expected empty secret, got: %q", cfg.Auth.GitHubClientSecret)
 	}
 }
+
+func TestLoadConfig_TrustedProxies(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	data := []byte(`
+gateway:
+  trusted_proxies:
+    - 127.0.0.1/32
+    - 10.0.0.0/8
+`)
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Gateway.TrustedProxies) != 2 {
+		t.Fatalf("trusted_proxies len: got %d, want 2", len(cfg.Gateway.TrustedProxies))
+	}
+	if cfg.Gateway.TrustedProxies[0] != "127.0.0.1/32" || cfg.Gateway.TrustedProxies[1] != "10.0.0.0/8" {
+		t.Errorf("trusted_proxies: got %#v", cfg.Gateway.TrustedProxies)
+	}
+}

--- a/internal/middleware/proxy_headers.go
+++ b/internal/middleware/proxy_headers.go
@@ -1,0 +1,120 @@
+package middleware
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"unicode"
+)
+
+var forwardedHeaderNames = []string{
+	"Forwarded",
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Real-Ip",
+}
+
+// ParseTrustedProxyCIDRs validates trusted proxy CIDR strings. Empty items are
+// ignored so callers can pass comma-separated env values directly after Split.
+func ParseTrustedProxyCIDRs(values []string) ([]netip.Prefix, error) {
+	var prefixes []netip.Prefix
+	for _, value := range values {
+		for _, raw := range strings.Split(value, ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			prefix, err := netip.ParsePrefix(raw)
+			if err != nil {
+				return nil, fmt.Errorf("trusted proxy CIDR %q: %w", raw, err)
+			}
+			prefixes = append(prefixes, prefix.Masked())
+		}
+	}
+	return prefixes, nil
+}
+
+// ProxyHeaders applies X-Forwarded-* headers only when the immediate peer is in
+// a configured trusted proxy CIDR. Untrusted forwarded headers are stripped so
+// downstream handlers cannot accidentally treat client-supplied values as real.
+func ProxyHeaders(trustedProxies []netip.Prefix) func(http.Handler) http.Handler {
+	trustedProxies = append([]netip.Prefix(nil), trustedProxies...)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			remoteIP, ok := remoteAddrIP(r.RemoteAddr)
+			if !ok || !isTrustedProxy(remoteIP, trustedProxies) {
+				next.ServeHTTP(w, withoutForwardedHeaders(r))
+				return
+			}
+
+			r2 := r.Clone(r.Context())
+			if proto := strings.ToLower(firstHeaderValue(r.Header.Get("X-Forwarded-Proto"))); proto == "http" || proto == "https" {
+				r2.URL.Scheme = proto
+			}
+			if host := firstHeaderValue(r.Header.Get("X-Forwarded-Host")); validForwardedHost(host) {
+				r2.Host = host
+			}
+			if clientIP, ok := forwardedClientIP(r.Header.Get("X-Forwarded-For")); ok {
+				r2.RemoteAddr = clientIP.String()
+			}
+
+			next.ServeHTTP(w, r2)
+		})
+	}
+}
+
+func withoutForwardedHeaders(r *http.Request) *http.Request {
+	r2 := r.Clone(r.Context())
+	for _, name := range forwardedHeaderNames {
+		r2.Header.Del(name)
+	}
+	return r2
+}
+
+func isTrustedProxy(remote netip.Addr, trustedProxies []netip.Prefix) bool {
+	for _, prefix := range trustedProxies {
+		if prefix.Contains(remote) {
+			return true
+		}
+	}
+	return false
+}
+
+func remoteAddrIP(remoteAddr string) (netip.Addr, bool) {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		addr, parseErr := netip.ParseAddr(host)
+		return addr, parseErr == nil
+	}
+	addr, parseErr := netip.ParseAddr(remoteAddr)
+	return addr, parseErr == nil
+}
+
+func forwardedClientIP(header string) (netip.Addr, bool) {
+	raw := firstHeaderValue(header)
+	if raw == "" {
+		return netip.Addr{}, false
+	}
+	addr, err := netip.ParseAddr(raw)
+	return addr, err == nil
+}
+
+func firstHeaderValue(header string) string {
+	beforeComma, _, _ := strings.Cut(header, ",")
+	return strings.TrimSpace(beforeComma)
+}
+
+func validForwardedHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, r := range host {
+		if unicode.IsControl(r) || unicode.IsSpace(r) || r == '/' || r == '\\' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/middleware/proxy_headers.go
+++ b/internal/middleware/proxy_headers.go
@@ -94,12 +94,18 @@ func remoteAddrIP(remoteAddr string) (netip.Addr, bool) {
 }
 
 func forwardedClientIP(header string) (netip.Addr, bool) {
-	raw := firstHeaderValue(header)
-	if raw == "" {
-		return netip.Addr{}, false
+	parts := strings.Split(header, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		raw := strings.TrimSpace(parts[i])
+		if raw == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(raw)
+		if err == nil {
+			return addr, true
+		}
 	}
-	addr, err := netip.ParseAddr(raw)
-	return addr, err == nil
+	return netip.Addr{}, false
 }
 
 func firstHeaderValue(header string) string {

--- a/internal/middleware/proxy_headers_test.go
+++ b/internal/middleware/proxy_headers_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func TestParseTrustedProxyCIDRs(t *testing.T) {
+	got, err := ParseTrustedProxyCIDRs([]string{"127.0.0.1/32, 10.0.0.0/8", "fc00::/7"})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxyCIDRs returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("prefix count: got %d, want 3", len(got))
+	}
+	if !got[0].Contains(netip.MustParseAddr("127.0.0.1")) {
+		t.Errorf("first prefix does not contain 127.0.0.1: %v", got[0])
+	}
+	if !got[1].Contains(netip.MustParseAddr("10.1.2.3")) {
+		t.Errorf("second prefix does not contain 10.1.2.3: %v", got[1])
+	}
+	if !got[2].Contains(netip.MustParseAddr("fc00::1")) {
+		t.Errorf("third prefix does not contain fc00::1: %v", got[2])
+	}
+}
+
+func TestParseTrustedProxyCIDRsRejectsInvalidCIDR(t *testing.T) {
+	_, err := ParseTrustedProxyCIDRs([]string{"127.0.0.1"})
+	if err == nil {
+		t.Fatal("expected invalid CIDR error")
+	}
+}
+
+func TestProxyHeadersTrustedAppliesForwardedValues(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got struct {
+		scheme     string
+		host       string
+		remoteAddr string
+	}
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.scheme = r.URL.Scheme
+		got.host = r.Host
+		got.remoteAddr = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r.Header.Set("X-Forwarded-Host", "mcp.example.com")
+	r.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got.scheme != "https" {
+		t.Errorf("scheme: got %q, want https", got.scheme)
+	}
+	if got.host != "mcp.example.com" {
+		t.Errorf("host: got %q, want mcp.example.com", got.host)
+	}
+	if got.remoteAddr != "203.0.113.9" {
+		t.Errorf("remote_addr: got %q, want 203.0.113.9", got.remoteAddr)
+	}
+}
+
+func TestProxyHeadersUntrustedStripsAndIgnoresForwardedValues(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got struct {
+		scheme      string
+		host        string
+		remoteAddr  string
+		protoHeader string
+		hostHeader  string
+		forHeader   string
+	}
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.scheme = r.URL.Scheme
+		got.host = r.Host
+		got.remoteAddr = r.RemoteAddr
+		got.protoHeader = r.Header.Get("X-Forwarded-Proto")
+		got.hostHeader = r.Header.Get("X-Forwarded-Host")
+		got.forHeader = r.Header.Get("X-Forwarded-For")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "198.51.100.10:4567"
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r.Header.Set("X-Forwarded-Host", "mcp.example.com")
+	r.Header.Set("X-Forwarded-For", "203.0.113.9")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got.scheme != "http" {
+		t.Errorf("scheme should remain original: got %q, want http", got.scheme)
+	}
+	if got.host != "internal.local" {
+		t.Errorf("host should remain original: got %q, want internal.local", got.host)
+	}
+	if got.remoteAddr != "198.51.100.10:4567" {
+		t.Errorf("remote_addr should remain original: got %q", got.remoteAddr)
+	}
+	if got.protoHeader != "" || got.hostHeader != "" || got.forHeader != "" {
+		t.Errorf("forwarded headers should be stripped, got proto=%q host=%q for=%q", got.protoHeader, got.hostHeader, got.forHeader)
+	}
+}
+
+func TestProxyHeadersInvalidForwardedValuesAreIgnored(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got struct {
+		scheme     string
+		host       string
+		remoteAddr string
+	}
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.scheme = r.URL.Scheme
+		got.host = r.Host
+		got.remoteAddr = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-Proto", "javascript")
+	r.Header.Set("X-Forwarded-Host", "bad host")
+	r.Header.Set("X-Forwarded-For", "not-an-ip")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got.scheme != "http" {
+		t.Errorf("scheme should remain original: got %q, want http", got.scheme)
+	}
+	if got.host != "internal.local" {
+		t.Errorf("host should remain original: got %q, want internal.local", got.host)
+	}
+	if got.remoteAddr != "127.0.0.1:4567" {
+		t.Errorf("remote_addr should remain original: got %q", got.remoteAddr)
+	}
+}
+
+func TestProxyHeadersSupportsTrustedIPv6Proxy(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("::1/128")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "[::1]:4567"
+	r.Header.Set("X-Forwarded-For", "2001:db8::10")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "2001:db8::10" {
+		t.Errorf("remote_addr: got %q, want 2001:db8::10", got)
+	}
+}
+
+func TestProxyHeadersBeforeLoggerLogsForwardedClientIP(t *testing.T) {
+	var buf bytes.Buffer
+	t.Cleanup(captureLogs(t, &buf))
+
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	h := ProxyHeaders(trusted)(Logger()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-For", "203.0.113.9")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	entry := parseLastLog(t, &buf)
+	if entry["remote_addr"] != "203.0.113.9" {
+		t.Errorf("remote_addr log field: got %v, want 203.0.113.9", entry["remote_addr"])
+	}
+}

--- a/internal/middleware/proxy_headers_test.go
+++ b/internal/middleware/proxy_headers_test.go
@@ -27,6 +27,19 @@ func TestParseTrustedProxyCIDRs(t *testing.T) {
 	}
 }
 
+func TestParseTrustedProxyCIDRsIgnoresEmptyItems(t *testing.T) {
+	got, err := ParseTrustedProxyCIDRs([]string{"", "  , 127.0.0.1/32, "})
+	if err != nil {
+		t.Fatalf("ParseTrustedProxyCIDRs returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("prefix count: got %d, want 1", len(got))
+	}
+	if !got[0].Contains(netip.MustParseAddr("127.0.0.1")) {
+		t.Errorf("prefix does not contain 127.0.0.1: %v", got[0])
+	}
+}
+
 func TestParseTrustedProxyCIDRsRejectsInvalidCIDR(t *testing.T) {
 	_, err := ParseTrustedProxyCIDRs([]string{"127.0.0.1"})
 	if err == nil {
@@ -142,6 +155,66 @@ func TestProxyHeadersInvalidForwardedValuesAreIgnored(t *testing.T) {
 	}
 	if got.remoteAddr != "127.0.0.1:4567" {
 		t.Errorf("remote_addr should remain original: got %q", got.remoteAddr)
+	}
+}
+
+func TestProxyHeadersTrustedRemoteAddrWithoutPort(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Host
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1"
+	r.Header.Set("X-Forwarded-Host", "mcp.example.com")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "mcp.example.com" {
+		t.Errorf("host: got %q, want mcp.example.com", got)
+	}
+}
+
+func TestProxyHeadersInvalidRemoteAddrStripsForwardedValues(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Forwarded-Host")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "not-a-remote-addr"
+	r.Header.Set("X-Forwarded-Host", "mcp.example.com")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "" {
+		t.Errorf("X-Forwarded-Host should be stripped, got %q", got)
+	}
+}
+
+func TestProxyHeadersTrustedEmptyForwardedForLeavesRemoteAddr(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-For", " ")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "127.0.0.1:4567" {
+		t.Errorf("remote_addr should remain original: got %q", got)
 	}
 }
 

--- a/internal/middleware/proxy_headers_test.go
+++ b/internal/middleware/proxy_headers_test.go
@@ -65,7 +65,7 @@ func TestProxyHeadersTrustedAppliesForwardedValues(t *testing.T) {
 	r.RemoteAddr = "127.0.0.1:4567"
 	r.Header.Set("X-Forwarded-Proto", "https")
 	r.Header.Set("X-Forwarded-Host", "mcp.example.com")
-	r.Header.Set("X-Forwarded-For", "203.0.113.9, 127.0.0.1")
+	r.Header.Set("X-Forwarded-For", "198.51.100.200, 203.0.113.9")
 	w := httptest.NewRecorder()
 
 	h.ServeHTTP(w, r)
@@ -78,6 +78,46 @@ func TestProxyHeadersTrustedAppliesForwardedValues(t *testing.T) {
 	}
 	if got.remoteAddr != "203.0.113.9" {
 		t.Errorf("remote_addr: got %q, want 203.0.113.9", got.remoteAddr)
+	}
+}
+
+func TestProxyHeadersTrustedUsesRightmostForwardedForIP(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-For", "1.2.3.4, 203.0.113.9")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "203.0.113.9" {
+		t.Errorf("remote_addr: got %q, want appended client IP 203.0.113.9", got)
+	}
+}
+
+func TestProxyHeadersTrustedSkipsInvalidForwardedForFromRight(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")}
+	var got string
+	h := ProxyHeaders(trusted)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.RemoteAddr
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "http://internal.local/mcp", nil)
+	r.RemoteAddr = "127.0.0.1:4567"
+	r.Header.Set("X-Forwarded-For", "203.0.113.9, not-an-ip")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if got != "203.0.113.9" {
+		t.Errorf("remote_addr: got %q, want 203.0.113.9", got)
 	}
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -29,6 +29,7 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
 
 			pr.Out.Header.Del("X-Forwarded-For")
 			pr.Out.Header.Del("X-Real-Ip")
+			pr.Out.Header.Del("Forwarded")
 			pr.Out.Header.Del("X-Authenticated-User")
 			pr.Out.Header.Del("X-GitHub-Login")
 			pr.Out.Header.Del("X-Forwarded-Host")

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -64,16 +64,18 @@ func TestProxyInjectsIdentityHeaders(t *testing.T) {
 
 func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	var got struct {
-		xff      string
-		realIP   string
-		authUser string
-		legacy   string
-		fwdHost  string
-		fwdProto string
+		xff       string
+		realIP    string
+		forwarded string
+		authUser  string
+		legacy    string
+		fwdHost   string
+		fwdProto  string
 	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got.xff = r.Header.Get("X-Forwarded-For")
 		got.realIP = r.Header.Get("X-Real-Ip")
+		got.forwarded = r.Header.Get("Forwarded")
 		got.authUser = r.Header.Get("X-Authenticated-User")
 		got.legacy = r.Header.Get("X-GitHub-Login")
 		got.fwdHost = r.Header.Get("X-Forwarded-Host")
@@ -88,6 +90,7 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	r := requestWithContext("bob", "tok")
 	r.Header.Set("X-Forwarded-For", "1.2.3.4")
 	r.Header.Set("X-Real-Ip", "1.2.3.4")
+	r.Header.Set("Forwarded", "for=1.2.3.4;proto=https;host=evil.example.com")
 	r.Header.Set("X-Authenticated-User", "evil-spoof")
 	r.Header.Set("X-GitHub-Login", "evil-spoof")
 	r.Header.Set("X-Forwarded-Host", "evil.example.com")
@@ -101,6 +104,9 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	}
 	if got.realIP != "" {
 		t.Errorf("X-Real-Ip not stripped: %q", got.realIP)
+	}
+	if got.forwarded != "" {
+		t.Errorf("Forwarded not stripped: %q", got.forwarded)
 	}
 	if got.authUser != "bob" {
 		t.Errorf("X-Authenticated-User spoofed: got %q, want %q", got.authUser, "bob")

--- a/tasks.md
+++ b/tasks.md
@@ -46,7 +46,7 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 | 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
 | 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🗒️ 計画段階 |
 | 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
-| 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | 🚧 PR-A 再投入中 / PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56)・PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
+| 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
 | 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | 🗒️ 計画段階 |
 | 6 | **v0.3.0 リリース** | release | — | 上記完了後 |
 


### PR DESCRIPTION
## Summary

Implements PR-B for #49 / #56: trusted reverse proxy header support.

Changes:
- Add `MCP_GATEWAY_TRUSTED_PROXIES` / `gateway.trusted_proxies` CIDR configuration.
- Add `middleware.ProxyHeaders` to trust `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-For` only when the immediate peer IP matches the configured CIDR allowlist.
- Strip forwarded headers from untrusted requests before later middleware and handlers see them.
- Apply proxy-header normalization before access logging and setup-mode handlers.
- Strip the RFC 7239 `Forwarded` header before proxying upstream.
- Update README, operations docs, changelogs, and tasks tracking.

## Validation

- `go test ./...`
- `go vet ./...`

`go test -race ./...` could not run locally on this Windows environment because cgo requires a C compiler and `gcc` is not installed. The CI workflow runs race tests on Ubuntu.

Closes #56.

Note: this is PR-B of #49. It intentionally does not close #49; PR-C #57 remains.