### PR TITLE
ci: harden pipeline — govulncheck, golangci-lint config, coverage threshold (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         run: govulncheck ./...
 
@@ -51,7 +51,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, govulncheck]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,21 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          install-mode: goinstall
+          version: v2.12.2
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - revive
+  settings:
+    revive:
+      rules:
+        - name: package-comments
+          disabled: true
+        - name: exported
+          disabled: true
+        - name: unused-parameter
+          disabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 ### CI / Infrastructure
 
 - CI pipeline hardening ([#43](https://github.com/scottlz0310/mcp-gateway/issues/43))
-  - Added `govulncheck` job that scans dependencies for known Go vulnerabilities (required check; build fails on detected vulnerabilities)
+  - Added `govulncheck` job that scans dependencies for known Go vulnerabilities. The job fails when vulnerabilities are detected, and the `build` job lists `govulncheck` in its `needs:` so Docker image build/publish is blocked when the scan fails. `govulncheck` itself is pinned to `v1.1.4` for reproducibility.
   - Added `.golangci.yml` with explicit linter set: `errcheck`, `govet`, `staticcheck`, `unused`, `revive` (instead of relying on `golangci-lint` defaults)
   - Pinned `golangci-lint` to `v2.12.2` and `golangci/golangci-lint-action` to `v9` (was `version: latest`) for CI reproducibility
   - Raised codecov patch coverage target from 70% to 75%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### CI / Infrastructure
+
+- CI pipeline hardening ([#43](https://github.com/scottlz0310/mcp-gateway/issues/43))
+  - Added `govulncheck` job that scans dependencies for known Go vulnerabilities (required check; build fails on detected vulnerabilities)
+  - Added `.golangci.yml` with explicit linter set: `errcheck`, `govet`, `staticcheck`, `unused`, `revive` (instead of relying on `golangci-lint` defaults)
+  - Pinned `golangci-lint` to `v2.12.2` and `golangci/golangci-lint-action` to `v9` (was `version: latest`) for CI reproducibility
+  - Raised codecov patch coverage target from 70% to 75%
+  - revive ruleset disables `package-comments`, `exported`, and `unused-parameter` to align with the project comment policy (comments only when the *why* is non-obvious)
+
 ### Added
 
 - RFC 8707 `resource` parameter support across all token acquisition flows ([#57](https://github.com/scottlz0310/mcp-gateway/issues/57), #49 PR-C)

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
       default:
         # cmd/ entrypoints are not unit-testable; the threshold reflects
         # intentionally-untested OS-specific branches (e.g. Windows rename fallback).
-        target: 70%
+        target: 75%
         threshold: 5%
     project:
       default:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,7 +114,7 @@ func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
 	configPath := filepath.Join(dir, "config.yaml")
 
 	km := testKeyMaterial(t)
-	os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
 
 	cfg := &AppConfig{}
 	_, err := MigrateSecret(configPath, cfg, km)

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -208,7 +208,7 @@ func TestStatusWriterHijackSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Hijack failed: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	if sw.statusCode() != http.StatusSwitchingProtocols {
 		t.Errorf("statusCode after Hijack: got %d, want 101", sw.statusCode())

--- a/tasks.md
+++ b/tasks.md
@@ -44,20 +44,20 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 | 優先 | 項目 | 種別 | Issue | 状態 |
 |---|---|---|---|---|
 | 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
-| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🗒️ 計画段階 |
+| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🚧 PR 作成予定 |
 | 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
 | 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
-| 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | 🗒️ 計画段階 |
+| 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | ✅ 完了（2026-05-07） |
 | 6 | **v0.3.0 リリース** | release | — | 上記完了後 |
 
-### 保留維持
+### v0.4.0 延期（#45 トリアージ 2026-05-07 確定）
 
-| ISSUE | 保留理由 |
-|---|---|
-| **#6** 汎用 OIDC | #18 結果次第で再評価 |
-| **#5** env var 移行 | 追加プロバイダ確定まで YAGNI |
-| **#4** fly.io OAuth | fly.io と直接調整が必要 |
-| **#3** fly.io 調査 | 調査完了済み・GitHub 側は close 候補（v0.3.0 triage で確定） |
+| ISSUE | 判断 | 理由 |
+|---|---|---|
+| **#5** env var 移行（`OAUTH_*` 系） | v0.4.0 延期 | 追加プロバイダ確定まで YAGNI |
+| **#6** 汎用 OIDC | v0.4.0 延期 | 認証基盤安定後に対応 |
+| **#3** fly.io 調査 | Close (completed) | 調査結果は Issue 本文に集約済み |
+| **#4** fly.io OAuth | Close (wontfix) | fly.io Extensions Provider 登録の外部調整コストが高い |
 
 ---
 
@@ -539,9 +539,9 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 
 ### [#6 feat: 汎用 OIDC（OpenID Connect）プロバイダサポート](https://github.com/scottlz0310/mcp-gateway/issues/6)
 
-**状態**: 保留（2026-04-27）
+**状態**: v0.4.0 延期（#45 トリアージ 2026-05-07）
 **依存**: #2
-**保留理由**: Entra ID は DCR 未サポートで MCP OAuth 2.1 仕様と不適合。対象 MCP サーバーが具体的に決まるまで見送り（YAGNI）。**#18 の結果次第で再評価**。
+**保留理由**: Entra ID は DCR 未サポートで MCP OAuth 2.1 仕様と不適合。認証基盤が安定してから対応。milestone v0.4.0 設定済み。
 
 #### サブタスク
 
@@ -555,9 +555,9 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 
 ### [#5 refactor: 環境変数を OAUTH_* 系に移行・GITHUB_MCP_* を deprecate](https://github.com/scottlz0310/mcp-gateway/issues/5)
 
-**状態**: 保留（2026-04-27）
+**状態**: v0.4.0 延期（#45 トリアージ 2026-05-07）
 **依存**: #2
-**保留理由**: 追加プロバイダがすべて保留・クローズとなったため優先度低下。プロバイダ追加が確定した時点で再開。
+**保留理由**: 追加プロバイダ（fly.io / OIDC）確定まで YAGNI。milestone v0.4.0 設定済み。
 
 #### サブタスク
 
@@ -570,9 +570,9 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 
 ### [#4 feat: fly.io OAuth プロバイダ実装](https://github.com/scottlz0310/mcp-gateway/issues/4)
 
-**状態**: 保留（2026-04-27）
+**状態**: ❌ Close (wontfix)（#45 トリアージ 2026-05-07）
 **依存**: #2, #3
-**保留理由**: fly.io OAuth（Sign in with Fly）は Extensions Provider 専用であり、開発用 client_id/client_secret の self-service 登録手段がない。fly.io と直接調整が必要なため、プロダクト品質が整うまで後回し。代替 OAuth プロバイダの検討を優先する。
+**クローズ理由**: fly.io Extensions Provider 登録に fly.io との直接調整（client_id/secret 発行・redirect_uri 事前登録）が必要であり外部依存コストが高い。self-service 登録が可能になった時点で別 issue で再評価。
 
 #### サブタスク
 
@@ -585,7 +585,7 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 
 ### [#3 spike: fly.io 認証方式の調査（OAuth Provider vs Macaroon Tokens）](https://github.com/scottlz0310/mcp-gateway/issues/3)
 
-**状態**: 調査完了（2026-04-27）
+**状態**: ❌ Close (completed)（#45 トリアージ 2026-05-07）
 **依存**: なし
 
 **結論**: Sign in with Fly（OAuth 2.0）を Issue #4 で採用。Macaroon は Provider IF 不適合のため対象外。Provider IF（#2 で確定）に変更不要。詳細は Issue #3 本文参照。

--- a/tasks.md
+++ b/tasks.md
@@ -44,7 +44,7 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 | 優先 | 項目 | 種別 | Issue | 状態 |
 |---|---|---|---|---|
 | 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
-| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🚧 PR 作成予定 |
+| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🚧 [PR #62](https://github.com/scottlz0310/mcp-gateway/pull/62) レビュー対応中 |
 | 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
 | 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
 | 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | ✅ 完了（2026-05-07） |


### PR DESCRIPTION
## Summary

- govulncheck ジョブを CI に追加（**required check** として運用、`continue-on-error` なし）
- `.golangci.yml` を新設し、有効リンターを `errcheck` / `govet` / `staticcheck` / `unused` / `revive` に明示
- `golangci-lint` を `v2.12.2`、`golangci-lint-action` を `v9` にバージョン固定（CI 再現性確保）
- codecov の patch coverage target を 70% → 75% に引き上げ
- revive の `package-comments` / `exported` / `unused-parameter` ルールはプロジェクトのコメント方針（非自明な場合のみコメント）と整合させるため無効化
- 新リンター適用で表面化した既存 errcheck 違反 2 件を修正

## Local verification

- `golangci-lint run ./...` → **0 issues**
- `go test ./...` → 全パッケージ pass
- `govulncheck ./...` → **No vulnerabilities found**

## Test plan

- [ ] CI 全ジョブ（lint / test / govulncheck / build）が green になる
- [ ] govulncheck が required check として PR ブロック動作することを確認

Closes #43