### PR TITLE
fix(auth): accept ancestor audience for route-scoped resources (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Audience validation accepts ancestor-scoped tokens for route-scoped resources ([#61](https://github.com/scottlz0310/mcp-gateway/issues/61))
+  - `validateAudience` now accepts a request when any recorded token audience equals or is a strict ancestor (sub-path) of the requested route audience, reusing the existing `isSubAudience` semantics.
+  - Resolves `token audience mismatch` 401 errors for MCP clients (e.g. Codex) that acquire a single gateway-wide token at `public_url` and then initialize multiple authenticated sub-routes (`/mcp/github`, `/mcp/copilot-review`, …). Without this fix, every sub-route required a separate token acquisition flow, which clients in the wild do not implement.
+  - Sibling routes, narrower-recorded-vs-broader-requested, and same-prefix-different-segment cases continue to be rejected. Legacy (no-audience) token grace-period behavior is unchanged.
+  - Verified end-to-end with Codex against a Compose stack (`mcp-gateway` + `github-mcp` + `copilot-review-mcp`).
+
 ### CI / Infrastructure
 
 - CI pipeline hardening ([#43](https://github.com/scottlz0310/mcp-gateway/issues/43))

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -752,12 +752,19 @@ func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
 // covers MCP clients (e.g. Codex) that acquire a single gateway-wide token and
 // then call multiple authenticated sub-routes; rejecting them on exact match
 // would force re-authentication per route, which clients in the wild do not
-// implement.
+// implement. Recorded audiences are normalized and empty entries skipped so
+// that a stale or malformed cache row cannot bypass strict-mode enforcement
+// (isSubAudience treats an empty `original` as a wildcard, which is correct
+// for the refresh-token grace path but unsafe here).
 func (h *Handler) validateAudience(token string, record TokenRecord, audience string) error {
 	if audience == "" {
 		return nil
 	}
 	for _, recorded := range record.Audiences {
+		recorded = normalizeAudience(recorded)
+		if recorded == "" {
+			continue
+		}
 		if isSubAudience(audience, recorded) {
 			return nil
 		}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -747,12 +747,20 @@ func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
 	return resource, nil
 }
 
+// validateAudience accepts the requested audience when any recorded audience
+// equals it or is a strict ancestor (gateway-wide → route-scoped). The latter
+// covers MCP clients (e.g. Codex) that acquire a single gateway-wide token and
+// then call multiple authenticated sub-routes; rejecting them on exact match
+// would force re-authentication per route, which clients in the wild do not
+// implement.
 func (h *Handler) validateAudience(token string, record TokenRecord, audience string) error {
 	if audience == "" {
 		return nil
 	}
-	if record.HasAudience(audience) {
-		return nil
+	for _, recorded := range record.Audiences {
+		if isSubAudience(audience, recorded) {
+			return nil
+		}
 	}
 	if len(record.Audiences) == 0 {
 		if h.cfg.TokenAudienceStrict {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -750,12 +750,13 @@ func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
 // validateAudience accepts the requested audience when any recorded audience
 // equals it or is a strict ancestor (gateway-wide → route-scoped). The latter
 // covers MCP clients (e.g. Codex) that acquire a single gateway-wide token and
-// then call multiple authenticated sub-routes; rejecting them on exact match
-// would force re-authentication per route, which clients in the wild do not
-// implement. Recorded audiences are normalized and empty entries skipped so
-// that a stale or malformed cache row cannot bypass strict-mode enforcement
-// (isSubAudience treats an empty `original` as a wildcard, which is correct
-// for the refresh-token grace path but unsafe here).
+// then call multiple authenticated sub-routes; rejecting them due to
+// exact-match-only validation would force re-authentication per route, which
+// clients in the wild do not implement. Recorded audiences are normalized and
+// empty entries skipped so that a stale or malformed cache row cannot bypass
+// strict-mode enforcement (isSubAudience treats an empty `original` as a
+// wildcard, which is correct for the refresh-token grace path but unsafe
+// here).
 func (h *Handler) validateAudience(token string, record TokenRecord, audience string) error {
 	if audience == "" {
 		return nil

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -379,6 +379,14 @@ func TestValidateTokenAudiencePrefixMatching(t *testing.T) {
 			requested: "http://localhost:8080/mcp/github-other",
 			wantErr:   ErrTokenAudienceMismatch,
 		},
+		{
+			// trailing-slash recorded values must be normalized before
+			// isSubAudience comparison, otherwise "http://gw/" + "/" = "http://gw//"
+			// which would never match descendants.
+			name:      "recorded_with_trailing_slash_accepts_descendant",
+			recorded:  "http://localhost:8080/",
+			requested: "http://localhost:8080/mcp/github",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -400,6 +408,28 @@ func TestValidateTokenAudiencePrefixMatching(t *testing.T) {
 				t.Fatalf("got err %v, want %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestValidateAudienceSkipsEmptyRecorded ensures that a stale or malformed
+// TokenRecord containing empty-string audience entries cannot bypass strict
+// mode. Empty entries are skipped by validateAudience so isSubAudience's
+// wildcard-on-empty semantics (used by the refresh-token grace path) cannot
+// leak into per-request validation.
+func TestValidateAudienceSkipsEmptyRecorded(t *testing.T) {
+	h, err := NewHandler(Config{
+		BaseURL:             "http://localhost:8080",
+		SessionTTL:          10 * time.Minute,
+		CacheTTL:            5 * time.Minute,
+		TokenAudienceStrict: true,
+	}, &provider.Mock{ClientIDValue: "test-client-id"})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	record := TokenRecord{Audiences: []string{""}}
+	got := h.validateAudience("token", record, "http://localhost:8080/mcp/github")
+	if !errors.Is(got, ErrTokenAudienceMismatch) {
+		t.Fatalf("got %v, want ErrTokenAudienceMismatch", got)
 	}
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -341,6 +341,68 @@ func TestValidateTokenAudienceMismatch(t *testing.T) {
 	}
 }
 
+// TestValidateTokenAudiencePrefixMatching covers the gateway-wide → route-scoped
+// acceptance path required by MCP clients (e.g. Codex) that acquire a single
+// token at the public URL and then call multiple authenticated sub-routes.
+func TestValidateTokenAudiencePrefixMatching(t *testing.T) {
+	cases := []struct {
+		name      string
+		recorded  string
+		requested string
+		wantErr   error
+	}{
+		{
+			name:      "broader_recorded_accepts_narrower_route",
+			recorded:  "http://localhost:8080",
+			requested: "http://localhost:8080/mcp/github",
+		},
+		{
+			name:      "exact_match",
+			recorded:  "http://localhost:8080/mcp/github",
+			requested: "http://localhost:8080/mcp/github",
+		},
+		{
+			name:      "sibling_route_rejected",
+			recorded:  "http://localhost:8080/mcp/github",
+			requested: "http://localhost:8080/mcp/copilot-review",
+			wantErr:   ErrTokenAudienceMismatch,
+		},
+		{
+			name:      "narrower_recorded_rejects_broader_request",
+			recorded:  "http://localhost:8080/mcp/github",
+			requested: "http://localhost:8080",
+			wantErr:   ErrTokenAudienceMismatch,
+		},
+		{
+			name:      "same_prefix_different_path_rejected",
+			recorded:  "http://localhost:8080/mcp/github",
+			requested: "http://localhost:8080/mcp/github-other",
+			wantErr:   ErrTokenAudienceMismatch,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			h.store.RegisterTokenAudience("token", tc.recorded)
+			h.store.CacheToken("token", "alice", "")
+
+			subject, err := h.ValidateToken(context.Background(), "token", tc.requested)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("got err %v, want nil", err)
+				}
+				if subject != "alice" {
+					t.Errorf("subject: got %q, want alice", subject)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got err %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateTokenLegacyGraceAndStrictModes(t *testing.T) {
 	const audience = "http://localhost:8080/mcp/foo"
 	var calls int

--- a/tasks.md
+++ b/tasks.md
@@ -48,7 +48,7 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 | 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
 | 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
 | 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | ✅ 完了（2026-05-07） |
-| 6 | **audience 検証の祖先一致対応**（Codex 互換性 fix） | bug | [#61](https://github.com/scottlz0310/mcp-gateway/issues/61) | 🚧 PR 作成予定（実環境検証完了） |
+| 6 | **audience 検証の祖先一致対応**（Codex 互換性 fix） | bug | [#61](https://github.com/scottlz0310/mcp-gateway/issues/61) | 🚧 [PR #63](https://github.com/scottlz0310/mcp-gateway/pull/63) レビュー対応中（実環境検証完了） |
 | 7 | **v0.3.0 リリース** | release | — | 上記完了後 |
 
 ### v0.4.0 延期（#45 トリアージ 2026-05-07 確定）

--- a/tasks.md
+++ b/tasks.md
@@ -44,11 +44,12 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 | 優先 | 項目 | 種別 | Issue | 状態 |
 |---|---|---|---|---|
 | 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
-| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | 🚧 [PR #62](https://github.com/scottlz0310/mcp-gateway/pull/62) レビュー対応中 |
+| 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | ✅ [PR #62](https://github.com/scottlz0310/mcp-gateway/pull/62) マージ済み（2026-05-07） |
 | 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
 | 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
 | 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | ✅ 完了（2026-05-07） |
-| 6 | **v0.3.0 リリース** | release | — | 上記完了後 |
+| 6 | **audience 検証の祖先一致対応**（Codex 互換性 fix） | bug | [#61](https://github.com/scottlz0310/mcp-gateway/issues/61) | 🚧 PR 作成予定（実環境検証完了） |
+| 7 | **v0.3.0 リリース** | release | — | 上記完了後 |
 
 ### v0.4.0 延期（#45 トリアージ 2026-05-07 確定）
 


### PR DESCRIPTION
## Summary

Codex などの MCP クライアントが `public_url` で取得した **gateway-wide audience の token** を `/mcp/github` などの **route-scoped resource** に対して使えるようにする修正です。

### 変更内容

- `validateAudience` を、recorded token audience のいずれかが requested audience と「等しい」または「**strict ancestor (sub-path)**」である場合に accept するよう変更（既存の `isSubAudience` ヘルパーを再利用）
- 各 `recorded` 値はループ内で `normalizeAudience` を通し（trailing slash の影響を排除）、空文字列エントリはスキップ（`isSubAudience` の wildcard-on-empty が strict-mode で bypass にならないよう防御）
- 既存挙動を維持する側:
  - **Sibling routes**: `/mcp/github` 用 token で `/mcp/copilot-review` → reject
  - **狭→広（逆方向）**: `/mcp/github` 用 token で `public_url` → reject
  - **同名 prefix だが path segment が異なる**: `/mcp/github` 用 token で `/mcp/github-other` → reject（`+"/"` 区切りで防止）
  - **Legacy no-audience grace-period**: 変更なし

### Why

Codex / 一部の MCP クライアントは、`/.well-known/oauth-protected-resource` での per-route token 取得をサポートせず、`public_url` で 1 度だけ token を取得して全ルートを初期化します。
従来の exact-match-only 検証では `audience mismatch` で 401 になり、`MCP startup incomplete` が発生していました。

## Tests

- パラメタライズドテスト `TestValidateTokenAudiencePrefixMatching` （6 ケース）
  - `broader_recorded_accepts_narrower_route` ✅
  - `exact_match` ✅
  - `sibling_route_rejected` ✅
  - `narrower_recorded_rejects_broader_request` ✅
  - `same_prefix_different_path_rejected` ✅
  - `recorded_with_trailing_slash_accepts_descendant` ✅
- 直接 unit test `TestValidateAudienceSkipsEmptyRecorded` — 空文字列 recorded entry が strict-mode を bypass しないことを保証
- 既存 `TestValidateTokenAudienceMismatch` / `TestValidateTokenLegacyGraceAndStrictModes` は変更なしで pass
- `go test ./...` 全パッケージ pass / `golangci-lint run ./...` 0 issues / `govulncheck ./...` clean

## End-to-end verification

Compose スタック（`mcp-gateway:dev-61` + `github-mcp` + `copilot-review-mcp:main`）+ Codex で検証:

- `codex mcp login github` / `codex mcp login copilot-review` 両方成功
- Codex から `copilot-review.get_copilot_review_status` / `get_copilot_review_watch_status` を呼び出し、MCP initialize → tools/list → tools/call まで正常動作
- mcp-gateway ログに `audience mismatch` / `auth failed` 行が一切出ないことを確認

Closes #61