### PR TITLE
feat(auth): RFC 8707 resource parameter on refresh_token + token audience tracking (#49 PR-C)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,7 +7,20 @@
 
 ### Added
 
-- 信頼済みリバースプロキシヘッダ対応（[#56](https://github.com/scottlz0310/mcp-gateway/issues/56), #49 PR-B）
+- `grant_type=refresh_token` がオプションの `resource` パラメータ（RFC 8707 §2）を受け付け、再発行トークンの audience を狭める
+  - 指定した resource は元のリフレッシュトークンに記録された audience と同一か、そのサブパスでなければならない。拡大・別ルートへの変更は `invalid_target` で拒否
+  - audience トラッキング以前に発行されたレガシートークン（保存 audience が空）は任意の登録済み resource を受け入れ、スムーズな移行を可能にする
+  - 検証失敗時は消費済みリフレッシュトークンを復元するため、クライアントは修正後の `resource` で再試行できる
+
+### 移行ガイド
+
+- **`token_audience_strict`**: audience トラッキングを含まない最後のデプロイから **90 日後** に `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true`（または設定ファイルの `token_audience_strict: true`）を有効にしてください。リフレッシュトークンのデフォルト TTL は 90 日であり、その期間が過ぎると流通中のすべてのトークンに audience メタデータが付与されます。それまでは audience メタデータを持たないトークンに警告ログを出力しますが、拒否はしません。
+
+### ロードマップ
+
+- マルチ audience トークン（1 つの opaque token に複数の `aud` 値、例：`["https://gw.example/mcp/a", "https://gw.example/mcp/b"]`）は将来の候補として記録しており、現リリースには含まれない。
+
+
   - `MCP_GATEWAY_TRUSTED_PROXIES` / `gateway.trusted_proxies` による CIDR allowlist を追加
   - 信頼済み送信元からの `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-For` のみを後段 request に反映
   - 未信頼送信元からの forwarded headers は削除し、spoofing を防止

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,14 +7,19 @@
 
 ### Added
 
-- `grant_type=refresh_token` がオプションの `resource` パラメータ（RFC 8707 §2）を受け付け、再発行トークンの audience を狭める
-  - 指定した resource は元のリフレッシュトークンに記録された audience と同一か、そのサブパスでなければならない。拡大・別ルートへの変更は `invalid_target` で拒否
-  - audience トラッキング以前に発行されたレガシートークン（保存 audience が空）は任意の登録済み resource を受け入れ、スムーズな移行を可能にする
+- すべてのトークン取得フローで RFC 8707 `resource` パラメータをサポート（[#57](https://github.com/scottlz0310/mcp-gateway/issues/57), #49 PR-C）
+  - `/authorize`、`/device_authorization`、`grant_type=refresh_token` のいずれも、オプションの `resource` パラメータを受け付け、発行トークンの audience を特定の値に結びつける
+  - ディスカバリメタデータに `resource_parameter_supported: true` を追加
+  - `grant_type=refresh_token` での `resource` は、元のリフレッシュトークンに記録された audience と同一かそのサブパスでなければならない。拡大・別ルートへの変更は `invalid_target` で拒否
+  - audience トラッキング以前のレガシートークン（保存 audience が空）はグレースピリオド中は任意の登録済み resource を受け入れる
   - 検証失敗時は消費済みリフレッシュトークンを復元するため、クライアントは修正後の `resource` で再試行できる
 
 ### 移行ガイド
 
-- **`token_audience_strict`**: audience トラッキングを含まない最後のデプロイから **90 日後** に `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true`（または設定ファイルの `token_audience_strict: true`）を有効にしてください。リフレッシュトークンのデフォルト TTL は 90 日であり、その期間が過ぎると流通中のすべてのトークンに audience メタデータが付与されます。それまでは audience メタデータを持たないトークンに警告ログを出力しますが、拒否はしません。
+- **`token_audience_strict`**: `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true`（または `token_audience_strict: true`）を有効にするには、**以下のすべてが満たされている**必要があります:
+  1. **永続トークンストアが必須** — `MCP_GATEWAY_TOKEN_STORE_PATH` / `token_store_path` を設定してください。インメモリストアではキャッシュ失効時に audience メタデータが消滅し、該当トークンが使用不能になります。インメモリストアで strict モードを有効にすると、起動時に警告ログを出力します。
+  2. **すべての有効トークンが audience メタデータを持つこと** — このリリース以前に発行されたトークンには audience が記録されていません。`resource` パラメータ**なし**で refresh すると、トークンはローテーションされますが audience なし（レガシー）のまま残ります。90 日の TTL ウィンドウは**自動的に十分ではありません** — このリリース以降にすべてのアクティブクライアントが `resource` 付きで refresh するか再認証した場合に限り有効です。
+  3. **推奨手順** — `"token without audience accepted during grace period"` ログエントリを監視してください。最長セッションのクライアントでこのログが消えたら、strict モードを安全に有効化できます。
 
 ### ロードマップ
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -20,7 +20,7 @@
 
 - マルチ audience トークン（1 つの opaque token に複数の `aud` 値、例：`["https://gw.example/mcp/a", "https://gw.example/mcp/b"]`）は将来の候補として記録しており、現リリースには含まれない。
 
-
+- 信頼済みリバースプロキシヘッダ対応（[#56](https://github.com/scottlz0310/mcp-gateway/issues/56), #49 PR-B）
   - `MCP_GATEWAY_TRUSTED_PROXIES` / `gateway.trusted_proxies` による CIDR allowlist を追加
   - 信頼済み送信元からの `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-For` のみを後段 request に反映
   - 未信頼送信元からの forwarded headers は削除し、spoofing を防止

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `grant_type=refresh_token` now accepts an optional `resource` parameter (RFC 8707 §2) to narrow the audience of the re-issued token
-  - The requested resource must equal or be a sub-path of the audience originally recorded on the refresh token; broadening or cross-route changes are rejected with `invalid_target`
-  - Legacy refresh tokens issued before audience tracking was introduced (empty stored audience) accept any registered resource, enabling a smooth migration
+- RFC 8707 `resource` parameter support across all token acquisition flows ([#57](https://github.com/scottlz0310/mcp-gateway/issues/57), #49 PR-C)
+  - `/authorize`, `/device_authorization`, and `grant_type=refresh_token` all accept an optional `resource` parameter to bind the issued token to a specific audience
+  - Discovery metadata now advertises `resource_parameter_supported: true`
+  - The requested `resource` on `grant_type=refresh_token` must equal or be a sub-path of the audience originally recorded on the refresh token; broadening or cross-route changes are rejected with `invalid_target`
+  - Legacy refresh tokens issued before audience tracking (empty stored audience) accept any registered resource during the grace period
   - The consumed refresh token is restored on validation failure so clients can retry with a corrected `resource` value
 
 ### Migration
 
-- **`token_audience_strict`**: Enable `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true` (or `token_audience_strict: true` in config) **90 days after your last deployment without audience tracking**.  The default TTL for refresh tokens is 90 days, so after that window all tokens in circulation will carry audience metadata and strict enforcement is safe.  Until then the gateway logs a warning for tokens without audience metadata but does not reject them.
+- **`token_audience_strict`**: Enabling `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true` (or `token_audience_strict: true`) is only safe when **all** of the following conditions are met:
+  1. **Persistent token store required** — Set `MCP_GATEWAY_TOKEN_STORE_PATH` / `token_store_path`. With an in-memory store, audience metadata is lost on cache eviction, making those tokens unusable. The gateway now logs a startup warning if strict mode is combined with an in-memory store.
+  2. **All active tokens carry audience metadata** — Tokens issued before this release have no audience recorded. A refresh *without* a `resource` parameter rotates the token but keeps it as a legacy (no-audience) token indefinitely. The 90-day TTL window is **not** automatically sufficient — it only holds if all active clients have refreshed with `resource` or re-authenticated at least once since this release.
+  3. **Recommended approach** — Monitor the `"token without audience accepted during grace period"` log entries. Once they disappear across your longest-lived sessions, it is safe to enable strict mode.
 
 ### Roadmap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-05-20
+### Added
+
+- `grant_type=refresh_token` now accepts an optional `resource` parameter (RFC 8707 §2) to narrow the audience of the re-issued token
+  - The requested resource must equal or be a sub-path of the audience originally recorded on the refresh token; broadening or cross-route changes are rejected with `invalid_target`
+  - Legacy refresh tokens issued before audience tracking was introduced (empty stored audience) accept any registered resource, enabling a smooth migration
+  - The consumed refresh token is restored on validation failure so clients can retry with a corrected `resource` value
+
+### Migration
+
+- **`token_audience_strict`**: Enable `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=true` (or `token_audience_strict: true` in config) **90 days after your last deployment without audience tracking**.  The default TTL for refresh tokens is 90 days, so after that window all tokens in circulation will carry audience metadata and strict enforcement is safe.  Until then the gateway logs a warning for tokens without audience metadata but does not reject them.
+
+### Roadmap
+
+- Multi-audience tokens (a single opaque token carrying multiple `aud` values, e.g., `["https://gw.example/mcp/a", "https://gw.example/mcp/b"]`) are recorded as a future candidate and are not part of the current release.
+
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 - Multi-audience tokens (a single opaque token carrying multiple `aud` values, e.g., `["https://gw.example/mcp/a", "https://gw.example/mcp/b"]`) are recorded as a future candidate and are not part of the current release.
 
-
-
-### Added
+## [0.3.0] - 2026-05-20
 
 - `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` — canonical URL used for OAuth callbacks, discovery metadata, and PRM ([#48](https://github.com/scottlz0310/mcp-gateway/issues/48))
 - `MCP_GATEWAY_BIND_ADDR` / `gateway.bind_addr` — HTTP listener bind address, separate from the public URL ([#48](https://github.com/scottlz0310/mcp-gateway/issues/48))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -121,6 +121,9 @@ func main() {
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")) == "" && len(appCfg.Gateway.TrustedProxies) > 0 {
 		cfg.trustedProxyCIDRs = appCfg.Gateway.TrustedProxies
 	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT")) == "" {
+		cfg.tokenAudienceStrict = appCfg.Gateway.TokenAudienceStrict
+	}
 	trustedProxies, err := middleware.ParseTrustedProxyCIDRs(cfg.trustedProxyCIDRs)
 	if err != nil {
 		slog.Error("invalid trusted proxy configuration", "err", err)
@@ -185,11 +188,13 @@ func main() {
 	}
 
 	oauthHandler, err := auth.NewHandler(auth.Config{
-		BaseURL:        cfg.publicURL,
-		SessionTTL:     time.Duration(cfg.sessionTTLMin) * time.Minute,
-		CacheTTL:       time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
-		ExpiresIn:      time.Duration(cfg.tokenExpiresInSec) * time.Second,
-		TokenStorePath: cfg.tokenStorePath,
+		BaseURL:             cfg.publicURL,
+		SessionTTL:          time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:            time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:           time.Duration(cfg.tokenExpiresInSec) * time.Second,
+		TokenStorePath:      cfg.tokenStorePath,
+		AllowedAudiences:    routeAudiences(strings.TrimRight(cfg.publicURL, "/"), routes),
+		TokenAudienceStrict: cfg.tokenAudienceStrict,
 	}, prov)
 	if err != nil {
 		slog.Error("auth handler init failed", "err", err)
@@ -228,15 +233,21 @@ func main() {
 		if route.NoAuth {
 			wrapped = h
 		} else {
+			routeResource := publicURL
+			if route.Prefix != "/" {
+				routeResource = publicURL + route.Prefix
+			}
 			// For a root prefix ("/"), the gateway-wide PRM registered above
 			// already covers the route (resource == public_url). Skip per-route
 			// registration to avoid (a) ServeMux duplicate-pattern panic, and
 			// (b) a trailing-slash subtree pattern that would shadow other
 			// per-route PRM URLs. The middleware then falls back to the
 			// gateway-wide resource_metadata URL via WithBaseURL.
-			authOpts := []middleware.AuthOption{middleware.WithBaseURL(cfg.publicURL)}
+			authOpts := []middleware.AuthOption{
+				middleware.WithBaseURL(cfg.publicURL),
+				middleware.WithAudience(routeResource),
+			}
 			if route.Prefix != "/" {
-				routeResource := publicURL + route.Prefix
 				routePRMPath := "/.well-known/oauth-protected-resource" + route.Prefix
 				mux.HandleFunc("GET "+routePRMPath, oauthHandler.RouteProtectedResourceMetadata(routeResource))
 				authOpts = append(authOpts, middleware.WithResourceMetadataURL(publicURL+routePRMPath))
@@ -260,6 +271,7 @@ func main() {
 		"provider", prov.Name(),
 		"routes", len(routes),
 		"trusted_proxies", len(trustedProxies),
+		"token_audience_strict", cfg.tokenAudienceStrict,
 	)
 
 	server := &http.Server{
@@ -328,18 +340,19 @@ type config struct {
 	// Replaces the deprecated baseURL / MCP_GATEWAY_BASE_URL.
 	publicURL string
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
-	bindAddr          string
-	oauthScopes       string
-	port              string
-	logLevel          string
-	upstreamURL       string // deprecated; prefer ROUTE_* env vars
-	trustedProxyCIDRs []string
-	sessionTTLMin     int
-	tokenCacheTTLMin  int
-	tokenExpiresInSec int
-	tokenStorePath    string
-	keyPath           string
-	configPath        string
+	bindAddr            string
+	oauthScopes         string
+	port                string
+	logLevel            string
+	upstreamURL         string // deprecated; prefer ROUTE_* env vars
+	trustedProxyCIDRs   []string
+	sessionTTLMin       int
+	tokenCacheTTLMin    int
+	tokenExpiresInSec   int
+	tokenAudienceStrict bool
+	tokenStorePath      string
+	keyPath             string
+	configPath          string
 }
 
 func loadConfig() config {
@@ -355,19 +368,20 @@ func loadConfig() config {
 
 	return config{
 		// githubClientID and githubClientSecret are resolved after key/config loading in main().
-		publicURL:         publicURL,
-		bindAddr:          bindAddr,
-		port:              port,
-		oauthScopes:       getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
-		logLevel:          getEnv("LOG_LEVEL", "info"),
-		upstreamURL:       getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
-		trustedProxyCIDRs: splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
-		sessionTTLMin:     getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:  getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
-		tokenExpiresInSec: getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
-		tokenStorePath:    lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
-		keyPath:           getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
-		configPath:        getEnv("MCP_CONFIG_FILE", "./config.yaml"),
+		publicURL:           publicURL,
+		bindAddr:            bindAddr,
+		port:                port,
+		oauthScopes:         getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
+		logLevel:            getEnv("LOG_LEVEL", "info"),
+		upstreamURL:         getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
+		trustedProxyCIDRs:   splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
+		sessionTTLMin:       getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:    getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
+		tokenExpiresInSec:   getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		tokenAudienceStrict: getEnvBool("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT", false),
+		tokenStorePath:      lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
+		keyPath:             getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
+		configPath:          getEnv("MCP_CONFIG_FILE", "./config.yaml"),
 	}
 }
 
@@ -381,6 +395,26 @@ func splitCSV(value string) []string {
 		}
 	}
 	return out
+}
+
+func routeAudiences(publicURL string, routes []router.Route) []string {
+	audiences := []string{publicURL}
+	seen := map[string]struct{}{publicURL: {}}
+	for _, route := range routes {
+		if route.NoAuth {
+			continue
+		}
+		audience := publicURL
+		if route.Prefix != "/" {
+			audience += route.Prefix
+		}
+		if _, ok := seen[audience]; ok {
+			continue
+		}
+		seen[audience] = struct{}{}
+		audiences = append(audiences, audience)
+	}
+	return audiences
 }
 
 func getEnv(key, fallback string) string {
@@ -407,6 +441,21 @@ func getEnvInt(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+func getEnvBool(key string, fallback bool) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if v == "" {
+		return fallback
+	}
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
 }
 
 func parseLogLevel(level string) slog.Level {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -27,6 +27,14 @@ var (
 	ErrTokenAudienceMissing  = errors.New("token audience metadata missing")
 )
 
+// audienceCheckError wraps audience validation sentinels so middleware can
+// distinguish them from generic token errors without importing this package.
+type audienceCheckError struct{ inner error }
+
+func (e audienceCheckError) Error() string         { return e.inner.Error() }
+func (e audienceCheckError) Unwrap() error         { return e.inner }
+func (e audienceCheckError) IsAudienceError() bool { return true }
+
 // githubClient is the HTTP client used for GitHub Device Flow API calls.
 // Exposed as a package-level var so tests can substitute a test server transport.
 var githubClient = &http.Client{Timeout: 15 * time.Second}
@@ -712,20 +720,18 @@ func (h *Handler) InvalidateCachedToken(token string) {
 }
 
 func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
-	var requested []string
-	for _, resource := range resources {
-		resource = normalizeAudience(resource)
-		if resource != "" {
-			requested = append(requested, resource)
+	for _, raw := range resources {
+		if strings.TrimSpace(raw) == "" {
+			return "", fmt.Errorf("resource parameter must not be empty")
 		}
 	}
-	if len(requested) == 0 {
+	if len(resources) == 0 {
 		return h.cfg.BaseURL, nil
 	}
-	if len(requested) > 1 {
+	if len(resources) > 1 {
 		return "", fmt.Errorf("multiple resource parameters are not supported")
 	}
-	resource := requested[0]
+	resource := normalizeAudience(resources[0])
 	u, err := url.Parse(resource)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.Fragment != "" {
 		return "", fmt.Errorf("resource must be an absolute http/https URL without fragment")
@@ -745,7 +751,7 @@ func (h *Handler) validateAudience(token string, record TokenRecord, audience st
 	}
 	if len(record.Audiences) == 0 {
 		if h.cfg.TokenAudienceStrict {
-			return ErrTokenAudienceMissing
+			return audienceCheckError{ErrTokenAudienceMissing}
 		}
 		slog.Warn("token without audience accepted during grace period",
 			"token_hash", tokenFingerprint(token),
@@ -753,7 +759,7 @@ func (h *Handler) validateAudience(token string, record TokenRecord, audience st
 		)
 		return nil
 	}
-	return ErrTokenAudienceMismatch
+	return audienceCheckError{ErrTokenAudienceMismatch}
 }
 
 func normalizeAllowedAudiences(baseURL string, audiences []string) []string {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -474,18 +474,23 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// originalAudience holds the audience recorded on the reserved token. It is
+	// used for all RestoreRefreshToken calls so that a failure never permanently
+	// narrows the old token to a narrower audience.
+	originalAudience := audience
+
 	// RFC 8707 §2: optional resource parameter narrows the audience for the
 	// re-issued token. The requested audience must be equal to or a strict
 	// sub-path of the audience recorded on the original refresh token.
 	if resources := r.Form["resource"]; len(resources) > 0 {
 		resolved, audErr := h.resolveRequestedAudience(resources)
 		if audErr != nil {
-			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
 			oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
 			return
 		}
-		if !isSubAudience(resolved, audience) {
-			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+		if !isSubAudience(resolved, originalAudience) {
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
 			oauthError(w, "invalid_target", "resource is not a valid narrowing of the original audience", http.StatusBadRequest)
 			return
 		}
@@ -500,8 +505,9 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		var upstreamErr *provider.UpstreamError
 		if errors.As(valErr, &upstreamErr) {
 			slog.Warn("refresh rejected: transient upstream error", "err", valErr)
-			// Restore the token so the client can retry later.
-			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+			// Restore the token with its original audience so the client can retry,
+			// potentially with a different resource value.
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
 			oauthError(w, "temporarily_unavailable", "upstream provider unreachable, retry later", http.StatusServiceUnavailable)
 		} else {
 			slog.Warn("refresh rejected: underlying token invalid", "err", valErr)
@@ -517,8 +523,8 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, h.refreshTokenTTL())
 	if rtErr != nil {
 		slog.Error("failed to rotate refresh token", "err", rtErr)
-		// Restore the original token so the client can retry later.
-		h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+		// Restore the original token (with its original audience) so the client can retry.
+		h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -22,6 +22,11 @@ import (
 // token expiry without requiring full re-authentication.
 const refreshTokenGracePeriod = 30 * 24 * time.Hour
 
+var (
+	ErrTokenAudienceMismatch = errors.New("token audience mismatch")
+	ErrTokenAudienceMissing  = errors.New("token audience metadata missing")
+)
+
 // githubClient is the HTTP client used for GitHub Device Flow API calls.
 // Exposed as a package-level var so tests can substitute a test server transport.
 var githubClient = &http.Client{Timeout: 15 * time.Second}
@@ -43,14 +48,21 @@ type Config struct {
 	// When set, validated tokens survive container restarts; the file is written
 	// with mode 0600 and only hashed token keys are stored.
 	TokenStorePath string
+	// AllowedAudiences is the set of RFC 8707 resource indicator values accepted
+	// by this gateway. BaseURL is always allowed.
+	AllowedAudiences []string
+	// TokenAudienceStrict rejects tokens without audience metadata. The default
+	// false value is a grace mode for tokens issued before this metadata existed.
+	TokenAudienceStrict bool
 }
 
 // Handler implements the OAuth façade endpoints, delegating provider-specific
 // operations to a provider.Provider.
 type Handler struct {
-	cfg      Config
-	provider provider.Provider
-	store    *Store
+	cfg              Config
+	provider         provider.Provider
+	store            *Store
+	allowedAudiences map[string]struct{}
 }
 
 // NewHandler creates a new OAuth Handler with the given configuration and provider.
@@ -66,6 +78,7 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 		return nil, fmt.Errorf("auth.NewHandler: provider must not be nil")
 	}
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	cfg.AllowedAudiences = normalizeAllowedAudiences(cfg.BaseURL, cfg.AllowedAudiences)
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
 	}
@@ -95,9 +108,10 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 	}
 
 	return &Handler{
-		cfg:      cfg,
-		provider: p,
-		store:    NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
+		cfg:              cfg,
+		provider:         p,
+		store:            NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
+		allowedAudiences: audienceSet(cfg.AllowedAudiences),
 	}, nil
 }
 
@@ -157,6 +171,7 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 		"response_types_supported":         []string{"code"},
 		"grant_types_supported":            []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 		"code_challenge_methods_supported": []string{"S256"},
+		"resource_parameter_supported":     true,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(doc)
@@ -207,6 +222,11 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	codeChallenge := q.Get("code_challenge")
 	responseType := q.Get("response_type")
 	codeChallengeMethod := q.Get("code_challenge_method")
+	audience, audErr := h.resolveRequestedAudience(q["resource"])
+	if audErr != nil {
+		oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if responseType != "code" {
 		oauthError(w, "unsupported_response_type", "response_type must be 'code'", http.StatusBadRequest)
@@ -234,7 +254,7 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.store.SaveSession(state, redirectURI, codeChallenge)
+	h.store.SaveSession(state, redirectURI, codeChallenge, audience)
 
 	http.Redirect(w, r, h.provider.AuthorizeURL(state, codeChallenge), http.StatusFound)
 }
@@ -304,7 +324,7 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
-	token, grantedScope, err := h.store.ExchangeCode(
+	token, grantedScope, audience, err := h.store.ExchangeCode(
 		r.FormValue("code"),
 		r.FormValue("redirect_uri"),
 		r.FormValue("code_verifier"),
@@ -314,7 +334,8 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
 		return
 	}
-	refreshToken, rtErr := h.store.CreateRefreshToken(token, h.refreshTokenTTL())
+	h.store.RegisterTokenAudience(token, audience)
+	refreshToken, rtErr := h.store.CreateRefreshToken(token, audience, h.refreshTokenTTL())
 	if rtErr != nil {
 		slog.Warn("failed to create refresh token", "err", rtErr)
 	}
@@ -379,11 +400,13 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Error {
 	case "":
-		if _, ok := h.store.AuthorizeAndConsumeDevice(deviceCode, result.AccessToken, result.Scope); !ok {
+		completed, ok := h.store.AuthorizeAndConsumeDevice(deviceCode, result.AccessToken, result.Scope)
+		if !ok {
 			oauthError(w, "invalid_grant", "device code already consumed", http.StatusBadRequest)
 			return
 		}
-		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, h.refreshTokenTTL())
+		h.store.RegisterTokenAudience(result.AccessToken, completed.Audience)
+		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, completed.Audience, h.refreshTokenTTL())
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
@@ -439,7 +462,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 
 	// Atomically reserve (remove) the token. Concurrent callers presenting the
 	// same token will fail here, preventing double-rotation.
-	accessToken, rtExpiresAt, err := h.store.ReserveRefreshToken(rt)
+	accessToken, audience, rtExpiresAt, err := h.store.ReserveRefreshToken(rt)
 	if err != nil {
 		if errors.Is(err, ErrRefreshTokenDeleteFailed) {
 			slog.Warn("refresh token store failure", "err", err)
@@ -451,6 +474,24 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// RFC 8707 §2: optional resource parameter narrows the audience for the
+	// re-issued token. The requested audience must be equal to or a strict
+	// sub-path of the audience recorded on the original refresh token.
+	if resources := r.Form["resource"]; len(resources) > 0 {
+		resolved, audErr := h.resolveRequestedAudience(resources)
+		if audErr != nil {
+			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+			oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
+			return
+		}
+		if !isSubAudience(resolved, audience) {
+			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
+			oauthError(w, "invalid_target", "resource is not a valid narrowing of the original audience", http.StatusBadRequest)
+			return
+		}
+		audience = resolved
+	}
+
 	// Re-validate the underlying token directly against the upstream provider,
 	// bypassing the local cache. Using the cache here could allow refresh to
 	// succeed for a revoked token until cache expiry.
@@ -460,7 +501,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		if errors.As(valErr, &upstreamErr) {
 			slog.Warn("refresh rejected: transient upstream error", "err", valErr)
 			// Restore the token so the client can retry later.
-			h.store.RestoreRefreshToken(rt, accessToken, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
 			oauthError(w, "temporarily_unavailable", "upstream provider unreachable, retry later", http.StatusServiceUnavailable)
 		} else {
 			slog.Warn("refresh rejected: underlying token invalid", "err", valErr)
@@ -470,14 +511,14 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Re-cache the freshly validated token.
-	h.store.CacheToken(accessToken, id.Subject)
+	h.store.CacheToken(accessToken, id.Subject, audience)
 
 	// Issue the rotated refresh token. The original is already consumed (reserved).
-	newRT, rtErr := h.store.CreateRefreshToken(accessToken, h.refreshTokenTTL())
+	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, h.refreshTokenTTL())
 	if rtErr != nil {
 		slog.Error("failed to rotate refresh token", "err", rtErr)
 		// Restore the original token so the client can retry later.
-		h.store.RestoreRefreshToken(rt, accessToken, rtExpiresAt)
+		h.store.RestoreRefreshToken(rt, accessToken, audience, rtExpiresAt)
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -494,6 +535,11 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
 		return
 	}
+	audience, audErr := h.resolveRequestedAudience(r.Form["resource"])
+	if audErr != nil {
+		oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Always use configured scopes to prevent clients from escalating to broader permissions.
 	scope := h.provider.Scopes()
@@ -506,7 +552,7 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	expiresAt := time.Now().Add(time.Duration(ghResp.ExpiresIn) * time.Second)
-	internalCode, err := h.store.CreateDevice(ghResp.DeviceCode, ghResp.UserCode, ghResp.VerificationURI, expiresAt, ghResp.Interval)
+	internalCode, err := h.store.CreateDevice(ghResp.DeviceCode, ghResp.UserCode, ghResp.VerificationURI, expiresAt, ghResp.Interval, audience)
 	if err != nil {
 		slog.Error("device session creation failed", "err", err)
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
@@ -626,23 +672,130 @@ func (h *Handler) pollGitHubDeviceToken(ctx context.Context, githubDevCode strin
 	}, nil
 }
 
-// ValidateToken checks the bearer token via the provider (with cache).
+// ValidateToken checks the bearer token via the provider (with cache) and
+// validates that its stored audience matches the protected resource.
 // The returned subject is the Identity.Subject from the provider.
-func (h *Handler) ValidateToken(ctx context.Context, token string) (string, error) {
-	if subject, ok := h.store.LookupToken(token); ok {
-		return subject, nil
+func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (string, error) {
+	audience = normalizeAudience(audience)
+	record, cached := h.store.LookupToken(token)
+	if cached {
+		if err := h.validateAudience(token, record, audience); err != nil {
+			return "", err
+		}
+		if record.Subject != "" {
+			return record.Subject, nil
+		}
+	} else if err := h.validateAudience(token, TokenRecord{}, audience); err != nil {
+		return "", err
 	}
 	id, err := h.provider.ValidateToken(ctx, token)
 	if err != nil {
 		return "", err
 	}
-	h.store.CacheToken(token, id.Subject)
+	cacheAudience := ""
+	if cached && record.HasAudience(audience) {
+		cacheAudience = audience
+	}
+	h.store.CacheToken(token, id.Subject, cacheAudience)
 	return id.Subject, nil
 }
 
 // InvalidateCachedToken delegates cache invalidation to the underlying store.
 func (h *Handler) InvalidateCachedToken(token string) {
 	h.store.InvalidateCachedToken(token)
+}
+
+func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
+	var requested []string
+	for _, resource := range resources {
+		resource = normalizeAudience(resource)
+		if resource != "" {
+			requested = append(requested, resource)
+		}
+	}
+	if len(requested) == 0 {
+		return h.cfg.BaseURL, nil
+	}
+	if len(requested) > 1 {
+		return "", fmt.Errorf("multiple resource parameters are not supported")
+	}
+	resource := requested[0]
+	u, err := url.Parse(resource)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.Fragment != "" {
+		return "", fmt.Errorf("resource must be an absolute http/https URL without fragment")
+	}
+	if _, ok := h.allowedAudiences[resource]; !ok {
+		return "", fmt.Errorf("resource is not registered with this gateway")
+	}
+	return resource, nil
+}
+
+func (h *Handler) validateAudience(token string, record TokenRecord, audience string) error {
+	if audience == "" {
+		return nil
+	}
+	if record.HasAudience(audience) {
+		return nil
+	}
+	if len(record.Audiences) == 0 {
+		if h.cfg.TokenAudienceStrict {
+			return ErrTokenAudienceMissing
+		}
+		slog.Warn("token without audience accepted during grace period",
+			"token_hash", tokenFingerprint(token),
+			"expected_audience", audience,
+		)
+		return nil
+	}
+	return ErrTokenAudienceMismatch
+}
+
+func normalizeAllowedAudiences(baseURL string, audiences []string) []string {
+	out := make([]string, 0, len(audiences)+1)
+	seen := map[string]struct{}{}
+	for _, audience := range append([]string{baseURL}, audiences...) {
+		audience = normalizeAudience(audience)
+		if audience == "" {
+			continue
+		}
+		if _, ok := seen[audience]; ok {
+			continue
+		}
+		seen[audience] = struct{}{}
+		out = append(out, audience)
+	}
+	return out
+}
+
+func audienceSet(audiences []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(audiences))
+	for _, audience := range audiences {
+		set[audience] = struct{}{}
+	}
+	return set
+}
+
+func normalizeAudience(audience string) string {
+	return strings.TrimRight(strings.TrimSpace(audience), "/")
+}
+
+// isSubAudience reports whether requested is equal to or a strict narrowing of
+// original (i.e. requested starts with original+"/"). When original is empty
+// the token was issued without audience metadata (legacy grace-period token),
+// and any registered audience is accepted.
+func isSubAudience(requested, original string) bool {
+	if original == "" {
+		return true
+	}
+	return requested == original || strings.HasPrefix(requested, original+"/")
+}
+
+func tokenFingerprint(token string) string {
+	key := tokenKey(token)
+	if len(key) <= 8 {
+		return key
+	}
+	return key[:8]
 }
 
 func isAllowedRedirectHost(hostname string, allowed []string) bool {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -113,6 +113,11 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 	} else {
 		ts = NewMemTokenStore()
 		tokensTTL = cfg.CacheTTL
+		if cfg.TokenAudienceStrict {
+			slog.Warn("token_audience_strict is enabled without a persistent token store; " +
+				"audience metadata is lost on cache eviction, making affected tokens unusable — " +
+				"set token_store_path for durable storage")
+		}
 	}
 
 	return &Handler{

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -237,6 +239,161 @@ func TestAuthorizeRedirectsToGitHub(t *testing.T) {
 	}
 }
 
+func TestAuthorizeResourceAudienceStoredOnToken(t *testing.T) {
+	const routeAudience = "http://localhost:8080/mcp/foo"
+	p := &provider.Mock{
+		ClientIDValue: "test-client-id",
+		ScopesValue:   "repo,user",
+		ExchangeCodeFunc: func(_ context.Context, _ string) (string, []string, error) {
+			return "opaque-route-token", []string{"repo", "user"}, nil
+		},
+		ValidateFunc: func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Provider: "mock", Subject: "alice"}, nil
+		},
+	}
+	h, err := NewHandler(Config{
+		BaseURL:          "http://localhost:8080",
+		SessionTTL:       10 * time.Minute,
+		CacheTTL:         5 * time.Minute,
+		ExpiresIn:        90 * 24 * time.Hour,
+		AllowedAudiences: []string{routeAudience},
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=state-aud&redirect_uri=http://localhost/cb&resource="+url.QueryEscape(routeAudience), nil)
+	authRec := httptest.NewRecorder()
+	h.Authorize(authRec, authReq)
+	if authRec.Code != http.StatusFound {
+		t.Fatalf("authorize status: got %d, want 302; body: %s", authRec.Code, authRec.Body.String())
+	}
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=provider-code&state=state-aud", nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback status: got %d, want 302; body: %s", cbRec.Code, cbRec.Body.String())
+	}
+	redirectURL, err := url.Parse(cbRec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parsing callback redirect: %v", err)
+	}
+	internalCode := redirectURL.Query().Get("code")
+	if internalCode == "" {
+		t.Fatal("callback redirect missing internal code")
+	}
+
+	body := "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code=" + url.QueryEscape(internalCode)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token status: got %d, want 200; body: %s", tokenRec.Code, tokenRec.Body.String())
+	}
+
+	rec, ok := h.store.LookupToken("opaque-route-token")
+	if !ok {
+		t.Fatal("issued token should be registered in token store")
+	}
+	if !rec.HasAudience(routeAudience) {
+		t.Fatalf("token audiences: got %#v, want %q", rec.Audiences, routeAudience)
+	}
+	subject, err := h.ValidateToken(context.Background(), "opaque-route-token", routeAudience)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if subject != "alice" {
+		t.Errorf("subject: got %q, want alice", subject)
+	}
+}
+
+func TestAuthorizeRejectsUnknownResource(t *testing.T) {
+	h := newTestHandler(t)
+	r := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=s&redirect_uri=http://localhost/cb&resource=http%3A%2F%2Flocalhost%3A8080%2Fmcp%2Fmissing", nil)
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %q, want invalid_target", resp["error"])
+	}
+}
+
+func TestValidateTokenAudienceMismatch(t *testing.T) {
+	h := newTestHandler(t)
+	h.store.RegisterTokenAudience("route-token", "http://localhost:8080/mcp/a")
+	h.store.CacheToken("route-token", "alice", "")
+
+	_, err := h.ValidateToken(context.Background(), "route-token", "http://localhost:8080/mcp/b")
+	if !errors.Is(err, ErrTokenAudienceMismatch) {
+		t.Fatalf("ValidateToken err: got %v, want ErrTokenAudienceMismatch", err)
+	}
+}
+
+func TestValidateTokenLegacyGraceAndStrictModes(t *testing.T) {
+	const audience = "http://localhost:8080/mcp/foo"
+	var calls int
+	p := &provider.Mock{
+		ClientIDValue: "test-client-id",
+		ValidateFunc: func(_ context.Context, _ string) (provider.Identity, error) {
+			calls++
+			return provider.Identity{Provider: "mock", Subject: "legacy-user"}, nil
+		},
+	}
+	grace, err := NewHandler(Config{
+		BaseURL:          "http://localhost:8080",
+		SessionTTL:       10 * time.Minute,
+		CacheTTL:         5 * time.Minute,
+		AllowedAudiences: []string{audience},
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler grace: %v", err)
+	}
+	subject, err := grace.ValidateToken(context.Background(), "legacy-token", audience)
+	if err != nil {
+		t.Fatalf("grace ValidateToken: %v", err)
+	}
+	if subject != "legacy-user" {
+		t.Errorf("subject: got %q", subject)
+	}
+	if calls != 1 {
+		t.Errorf("provider calls in grace mode: got %d, want 1", calls)
+	}
+	rec, ok := grace.store.LookupToken("legacy-token")
+	if !ok || rec.Subject != "legacy-user" || len(rec.Audiences) != 0 {
+		t.Fatalf("legacy cache record: got %#v ok=%v", rec, ok)
+	}
+
+	strict, err := NewHandler(Config{
+		BaseURL:             "http://localhost:8080",
+		SessionTTL:          10 * time.Minute,
+		CacheTTL:            5 * time.Minute,
+		AllowedAudiences:    []string{audience},
+		TokenAudienceStrict: true,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler strict: %v", err)
+	}
+	_, err = strict.ValidateToken(context.Background(), "legacy-token", audience)
+	if !errors.Is(err, ErrTokenAudienceMissing) {
+		t.Fatalf("strict ValidateToken err: got %v, want ErrTokenAudienceMissing", err)
+	}
+	if calls != 1 {
+		t.Errorf("strict mode should reject before provider validation; calls=%d", calls)
+	}
+}
+
 func TestDiscoveryIncludesDeviceEndpoints(t *testing.T) {
 	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
@@ -341,7 +498,7 @@ func TestTokenDeviceGrantPending(t *testing.T) {
 
 	// Create a pending device session directly in the store.
 	expiresAt := time.Now().Add(15 * time.Minute)
-	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5)
+	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5, "http://localhost:8080")
 	if err != nil {
 		t.Fatalf("creating device session: %v", err)
 	}
@@ -382,7 +539,7 @@ func TestTokenDeviceGrantConcurrentPollingDoesNotSlowDown(t *testing.T) {
 	h := newTestHandler(t)
 
 	expiresAt := time.Now().Add(15 * time.Minute)
-	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5)
+	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5, "http://localhost:8080/mcp")
 	if err != nil {
 		t.Fatalf("creating device session: %v", err)
 	}
@@ -449,7 +606,7 @@ func TestTokenDeviceGrantSuccess(t *testing.T) {
 	h := newTestHandler(t)
 
 	expiresAt := time.Now().Add(15 * time.Minute)
-	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5)
+	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5, "http://localhost:8080")
 	if err != nil {
 		t.Fatalf("creating device session: %v", err)
 	}
@@ -505,7 +662,7 @@ func TestTokenRefreshSuccess(t *testing.T) {
 	}
 
 	// Seed a refresh token for an existing access token.
-	rt, err := h.store.CreateRefreshToken("gha_existing_token", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_existing_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -608,7 +765,7 @@ func TestTokenRefreshUpstreamErrorPreservesToken(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	rt, err := h.store.CreateRefreshToken("gha_token", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -662,7 +819,7 @@ func TestTokenRefreshConcurrentSameToken(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	rt, err := h.store.CreateRefreshToken("gha_concurrent_token", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_concurrent_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -756,7 +913,7 @@ func TestHandlerRefreshTokenSurvivesRestart(t *testing.T) {
 	}
 
 	h1 := newHandlerWithPath(t, storePath)
-	rt, err := h1.store.CreateRefreshToken("gha_access_token", 24*time.Hour)
+	rt, err := h1.store.CreateRefreshToken("gha_access_token", "http://localhost:8080/mcp", 24*time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -809,10 +966,10 @@ type deleteFailRefreshStore struct {
 	inner *memRefreshTokenStore
 }
 
-func (d *deleteFailRefreshStore) Save(rt, at string, exp time.Time) error {
-	return d.inner.Save(rt, at, exp)
+func (d *deleteFailRefreshStore) Save(rt, at, aud string, exp time.Time) error {
+	return d.inner.Save(rt, at, aud, exp)
 }
-func (d *deleteFailRefreshStore) Lookup(rt string) (string, time.Time, bool) {
+func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, time.Time, bool) {
 	return d.inner.Lookup(rt)
 }
 func (d *deleteFailRefreshStore) Delete(_ string) error { return fmt.Errorf("disk I/O error") }
@@ -831,7 +988,7 @@ func TestTokenRefreshDeleteFailed503(t *testing.T) {
 
 	inner := &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
 	failStore := &deleteFailRefreshStore{inner: inner}
-	_ = inner.Save("test-rt", "test-at", time.Now().Add(time.Hour))
+	_ = inner.Save("test-rt", "test-at", "http://localhost:8080/mcp", time.Now().Add(time.Hour))
 
 	store := NewStore(time.Minute, 90*24*time.Hour, NewMemTokenStore(),
 		WithRefreshTokenStore(failStore))
@@ -881,5 +1038,194 @@ func TestNewHandlerRefreshStoreInitError(t *testing.T) {
 	}, p)
 	if err == nil {
 		t.Fatal("expected error when refresh token store init fails, got nil")
+	}
+}
+
+// newTestRefreshHandlerWithGitHub creates a Handler wired to a stub GitHub user API
+// and configured with extra allowed audiences.
+func newTestRefreshHandlerWithGitHub(t *testing.T, extraAudiences []string) (*Handler, *httptest.Server) {
+	t.Helper()
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"login":"alice","name":"Alice"}`)
+	}))
+	t.Cleanup(ghServer.Close)
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+		UserAPI:      ghServer.URL + "/user",
+		HTTPClient:   ghServer.Client(),
+	})
+	h, err := NewHandler(Config{
+		BaseURL:          "http://localhost:8080",
+		SessionTTL:       10 * time.Minute,
+		CacheTTL:         5 * time.Minute,
+		ExpiresIn:        90 * 24 * time.Hour,
+		AllowedAudiences: extraAudiences,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h, ghServer
+}
+
+// TestTokenRefreshResourceSameAudience verifies that a resource matching the
+// original audience is accepted and returns 200.
+func TestTokenRefreshResourceSameAudience(t *testing.T) {
+	const audience = "http://localhost:8080/mcp/route-a"
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{audience})
+
+	rt, err := h.store.CreateRefreshToken("gha_token", audience, h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(audience)
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["refresh_token"] == nil {
+		t.Error("expected rotated refresh_token in response")
+	}
+}
+
+// TestTokenRefreshResourceNarrowing verifies that a client may narrow a
+// gateway-wide audience to a per-route sub-path on refresh.
+func TestTokenRefreshResourceNarrowing(t *testing.T) {
+	const routeAud = "http://localhost:8080/mcp/route-a"
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+
+	// Original token is gateway-wide.
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(routeAud)
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestTokenRefreshResourceCrossRoute verifies that switching from one route
+// audience to a sibling route is rejected with 400 invalid_target.
+func TestTokenRefreshResourceCrossRoute(t *testing.T) {
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{
+		"http://localhost:8080/mcp/route-a",
+		"http://localhost:8080/mcp/route-b",
+	})
+
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp/route-a", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("http://localhost:8080/mcp/route-b")
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %v, want invalid_target", resp["error"])
+	}
+}
+
+// TestTokenRefreshResourceWidening verifies that broadening a per-route
+// audience to gateway-wide is rejected with 400 invalid_target.
+func TestTokenRefreshResourceWidening(t *testing.T) {
+	const routeAud = "http://localhost:8080/mcp/route-a"
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+
+	rt, err := h.store.CreateRefreshToken("gha_token", routeAud, h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("http://localhost:8080")
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %v, want invalid_target", resp["error"])
+	}
+}
+
+// TestTokenRefreshResourceUnknown verifies that an unregistered resource is
+// rejected with 400 invalid_target and the refresh token is restored.
+func TestTokenRefreshResourceUnknown(t *testing.T) {
+	h, _ := newTestRefreshHandlerWithGitHub(t, nil)
+
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("https://unknown.example/mcp")
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %v, want invalid_target", resp["error"])
+	}
+	// Token must be restored so the client can retry with a valid resource.
+	if _, err := h.store.UseRefreshToken(rt); err != nil {
+		t.Error("refresh token should be restored after invalid resource rejection")
+	}
+}
+
+// TestTokenRefreshResourceLegacyToken verifies that a legacy token (empty
+// stored audience) accepts any registered resource as a valid narrowing.
+func TestTokenRefreshResourceLegacyToken(t *testing.T) {
+	const routeAud = "http://localhost:8080/mcp/route-a"
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+
+	// Empty audience simulates a pre-audience (legacy) refresh token.
+	rt, err := h.store.CreateRefreshToken("gha_token", "", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(routeAud)
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1229,3 +1229,57 @@ func TestTokenRefreshResourceLegacyToken(t *testing.T) {
 		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
 	}
 }
+
+// TestTokenRefreshResourceEmptyValue verifies that resource= (empty value) is
+// rejected as invalid_target (RFC 8707 requires a non-empty absolute URI).
+func TestTokenRefreshResourceEmptyValue(t *testing.T) {
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{"http://localhost:8080/mcp/route-a"})
+
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource="
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %v, want invalid_target", resp["error"])
+	}
+}
+
+// TestTokenRefreshResourceMultipleRaw verifies that resource=&resource=https://x
+// (one empty, one valid) is rejected — raw count check ignores empty filtering.
+func TestTokenRefreshResourceMultipleRaw(t *testing.T) {
+	const routeAud = "http://localhost:8080/mcp/route-a"
+	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("seeding refresh token: %v", err)
+	}
+
+	// resource= (empty) is present first — should be rejected before multi-check
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=&resource=" + url.QueryEscape(routeAud)
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid_target" {
+		t.Errorf("error: got %v, want invalid_target", resp["error"])
+	}
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -22,6 +22,7 @@ type Session struct {
 	State         string
 	RedirectURI   string
 	CodeChallenge string
+	Audience      string
 	InternalCode  string
 	AccessToken   string
 	Scope         string
@@ -32,7 +33,7 @@ type deviceStatus int
 
 const (
 	devicePending deviceStatus = iota
-	deviceDenied                // user denied or access_denied from GitHub
+	deviceDenied               // user denied or access_denied from GitHub
 )
 
 // DeviceSession tracks a Device Authorization Grant (RFC 8628) flow and its current status.
@@ -45,6 +46,7 @@ type DeviceSession struct {
 	Interval        int // minimum seconds between client polls (from GitHub)
 	AccessToken     string
 	Scope           string
+	Audience        string
 	Status          deviceStatus
 	pollingInFlight bool // true while one request is actively polling GitHub
 	nextPollAfter   time.Time
@@ -53,11 +55,11 @@ type DeviceSession struct {
 // Store holds OAuth flow state (sessions, codes, devices) and delegates token
 // validation persistence to a TokenStore.
 type Store struct {
-	mu           sync.RWMutex
-	sessions     map[string]*Session
-	codes        map[string]*Session
-	devices      map[string]*DeviceSession // keyed by gateway-internal device code
-	ttl          time.Duration
+	mu       sync.RWMutex
+	sessions map[string]*Session
+	codes    map[string]*Session
+	devices  map[string]*DeviceSession // keyed by gateway-internal device code
+	ttl      time.Duration
 
 	tokens       TokenStore
 	tokensTTL    time.Duration // TTL applied when saving a validated token
@@ -110,13 +112,14 @@ func (s *Store) Stop() {
 }
 
 // SaveSession stores a new OAuth session keyed by state.
-func (s *Store) SaveSession(state, redirectURI, codeChallenge string) {
+func (s *Store) SaveSession(state, redirectURI, codeChallenge, audience string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions[state] = &Session{
 		State:         state,
 		RedirectURI:   redirectURI,
 		CodeChallenge: codeChallenge,
+		Audience:      audience,
 		ExpiresAt:     time.Now().Add(s.ttl),
 	}
 }
@@ -151,35 +154,36 @@ func (s *Store) CompleteCallback(state, accessToken, scope string) (string, erro
 	return code, nil
 }
 
-// ExchangeCode validates PKCE and returns the access token and granted scope.
-// The code is consumed on success (one-time use).
-func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, string, error) {
+// ExchangeCode validates PKCE and returns the access token, granted scope, and
+// requested audience. The code is consumed on success (one-time use).
+func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (string, string, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	sess, ok := s.codes[code]
 	if !ok || time.Now().After(sess.ExpiresAt) {
 		delete(s.codes, code)
-		return "", "", fmt.Errorf("code not found or expired")
+		return "", "", "", fmt.Errorf("code not found or expired")
 	}
 	if sess.RedirectURI != redirectURI {
-		return "", "", fmt.Errorf("redirect_uri mismatch")
+		return "", "", "", fmt.Errorf("redirect_uri mismatch")
 	}
 	if sess.CodeChallenge != "" {
 		if err := verifyPKCE(codeVerifier, sess.CodeChallenge); err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	}
 
 	token := sess.AccessToken
 	scope := sess.Scope
+	audience := sess.Audience
 	delete(s.codes, code)
 	delete(s.sessions, sess.State)
-	return token, scope, nil
+	return token, scope, audience, nil
 }
 
 // CreateDevice stores a new Device Authorization Grant session and returns the gateway-internal device code.
-func (s *Store) CreateDevice(githubDevCode, userCode, verificationURI string, expiresAt time.Time, interval int) (string, error) {
+func (s *Store) CreateDevice(githubDevCode, userCode, verificationURI string, expiresAt time.Time, interval int, audience string) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", err
@@ -193,6 +197,7 @@ func (s *Store) CreateDevice(githubDevCode, userCode, verificationURI string, ex
 		VerificationURI: verificationURI,
 		ExpiresAt:       expiresAt,
 		Interval:        interval,
+		Audience:        audience,
 		Status:          devicePending,
 	}
 	return code, nil
@@ -287,12 +292,12 @@ func (s *Store) ReleaseDevicePolling(internalCode string) {
 // (MCP_GATEWAY_TOKEN_STORE_PATH is set), the associated access token value is
 // written to disk in the .refresh sibling file (mode 0600); see the
 // MCP_GATEWAY_TOKEN_STORE_PATH documentation for security considerations.
-func (s *Store) CreateRefreshToken(accessToken string, ttl time.Duration) (string, error) {
+func (s *Store) CreateRefreshToken(accessToken, audience string, ttl time.Duration) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", fmt.Errorf("generating refresh token: %w", err)
 	}
-	if err := s.refreshStore.Save(code, accessToken, time.Now().Add(ttl)); err != nil {
+	if err := s.refreshStore.Save(code, accessToken, audience, time.Now().Add(ttl)); err != nil {
 		return "", fmt.Errorf("saving refresh token: %w", err)
 	}
 	return code, nil
@@ -305,7 +310,7 @@ func (s *Store) CreateRefreshToken(accessToken string, ttl time.Duration) (strin
 func (s *Store) UseRefreshToken(refreshToken string) (string, error) {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
-	accessToken, _, ok := s.refreshStore.Lookup(refreshToken)
+	accessToken, _, _, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
 		return "", fmt.Errorf("refresh token not found or expired")
 	}
@@ -320,7 +325,7 @@ func (s *Store) UseRefreshToken(refreshToken string) (string, error) {
 // when the token is unknown or has expired.  Use ConsumeRefreshToken to
 // delete the token only after the full rotation has succeeded.
 func (s *Store) PeekRefreshToken(refreshToken string) (string, error) {
-	accessToken, _, ok := s.refreshStore.Lookup(refreshToken)
+	accessToken, _, _, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
 		return "", fmt.Errorf("refresh token not found or expired")
 	}
@@ -341,40 +346,54 @@ func (s *Store) ConsumeRefreshToken(refreshToken string) {
 // receive an error here, preventing double-rotation.  On any subsequent
 // failure in the rotation flow, call RestoreRefreshToken to put the token
 // back so the client can retry.
-func (s *Store) ReserveRefreshToken(refreshToken string) (string, time.Time, error) {
+func (s *Store) ReserveRefreshToken(refreshToken string) (string, string, time.Time, error) {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
-	accessToken, expiresAt, ok := s.refreshStore.Lookup(refreshToken)
+	accessToken, audience, expiresAt, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
-		return "", time.Time{}, fmt.Errorf("refresh token not found or expired")
+		return "", "", time.Time{}, fmt.Errorf("refresh token not found or expired")
 	}
 	if err := s.refreshStore.Delete(refreshToken); err != nil {
-		return "", time.Time{}, fmt.Errorf("%w: %w", ErrRefreshTokenDeleteFailed, err)
+		return "", "", time.Time{}, fmt.Errorf("%w: %w", ErrRefreshTokenDeleteFailed, err)
 	}
-	return accessToken, expiresAt, nil
+	return accessToken, audience, expiresAt, nil
 }
 
 // RestoreRefreshToken puts a previously reserved refresh token back into the
 // store.  Call this when the rotation flow fails after ReserveRefreshToken so
 // that the client can retry without full re-authentication.
-func (s *Store) RestoreRefreshToken(refreshToken, accessToken string, expiresAt time.Time) {
-	if err := s.refreshStore.Save(refreshToken, accessToken, expiresAt); err != nil {
+func (s *Store) RestoreRefreshToken(refreshToken, accessToken, audience string, expiresAt time.Time) {
+	if err := s.refreshStore.Save(refreshToken, accessToken, audience, expiresAt); err != nil {
 		slog.Warn("refresh token restore failed", "err", err)
 	}
 }
 
-// CacheToken records that token maps to subject (e.g. GitHub login) and is valid
-// for tokensTTL from now. The entry survives process restarts when a persistent
+// RegisterTokenAudience records the audience granted to a newly issued token.
+// The subject may be filled later after the first provider validation.
+func (s *Store) RegisterTokenAudience(token, audience string) {
+	s.saveTokenRecord(token, "", audience)
+}
+
+// CacheToken records that token maps to subject (e.g. GitHub login) and merges
+// any supplied audience. The entry survives process restarts when a persistent
 // TokenStore is configured.
-func (s *Store) CacheToken(token, subject string) {
-	if err := s.tokens.Save(token, subject, time.Now().Add(s.tokensTTL)); err != nil {
+func (s *Store) CacheToken(token, subject, audience string) {
+	s.saveTokenRecord(token, subject, audience)
+}
+
+func (s *Store) saveTokenRecord(token, subject, audience string) {
+	var audiences []string
+	if audience != "" {
+		audiences = []string{audience}
+	}
+	if err := s.tokens.Save(token, subject, audiences, time.Now().Add(s.tokensTTL)); err != nil {
 		// Non-fatal: next request will re-validate against the upstream provider.
 		slog.Warn("token store save failed", "err", err)
 	}
 }
 
-// LookupToken returns (subject, true) if token is cached and not expired.
-func (s *Store) LookupToken(token string) (string, bool) {
+// LookupToken returns cached metadata if token is known and not expired.
+func (s *Store) LookupToken(token string) (TokenRecord, bool) {
 	return s.tokens.Lookup(token)
 }
 

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -10,7 +10,7 @@ import (
 func TestStoreSessionLifecycle(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	s.SaveSession("state1", "http://localhost/cb", "")
+	s.SaveSession("state1", "http://localhost/cb", "", "https://gw.example/mcp")
 	if !s.HasSession("state1") {
 		t.Fatal("expected session to exist")
 	}
@@ -21,7 +21,7 @@ func TestStoreSessionLifecycle(t *testing.T) {
 
 func TestStoreCompleteCallback(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state2", "http://localhost/cb", "")
+	s.SaveSession("state2", "http://localhost/cb", "", "https://gw.example/mcp")
 
 	code, err := s.CompleteCallback("state2", "token123", "repo,user")
 	if err != nil {
@@ -42,6 +42,9 @@ func TestStoreCompleteCallback(t *testing.T) {
 	if sess.Scope != "repo,user" {
 		t.Errorf("scope: got %q, want %q", sess.Scope, "repo,user")
 	}
+	if sess.Audience != "https://gw.example/mcp" {
+		t.Errorf("audience: got %q", sess.Audience)
+	}
 }
 
 func TestStoreCompleteCallbackUnknownState(t *testing.T) {
@@ -54,18 +57,21 @@ func TestStoreCompleteCallbackUnknownState(t *testing.T) {
 
 func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state3", "http://localhost/cb", "")
+	s.SaveSession("state3", "http://localhost/cb", "", "https://gw.example/mcp")
 
 	code, _ := s.CompleteCallback("state3", "tok", "")
-	token, _, err := s.ExchangeCode(code, "http://localhost/cb", "")
+	token, _, audience, err := s.ExchangeCode(code, "http://localhost/cb", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode: %v", err)
 	}
 	if token != "tok" {
 		t.Errorf("token: got %q, want %q", token, "tok")
 	}
+	if audience != "https://gw.example/mcp" {
+		t.Errorf("audience: got %q", audience)
+	}
 
-	_, _, err = s.ExchangeCode(code, "http://localhost/cb", "")
+	_, _, _, err = s.ExchangeCode(code, "http://localhost/cb", "")
 	if err == nil {
 		t.Fatal("expected error on second exchange (one-time use)")
 	}
@@ -73,10 +79,10 @@ func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 
 func TestStoreExchangeCodeRedirectURIMismatch(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state4", "http://localhost/cb", "")
+	s.SaveSession("state4", "http://localhost/cb", "", "https://gw.example/mcp")
 
 	code, _ := s.CompleteCallback("state4", "tok", "")
-	_, _, err := s.ExchangeCode(code, "http://localhost/other", "")
+	_, _, _, err := s.ExchangeCode(code, "http://localhost/other", "")
 	if err == nil {
 		t.Fatal("expected error for redirect_uri mismatch")
 	}
@@ -88,18 +94,18 @@ func TestStorePKCE(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state5", "http://localhost/cb", challenge)
+	s.SaveSession("state5", "http://localhost/cb", challenge, "https://gw.example/mcp")
 	code, _ := s.CompleteCallback("state5", "tok", "")
 
 	// Wrong verifier: code is NOT consumed on PKCE failure so we can retry.
 	wrongVerifier := "wrongverifier_wrongverifier_wrongverifier_wrong"
-	_, _, err := s.ExchangeCode(code, "http://localhost/cb", wrongVerifier)
+	_, _, _, err := s.ExchangeCode(code, "http://localhost/cb", wrongVerifier)
 	if err == nil {
 		t.Fatal("expected PKCE failure with wrong verifier")
 	}
 
 	// Correct verifier should succeed.
-	_, _, err = s.ExchangeCode(code, "http://localhost/cb", verifier)
+	_, _, _, err = s.ExchangeCode(code, "http://localhost/cb", verifier)
 	if err != nil {
 		t.Fatalf("PKCE exchange with correct verifier: %v", err)
 	}
@@ -109,10 +115,10 @@ func TestStorePKCEInvalidVerifierLength(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state6", "http://localhost/cb", challenge)
+	s.SaveSession("state6", "http://localhost/cb", challenge, "https://gw.example/mcp")
 	code, _ := s.CompleteCallback("state6", "tok", "")
 
-	_, _, err := s.ExchangeCode(code, "http://localhost/cb", "tooshort")
+	_, _, _, err := s.ExchangeCode(code, "http://localhost/cb", "tooshort")
 	if err == nil {
 		t.Fatal("expected error for verifier that is too short")
 	}
@@ -122,7 +128,7 @@ func TestStoreDeviceLifecycle(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	code, err := s.CreateDevice("gh-dev-code", "ABCD-1234", "https://github.com/login/device", expiresAt, 5)
+	code, err := s.CreateDevice("gh-dev-code", "ABCD-1234", "https://github.com/login/device", expiresAt, 5, "https://gw.example/mcp")
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}
@@ -139,6 +145,9 @@ func TestStoreDeviceLifecycle(t *testing.T) {
 	}
 	if d.Status != devicePending {
 		t.Errorf("status: got %v, want pending", d.Status)
+	}
+	if d.Audience != "https://gw.example/mcp" {
+		t.Errorf("audience: got %q", d.Audience)
 	}
 
 	consumed, ok := s.AuthorizeAndConsumeDevice(code, "gha_token", "repo,user")
@@ -157,7 +166,7 @@ func TestStoreDeviceDeny(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	code, err := s.CreateDevice("gh-dev", "WXYZ-5678", "https://github.com/login/device", expiresAt, 5)
+	code, err := s.CreateDevice("gh-dev", "WXYZ-5678", "https://github.com/login/device", expiresAt, 5, "https://gw.example/mcp")
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}
@@ -184,13 +193,16 @@ func TestStoreDeviceNotFound(t *testing.T) {
 func TestTokenCache(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	s.CacheToken("tok1", "alice")
-	login, ok := s.LookupToken("tok1")
+	s.CacheToken("tok1", "alice", "https://gw.example/mcp")
+	rec, ok := s.LookupToken("tok1")
 	if !ok {
 		t.Fatal("expected cache hit")
 	}
-	if login != "alice" {
-		t.Errorf("login: got %q, want %q", login, "alice")
+	if rec.Subject != "alice" {
+		t.Errorf("login: got %q, want %q", rec.Subject, "alice")
+	}
+	if !rec.HasAudience("https://gw.example/mcp") {
+		t.Errorf("audiences: got %#v", rec.Audiences)
 	}
 
 	s.InvalidateCachedToken("tok1")
@@ -204,42 +216,44 @@ func TestTokenCache(t *testing.T) {
 // the error-logging paths in CacheToken and InvalidateCachedToken.
 type errTokenStore struct{ mem *memTokenStore }
 
-func (e *errTokenStore) Save(_, _ string, _ time.Time) error { return fmt.Errorf("injected save error") }
-func (e *errTokenStore) Lookup(token string) (string, bool)  { return e.mem.Lookup(token) }
-func (e *errTokenStore) Delete(_ string) error               { return fmt.Errorf("injected delete error") }
-func (e *errTokenStore) Sweep() error                        { return e.mem.Sweep() }
+func (e *errTokenStore) Save(_, _ string, _ []string, _ time.Time) error {
+	return fmt.Errorf("injected save error")
+}
+func (e *errTokenStore) Lookup(token string) (TokenRecord, bool) { return e.mem.Lookup(token) }
+func (e *errTokenStore) Delete(_ string) error                   { return fmt.Errorf("injected delete error") }
+func (e *errTokenStore) Sweep() error                            { return e.mem.Sweep() }
 
 // TestNewStoreNilTokenStore verifies that a nil TokenStore defaults to memTokenStore.
 func TestNewStoreNilTokenStore(t *testing.T) {
-s := NewStore(10*time.Minute, 5*time.Minute, nil)
-s.CacheToken("tok-nil", "niluser")
-if _, ok := s.LookupToken("tok-nil"); !ok {
-t.Fatal("expected cache hit: nil TokenStore should default to mem store")
-}
+	s := NewStore(10*time.Minute, 5*time.Minute, nil)
+	s.CacheToken("tok-nil", "niluser", "https://gw.example/mcp")
+	if _, ok := s.LookupToken("tok-nil"); !ok {
+		t.Fatal("expected cache hit: nil TokenStore should default to mem store")
+	}
 }
 
 // TestCacheTokenSaveError verifies that CacheToken logs (does not panic) when the
 // underlying store returns a Save error.
 func TestCacheTokenSaveError(t *testing.T) {
-ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
-s := NewStore(10*time.Minute, 5*time.Minute, ts)
-// Must not panic; error is logged via slog.Warn.
-s.CacheToken("tok-err", "user")
+	ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
+	s := NewStore(10*time.Minute, 5*time.Minute, ts)
+	// Must not panic; error is logged via slog.Warn.
+	s.CacheToken("tok-err", "user", "https://gw.example/mcp")
 }
 
 // TestInvalidateCachedTokenDeleteError verifies that InvalidateCachedToken logs
 // (does not panic) when the underlying store returns a Delete error.
 func TestInvalidateCachedTokenDeleteError(t *testing.T) {
-ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
-s := NewStore(10*time.Minute, 5*time.Minute, ts)
-// Must not panic; error is logged via slog.Warn.
-s.InvalidateCachedToken("tok-err")
+	ts := &errTokenStore{mem: NewMemTokenStore().(*memTokenStore)}
+	s := NewStore(10*time.Minute, 5*time.Minute, ts)
+	// Must not panic; error is logged via slog.Warn.
+	s.InvalidateCachedToken("tok-err")
 }
 
 func TestCreateAndUseRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("access-token-abc", time.Hour)
+	rt, err := s.CreateRefreshToken("access-token-abc", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -259,7 +273,7 @@ func TestCreateAndUseRefreshToken(t *testing.T) {
 func TestUseRefreshTokenIsOneTimeUse(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -275,7 +289,7 @@ func TestUseRefreshTokenIsOneTimeUse(t *testing.T) {
 func TestUseRefreshTokenExpired(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", -time.Second) // already expired
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", -time.Second) // already expired
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -296,7 +310,7 @@ func TestUseRefreshTokenUnknown(t *testing.T) {
 func TestPeekRefreshTokenDoesNotConsume(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -321,7 +335,7 @@ func TestPeekRefreshTokenDoesNotConsume(t *testing.T) {
 func TestConsumeRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -342,20 +356,23 @@ func TestConsumeRefreshTokenNoOp(t *testing.T) {
 func TestReserveRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("access-tok", time.Hour)
+	rt, err := s.CreateRefreshToken("access-tok", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
 
-	got, _, err := s.ReserveRefreshToken(rt)
+	got, audience, _, err := s.ReserveRefreshToken(rt)
 	if err != nil {
 		t.Fatalf("ReserveRefreshToken: %v", err)
 	}
 	if got != "access-tok" {
 		t.Errorf("access token: got %q, want %q", got, "access-tok")
 	}
+	if audience != "https://gw.example/mcp" {
+		t.Errorf("audience: got %q", audience)
+	}
 	// Token must be gone after reservation (concurrent callers must fail).
-	if _, _, err2 := s.ReserveRefreshToken(rt); err2 == nil {
+	if _, _, _, err2 := s.ReserveRefreshToken(rt); err2 == nil {
 		t.Fatal("expected error on second ReserveRefreshToken (atomic one-time removal)")
 	}
 }
@@ -363,11 +380,11 @@ func TestReserveRefreshToken(t *testing.T) {
 func TestReserveRefreshTokenExpired(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", -time.Second) // already expired
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", -time.Second) // already expired
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
-	if _, _, err := s.ReserveRefreshToken(rt); err == nil {
+	if _, _, _, err := s.ReserveRefreshToken(rt); err == nil {
 		t.Fatal("expected error for expired refresh token")
 	}
 }
@@ -375,17 +392,17 @@ func TestReserveRefreshTokenExpired(t *testing.T) {
 func TestRestoreRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok-restore", time.Hour)
+	rt, err := s.CreateRefreshToken("tok-restore", "https://gw.example/mcp", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
 
-	_, expiresAt, err := s.ReserveRefreshToken(rt)
+	_, audience, expiresAt, err := s.ReserveRefreshToken(rt)
 	if err != nil {
 		t.Fatalf("ReserveRefreshToken: %v", err)
 	}
 	// Simulate rotation failure: restore the token.
-	s.RestoreRefreshToken(rt, "tok-restore", expiresAt)
+	s.RestoreRefreshToken(rt, "tok-restore", audience, expiresAt)
 
 	// Token must be accessible again via Peek after restoration.
 	got, err := s.PeekRefreshToken(rt)
@@ -401,7 +418,7 @@ func TestAcquireDevicePollingSerializes(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	code, err := s.CreateDevice("gh-dev", "ABCD-9999", "https://github.com/login/device", expiresAt, 0)
+	code, err := s.CreateDevice("gh-dev", "ABCD-9999", "https://github.com/login/device", expiresAt, 0, "https://gw.example/mcp")
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}
@@ -428,7 +445,7 @@ func TestAcquireDevicePollingConcurrent(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	code, err := s.CreateDevice("gh-dev-concurrent", "EFGH-0001", "https://github.com/login/device", expiresAt, 0)
+	code, err := s.CreateDevice("gh-dev-concurrent", "EFGH-0001", "https://github.com/login/device", expiresAt, 0, "https://gw.example/mcp")
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}
@@ -487,7 +504,7 @@ func TestAcquireDevicePollingEnforcesInterval(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	expiresAt := time.Now().Add(15 * time.Minute)
 
-	code, err := s.CreateDevice("gh-dev-interval", "IJKL-0002", "https://github.com/login/device", expiresAt, 5)
+	code, err := s.CreateDevice("gh-dev-interval", "IJKL-0002", "https://github.com/login/device", expiresAt, 5, "https://gw.example/mcp")
 	if err != nil {
 		t.Fatalf("CreateDevice: %v", err)
 	}

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -8,18 +8,38 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
 
-// TokenStore persists validated token → identity mappings.
+// TokenRecord is the cached metadata for an access token. Audiences is empty
+// for legacy entries written before per-route audience metadata existed.
+type TokenRecord struct {
+	Subject   string
+	Audiences []string
+}
+
+// HasAudience reports whether the token record is scoped to audience.
+func (r TokenRecord) HasAudience(audience string) bool {
+	for _, aud := range r.Audiences {
+		if aud == audience {
+			return true
+		}
+	}
+	return false
+}
+
+// TokenStore persists access token metadata.
 // Two implementations are provided: memTokenStore (default, in-process) and
 // fileTokenStore (JSON file, survives container restarts).
 type TokenStore interface {
-	// Save records that token maps to subject and is valid until expiresAt.
-	Save(token, subject string, expiresAt time.Time) error
-	// Lookup returns the subject for a non-expired token, or ("", false).
-	Lookup(token string) (subject string, ok bool)
+	// Save records that token maps to subject/audiences and is valid until expiresAt.
+	// Re-saving an existing non-expired token merges audiences and preserves a
+	// previously cached subject when subject is empty.
+	Save(token, subject string, audiences []string, expiresAt time.Time) error
+	// Lookup returns metadata for a non-expired token, or (zero, false).
+	Lookup(token string) (TokenRecord, bool)
 	// Delete removes a single token entry immediately.
 	Delete(token string) error
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
@@ -37,6 +57,7 @@ func tokenKey(token string) string {
 
 type memEntry struct {
 	subject   string
+	audiences []string
 	expiresAt time.Time
 }
 
@@ -51,21 +72,31 @@ func NewMemTokenStore() TokenStore {
 	return &memTokenStore{entries: make(map[string]memEntry)}
 }
 
-func (m *memTokenStore) Save(token, subject string, expiresAt time.Time) error {
+func (m *memTokenStore) Save(token, subject string, audiences []string, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.entries[tokenKey(token)] = memEntry{subject: subject, expiresAt: expiresAt}
+	key := tokenKey(token)
+	entry := memEntry{}
+	if current, ok := m.entries[key]; ok && time.Now().Before(current.expiresAt) {
+		entry = current
+	}
+	if subject != "" {
+		entry.subject = subject
+	}
+	entry.audiences = mergeAudiences(entry.audiences, audiences)
+	entry.expiresAt = expiresAt
+	m.entries[key] = entry
 	return nil
 }
 
-func (m *memTokenStore) Lookup(token string) (string, bool) {
+func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	e, ok := m.entries[tokenKey(token)]
 	if !ok || time.Now().After(e.expiresAt) {
-		return "", false
+		return TokenRecord{}, false
 	}
-	return e.subject, true
+	return TokenRecord{Subject: e.subject, Audiences: cloneStrings(e.audiences)}, true
 }
 
 func (m *memTokenStore) Delete(token string) error {
@@ -93,6 +124,7 @@ func (m *memTokenStore) Sweep() error {
 // The map key is tokenKey(rawToken), so raw tokens never appear in the file.
 type fileEntry struct {
 	Subject   string    `json:"s"`
+	Audiences []string  `json:"aud,omitempty"`
 	ExpiresAt time.Time `json:"e"`
 }
 
@@ -165,21 +197,31 @@ func NewFileTokenStore(path string) (TokenStore, error) {
 	return s, nil
 }
 
-func (f *fileTokenStore) Save(token, subject string, expiresAt time.Time) error {
+func (f *fileTokenStore) Save(token, subject string, audiences []string, expiresAt time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.entries[tokenKey(token)] = fileEntry{Subject: subject, ExpiresAt: expiresAt}
+	key := tokenKey(token)
+	entry := fileEntry{}
+	if current, ok := f.entries[key]; ok && time.Now().Before(current.ExpiresAt) {
+		entry = current
+	}
+	if subject != "" {
+		entry.Subject = subject
+	}
+	entry.Audiences = mergeAudiences(entry.Audiences, audiences)
+	entry.ExpiresAt = expiresAt
+	f.entries[key] = entry
 	return f.flush()
 }
 
-func (f *fileTokenStore) Lookup(token string) (string, bool) {
+func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	e, ok := f.entries[tokenKey(token)]
 	if !ok || time.Now().After(e.ExpiresAt) {
-		return "", false
+		return TokenRecord{}, false
 	}
-	return e.Subject, true
+	return TokenRecord{Subject: e.Subject, Audiences: cloneStrings(e.Audiences)}, true
 }
 
 func (f *fileTokenStore) Delete(token string) error {
@@ -273,11 +315,11 @@ func (f *fileTokenStore) flush() error {
 // RefreshTokenStore persists gateway-issued refresh token → access token mappings.
 // Two implementations: memRefreshTokenStore (default) and fileRefreshTokenStore (JSON file).
 type RefreshTokenStore interface {
-	// Save records that refreshToken maps to accessToken and is valid until expiresAt.
-	Save(refreshToken, accessToken string, expiresAt time.Time) error
-	// Lookup returns the access token and expiry for a non-expired refresh token, or ("", zero, false).
+	// Save records that refreshToken maps to accessToken/audience and is valid until expiresAt.
+	Save(refreshToken, accessToken, audience string, expiresAt time.Time) error
+	// Lookup returns the access token, audience, and expiry for a non-expired refresh token, or ("", "", zero, false).
 	// expiresAt is returned so that RestoreRefreshToken can re-save with the original expiry on rotation failure.
-	Lookup(refreshToken string) (accessToken string, expiresAt time.Time, ok bool)
+	Lookup(refreshToken string) (accessToken, audience string, expiresAt time.Time, ok bool)
 	// Delete removes a single refresh token entry immediately.
 	Delete(refreshToken string) error
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
@@ -288,6 +330,7 @@ type RefreshTokenStore interface {
 
 type memRTEntry struct {
 	accessToken string
+	audience    string
 	expiresAt   time.Time
 }
 
@@ -302,21 +345,21 @@ func NewMemRefreshTokenStore() RefreshTokenStore {
 	return &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
 }
 
-func (m *memRefreshTokenStore) Save(refreshToken, accessToken string, expiresAt time.Time) error {
+func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience string, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.entries[tokenKey(refreshToken)] = memRTEntry{accessToken: accessToken, expiresAt: expiresAt}
+	m.entries[tokenKey(refreshToken)] = memRTEntry{accessToken: accessToken, audience: audience, expiresAt: expiresAt}
 	return nil
 }
 
-func (m *memRefreshTokenStore) Lookup(refreshToken string) (string, time.Time, bool) {
+func (m *memRefreshTokenStore) Lookup(refreshToken string) (string, string, time.Time, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	e, ok := m.entries[tokenKey(refreshToken)]
 	if !ok || time.Now().After(e.expiresAt) {
-		return "", time.Time{}, false
+		return "", "", time.Time{}, false
 	}
-	return e.accessToken, e.expiresAt, true
+	return e.accessToken, e.audience, e.expiresAt, true
 }
 
 func (m *memRefreshTokenStore) Delete(refreshToken string) error {
@@ -346,6 +389,7 @@ func (m *memRefreshTokenStore) Sweep() error {
 // the gateway must re-present it to the upstream provider on token refresh.
 type fileRTEntry struct {
 	AccessToken string    `json:"a"`
+	Audience    string    `json:"aud,omitempty"`
 	ExpiresAt   time.Time `json:"e"`
 }
 
@@ -408,12 +452,12 @@ func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	return s, nil
 }
 
-func (f *fileRefreshTokenStore) Save(refreshToken, accessToken string, expiresAt time.Time) error {
+func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience string, expiresAt time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	key := tokenKey(refreshToken)
 	prev, hasPrev := f.entries[key]
-	f.entries[key] = fileRTEntry{AccessToken: accessToken, ExpiresAt: expiresAt}
+	f.entries[key] = fileRTEntry{AccessToken: accessToken, Audience: audience, ExpiresAt: expiresAt}
 	if err := f.flush(); err != nil {
 		if hasPrev {
 			f.entries[key] = prev
@@ -425,14 +469,14 @@ func (f *fileRefreshTokenStore) Save(refreshToken, accessToken string, expiresAt
 	return nil
 }
 
-func (f *fileRefreshTokenStore) Lookup(refreshToken string) (string, time.Time, bool) {
+func (f *fileRefreshTokenStore) Lookup(refreshToken string) (string, string, time.Time, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	e, ok := f.entries[tokenKey(refreshToken)]
 	if !ok || time.Now().After(e.ExpiresAt) {
-		return "", time.Time{}, false
+		return "", "", time.Time{}, false
 	}
-	return e.AccessToken, e.ExpiresAt, true
+	return e.AccessToken, e.Audience, e.ExpiresAt, true
 }
 
 func (f *fileRefreshTokenStore) Delete(refreshToken string) error {
@@ -520,4 +564,33 @@ func (f *fileRefreshTokenStore) flush() error {
 		_ = os.Remove(backup)
 	}
 	return nil
+}
+
+func mergeAudiences(existing, additions []string) []string {
+	out := cloneStrings(existing)
+	seen := make(map[string]struct{}, len(out)+len(additions))
+	for _, aud := range out {
+		seen[aud] = struct{}{}
+	}
+	for _, aud := range additions {
+		aud = strings.TrimRight(strings.TrimSpace(aud), "/")
+		if aud == "" {
+			continue
+		}
+		if _, ok := seen[aud]; ok {
+			continue
+		}
+		seen[aud] = struct{}{}
+		out = append(out, aud)
+	}
+	return out
+}
+
+func cloneStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
 }

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -14,15 +14,18 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 	t.Helper()
 
 	// Save and Lookup — hit
-	if err := ts.Save("tok1", "alice", time.Now().Add(time.Hour)); err != nil {
+	if err := ts.Save("tok1", "alice", []string{"https://gw.example/mcp"}, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	subj, ok := ts.Lookup("tok1")
+	rec, ok := ts.Lookup("tok1")
 	if !ok {
 		t.Fatal("Lookup: expected hit after Save")
 	}
-	if subj != "alice" {
-		t.Errorf("Lookup: subject got %q, want %q", subj, "alice")
+	if rec.Subject != "alice" {
+		t.Errorf("Lookup: subject got %q, want %q", rec.Subject, "alice")
+	}
+	if !rec.HasAudience("https://gw.example/mcp") {
+		t.Errorf("Lookup: audiences got %#v, want https://gw.example/mcp", rec.Audiences)
 	}
 
 	// Lookup — miss for unknown token
@@ -39,7 +42,7 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 	}
 
 	// Expired entries are not returned by Lookup
-	if err := ts.Save("tok2", "bob", time.Now().Add(-time.Second)); err != nil {
+	if err := ts.Save("tok2", "bob", nil, time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save expired: %v", err)
 	}
 	if _, ok := ts.Lookup("tok2"); ok {
@@ -63,7 +66,7 @@ func TestMemTokenStoreMultiple(t *testing.T) {
 
 	for i, name := range []string{"alice", "bob", "carol"} {
 		token := string(rune('a' + i))
-		if err := ts.Save(token, name, time.Now().Add(time.Hour)); err != nil {
+		if err := ts.Save(token, name, nil, time.Now().Add(time.Hour)); err != nil {
 			t.Fatalf("Save %q: %v", token, err)
 		}
 	}
@@ -74,8 +77,8 @@ func TestMemTokenStoreMultiple(t *testing.T) {
 		if !ok {
 			t.Fatalf("Lookup %q: expected hit", token)
 		}
-		if got != want {
-			t.Errorf("Lookup %q: got %q, want %q", token, got, want)
+		if got.Subject != want {
+			t.Errorf("Lookup %q: got %q, want %q", token, got.Subject, want)
 		}
 	}
 }
@@ -105,7 +108,7 @@ func TestFileTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial NewFileTokenStore: %v", err)
 	}
-	if err := ts1.Save("persist-tok", "dave", time.Now().Add(time.Hour)); err != nil {
+	if err := ts1.Save("persist-tok", "dave", []string{"https://gw.example/mcp"}, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -114,12 +117,15 @@ func TestFileTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileTokenStore: %v", err)
 	}
-	subj, ok := ts2.Lookup("persist-tok")
+	rec, ok := ts2.Lookup("persist-tok")
 	if !ok {
 		t.Fatal("after reload: expected cache hit for previously saved token")
 	}
-	if subj != "dave" {
-		t.Errorf("after reload: subject got %q, want %q", subj, "dave")
+	if rec.Subject != "dave" {
+		t.Errorf("after reload: subject got %q, want %q", rec.Subject, "dave")
+	}
+	if !rec.HasAudience("https://gw.example/mcp") {
+		t.Errorf("after reload: audiences got %#v", rec.Audiences)
 	}
 }
 
@@ -133,7 +139,7 @@ func TestFileTokenStoreExpiredNotLoaded(t *testing.T) {
 		t.Fatalf("initial NewFileTokenStore: %v", err)
 	}
 	// Save an entry that is already expired.
-	if err := ts1.Save("expired-tok", "eve", time.Now().Add(-time.Second)); err != nil {
+	if err := ts1.Save("expired-tok", "eve", nil, time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -158,7 +164,7 @@ func TestFileTokenStoreFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileTokenStore: %v", err)
 	}
-	if err := ts.Save("tok", "frank", time.Now().Add(time.Hour)); err != nil {
+	if err := ts.Save("tok", "frank", nil, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -224,10 +230,10 @@ func TestFileTokenStoreSweepWritesToDisk(t *testing.T) {
 		t.Fatalf("NewFileTokenStore: %v", err)
 	}
 	// One valid, one expired.
-	if err := ts1.Save("valid-tok", "grace", time.Now().Add(time.Hour)); err != nil {
+	if err := ts1.Save("valid-tok", "grace", nil, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save valid token: %v", err)
 	}
-	if err := ts1.Save("stale-tok", "harry", time.Now().Add(-time.Second)); err != nil {
+	if err := ts1.Save("stale-tok", "harry", nil, time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save stale token: %v", err)
 	}
 	if err := ts1.Sweep(); err != nil {
@@ -254,22 +260,25 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 
 	// Save and Lookup — hit
 	exp := time.Now().Add(time.Hour)
-	if err := rts.Save("rt1", "access-tok-1", exp); err != nil {
+	if err := rts.Save("rt1", "access-tok-1", "https://gw.example/mcp", exp); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, gotExp, ok := rts.Lookup("rt1")
+	got, gotAudience, gotExp, ok := rts.Lookup("rt1")
 	if !ok {
 		t.Fatal("Lookup: expected hit after Save")
 	}
 	if got != "access-tok-1" {
 		t.Errorf("Lookup: accessToken got %q, want %q", got, "access-tok-1")
 	}
+	if gotAudience != "https://gw.example/mcp" {
+		t.Errorf("Lookup: audience got %q, want %q", gotAudience, "https://gw.example/mcp")
+	}
 	if gotExp.IsZero() {
 		t.Error("Lookup: expiresAt should not be zero")
 	}
 
 	// Lookup — miss for unknown token
-	if _, _, ok := rts.Lookup("unknown"); ok {
+	if _, _, _, ok := rts.Lookup("unknown"); ok {
 		t.Error("Lookup: expected miss for unknown token")
 	}
 
@@ -277,15 +286,15 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if err := rts.Delete("rt1"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if _, _, ok := rts.Lookup("rt1"); ok {
+	if _, _, _, ok := rts.Lookup("rt1"); ok {
 		t.Error("Lookup: expected miss after Delete")
 	}
 
 	// Expired entries are not returned by Lookup
-	if err := rts.Save("rt2", "access-tok-2", time.Now().Add(-time.Second)); err != nil {
+	if err := rts.Save("rt2", "access-tok-2", "", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save expired: %v", err)
 	}
-	if _, _, ok := rts.Lookup("rt2"); ok {
+	if _, _, _, ok := rts.Lookup("rt2"); ok {
 		t.Error("Lookup: expected miss for expired entry")
 	}
 
@@ -326,7 +335,7 @@ func TestFileRefreshTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("persist-rt", "access-tok-persist", time.Now().Add(time.Hour)); err != nil {
+	if err := rts1.Save("persist-rt", "access-tok-persist", "https://gw.example/mcp", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -335,12 +344,15 @@ func TestFileRefreshTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	accessTok, _, ok := rts2.Lookup("persist-rt")
+	accessTok, audience, _, ok := rts2.Lookup("persist-rt")
 	if !ok {
 		t.Fatal("after reload: expected hit for previously saved refresh token")
 	}
 	if accessTok != "access-tok-persist" {
 		t.Errorf("after reload: accessToken got %q, want %q", accessTok, "access-tok-persist")
+	}
+	if audience != "https://gw.example/mcp" {
+		t.Errorf("after reload: audience got %q", audience)
 	}
 }
 
@@ -353,7 +365,7 @@ func TestFileRefreshTokenStoreExpiredNotLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("expired-rt", "access-tok-old", time.Now().Add(-time.Second)); err != nil {
+	if err := rts1.Save("expired-rt", "access-tok-old", "", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -362,7 +374,7 @@ func TestFileRefreshTokenStoreExpiredNotLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	if _, _, ok := rts2.Lookup("expired-rt"); ok {
+	if _, _, _, ok := rts2.Lookup("expired-rt"); ok {
 		t.Error("after reload: expired refresh token should not be returned")
 	}
 }
@@ -378,7 +390,7 @@ func TestFileRefreshTokenStoreFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts.Save("rt", "at", time.Now().Add(time.Hour)); err != nil {
+	if err := rts.Save("rt", "at", "", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -459,10 +471,10 @@ func TestFileRefreshTokenStoreSweepWritesToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("valid-rt", "valid-at", time.Now().Add(time.Hour)); err != nil {
+	if err := rts1.Save("valid-rt", "valid-at", "", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save valid: %v", err)
 	}
-	if err := rts1.Save("stale-rt", "stale-at", time.Now().Add(-time.Second)); err != nil {
+	if err := rts1.Save("stale-rt", "stale-at", "", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save stale: %v", err)
 	}
 	if err := rts1.Sweep(); err != nil {
@@ -474,10 +486,10 @@ func TestFileRefreshTokenStoreSweepWritesToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	if _, _, ok := rts2.Lookup("valid-rt"); !ok {
+	if _, _, _, ok := rts2.Lookup("valid-rt"); !ok {
 		t.Error("after sweep+reload: valid refresh token should still be present")
 	}
-	if _, _, ok := rts2.Lookup("stale-rt"); ok {
+	if _, _, _, ok := rts2.Lookup("stale-rt"); ok {
 		t.Error("after sweep+reload: stale refresh token should have been removed")
 	}
 }
@@ -492,11 +504,11 @@ type alwaysFailRefreshStore struct{}
 
 var errInjectedStoreFailure = errors.New("test: injected store failure")
 
-func (f *alwaysFailRefreshStore) Save(_, _ string, _ time.Time) error {
+func (f *alwaysFailRefreshStore) Save(_, _, _ string, _ time.Time) error {
 	return errInjectedStoreFailure
 }
-func (f *alwaysFailRefreshStore) Lookup(_ string) (string, time.Time, bool) {
-	return "", time.Time{}, false
+func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, time.Time, bool) {
+	return "", "", time.Time{}, false
 }
 func (f *alwaysFailRefreshStore) Delete(_ string) error { return errInjectedStoreFailure }
 func (f *alwaysFailRefreshStore) Sweep() error          { return nil }
@@ -506,7 +518,7 @@ func (f *alwaysFailRefreshStore) Sweep() error          { return nil }
 func TestCreateRefreshTokenSaveError(t *testing.T) {
 	store := NewStore(time.Minute, time.Minute, NewMemTokenStore(),
 		WithRefreshTokenStore(&alwaysFailRefreshStore{}))
-	_, err := store.CreateRefreshToken("access-tok", time.Minute)
+	_, err := store.CreateRefreshToken("access-tok", "https://gw.example/mcp", time.Minute)
 	if err == nil {
 		t.Fatal("expected Save error, got nil")
 	}
@@ -527,5 +539,5 @@ func TestRestoreRefreshTokenSaveError(t *testing.T) {
 	store := NewStore(time.Minute, time.Minute, NewMemTokenStore(),
 		WithRefreshTokenStore(&alwaysFailRefreshStore{}))
 	// Save always fails; RestoreRefreshToken must log and return without panicking.
-	store.RestoreRefreshToken("refresh-tok", "access-tok", time.Now().Add(time.Hour))
+	store.RestoreRefreshToken("refresh-tok", "access-tok", "https://gw.example/mcp", time.Now().Add(time.Hour))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,9 @@ type GatewayConfig struct {
 	// TrustedProxies is a CIDR allowlist for reverse proxies whose
 	// X-Forwarded-* headers may be reflected into downstream requests.
 	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
+	// TokenAudienceStrict rejects tokens that lack per-route audience metadata.
+	// Leave false during the migration grace period for tokens issued before #57.
+	TokenAudienceStrict bool `yaml:"token_audience_strict,omitempty"`
 }
 
 // LoadConfig reads AppConfig from path.

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -21,7 +21,7 @@ const ContextKeyToken contextKey = "auth_token"
 
 // TokenValidator is implemented by auth.Handler.
 type TokenValidator interface {
-	ValidateToken(ctx context.Context, token string) (string, error)
+	ValidateToken(ctx context.Context, token, audience string) (string, error)
 }
 
 type upstreamErrorer interface {
@@ -32,6 +32,7 @@ type upstreamErrorer interface {
 type authOptions struct {
 	baseURL             string
 	resourceMetadataURL string
+	audience            string
 }
 
 // AuthOption configures the Auth middleware.
@@ -59,6 +60,11 @@ func WithResourceMetadataURL(u string) AuthOption {
 	return func(o *authOptions) { o.resourceMetadataURL = strings.TrimSpace(u) }
 }
 
+// WithAudience sets the expected token audience for the protected resource.
+func WithAudience(u string) AuthOption {
+	return func(o *authOptions) { o.audience = strings.TrimRight(strings.TrimSpace(u), "/") }
+}
+
 // Auth returns a middleware that validates Bearer tokens via the configured
 // OAuth provider.
 func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler {
@@ -67,6 +73,7 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 		opt(&options)
 	}
 	resourceMetadataURL := resolveResourceMetadataURL(options)
+	audience := resolveAudience(options)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractBearer(r)
@@ -77,7 +84,7 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 				return
 			}
 
-			subject, err := v.ValidateToken(r.Context(), token)
+			subject, err := v.ValidateToken(r.Context(), token, audience)
 			if err != nil {
 				var ue upstreamErrorer
 				if errors.As(err, &ue) {
@@ -102,6 +109,16 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func resolveAudience(o authOptions) string {
+	if o.audience != "" {
+		return o.audience
+	}
+	if o.baseURL != "" {
+		return strings.TrimRight(o.baseURL, "/")
+	}
+	return ""
 }
 
 // resolveResourceMetadataURL chooses the resource_metadata URL for the

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -28,6 +28,12 @@ type upstreamErrorer interface {
 	IsUpstreamError() bool
 }
 
+// audienceErrorer is satisfied by auth.audienceCheckError, which wraps
+// ErrTokenAudienceMismatch / ErrTokenAudienceMissing.
+type audienceErrorer interface {
+	IsAudienceError() bool
+}
+
 // authOptions holds optional configuration for the Auth middleware.
 type authOptions struct {
 	baseURL             string
@@ -98,6 +104,13 @@ func Auth(v TokenValidator, opts ...AuthOption) func(http.Handler) http.Handler 
 					return
 				}
 				slog.Warn("auth failed", "err", err, "path", r.URL.Path)
+				var ae audienceErrorer
+				if errors.As(err, &ae) {
+					writeUnauthorized(w, "invalid_token",
+						"Access token is not valid for this resource. Re-authenticate with the correct resource scope.",
+						resourceMetadataURL)
+					return
+				}
 				writeUnauthorized(w, "invalid_token",
 					"Access token expired or invalid. Re-authenticate via the gateway OAuth flow.",
 					resourceMetadataURL)

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -12,11 +12,15 @@ import (
 
 // mockValidator implements TokenValidator for testing.
 type mockValidator struct {
-	login string
-	err   error
+	login       string
+	err         error
+	gotToken    string
+	gotAudience string
 }
 
-func (m *mockValidator) ValidateToken(_ context.Context, _ string) (string, error) {
+func (m *mockValidator) ValidateToken(_ context.Context, token, audience string) (string, error) {
+	m.gotToken = token
+	m.gotAudience = audience
 	return m.login, m.err
 }
 
@@ -95,6 +99,29 @@ func TestAuthValidToken(t *testing.T) {
 	}
 	if gotToken != "my-token" {
 		t.Errorf("token in context: got %q, want %q", gotToken, "my-token")
+	}
+}
+
+func TestAuthPassesExpectedAudience(t *testing.T) {
+	validator := &mockValidator{login: "alice"}
+	h := Auth(validator,
+		WithBaseURL("https://gateway.example.com"),
+		WithAudience("https://gateway.example.com/mcp/copilot-review"),
+	)(http.HandlerFunc(okHandler))
+	r := httptest.NewRequest(http.MethodGet, "/mcp/copilot-review", nil)
+	r.Header.Set("Authorization", "Bearer my-token")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusOK)
+	}
+	if validator.gotToken != "my-token" {
+		t.Errorf("token: got %q, want my-token", validator.gotToken)
+	}
+	if validator.gotAudience != "https://gateway.example.com/mcp/copilot-review" {
+		t.Errorf("audience: got %q", validator.gotAudience)
 	}
 }
 

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -14,7 +14,7 @@ import (
 // testValidator is a stub TokenValidator for integration-level tests.
 type testValidator struct{ login string }
 
-func (v *testValidator) ValidateToken(_ context.Context, _ string) (string, error) {
+func (v *testValidator) ValidateToken(_ context.Context, _, _ string) (string, error) {
 	return v.login, nil
 }
 


### PR DESCRIPTION
## Summary

Completes [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) (PR-C of 3) and closes [#57](https://github.com/scottlz0310/mcp-gateway/issues/57).

Implements RFC 8707 §2 \esource\ parameter on \grant_type=refresh_token\, plus the full opaque-token audience tracking infrastructure it depends on.

## Changes

### RFC 8707 on refresh_token
- \grant_type=refresh_token\ now accepts an optional \esource\ parameter
- Narrowing (gateway-wide → per-route sub-path) is **permitted**
- Widening, cross-route change, and unknown resources are rejected with \invalid_target\
- Consumed refresh token is restored on failure so the client can retry
- Legacy tokens with empty stored audience accept any registered resource (grace period)

### Token audience tracking (infrastructure)
- \TokenRecord{Subject, Audiences []string}\ — opaque token now carries audience metadata
- \TokenAudienceStrict\ config flag (\MCP_GATEWAY_TOKEN_AUDIENCE_STRICT\, \	oken_audience_strict:\)
  - **false** (default): tokens without audience metadata accepted with warning log
  - **true**: strict enforcement — enable 90 days after rollout when all old tokens have expired

### Helpers
- \isSubAudience(requested, original string) bool\ — narrowing comparison; empty original → legacy grace

## Tests
6 new test cases for refresh+resource:
| Test | Scenario | Expected |
|---|---|---|
| \TestTokenRefreshResourceSameAudience\ | resource = original | 200 |
| \TestTokenRefreshResourceNarrowing\ | gateway-wide → per-route | 200 |
| \TestTokenRefreshResourceCrossRoute\ | route-a → route-b | 400 invalid_target |
| \TestTokenRefreshResourceWidening\ | per-route → gateway-wide | 400 invalid_target |
| \TestTokenRefreshResourceUnknown\ | unregistered resource | 400 + token restored |
| \TestTokenRefreshResourceLegacyToken\ | empty audience (legacy) | 200 |

## Migration
Enable \	oken_audience_strict: true\ **90 days** after the last deployment without audience tracking (matches default refresh token TTL). Until then, tokens without audience metadata are accepted with a warning log.

## Checklist
- [x] \go test ./...\ passes
- [x] \go build ./...\ passes
- [x] CHANGELOG.md and CHANGELOG.ja.md updated
