### PR TITLE
[codex] docs: restructure operations documentation

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- 運用・設定ドキュメントの再構成（[#44](https://github.com/scottlz0310/mcp-gateway/issues/44)）
+  - root README を Getting Started 優先の構成に整理し、詳細リファレンスを本文から分離
+  - `docs/operations.md` に起動停止、ヘルスチェック、構造化 `slog` フィールド一覧、よくあるトラブルと復旧手順、reverse proxy 移行メモを追加
+  - `docs/configuration.md` を追加し、環境変数、`config.yaml`、route、token persistence、reverse proxy、endpoint の詳細リファレンスを集約
+  - `docs/README.md` を追加し、guide、runbook、example、spike note への入口を整理
+
 ### Added
 
 - すべてのトークン取得フローで RFC 8707 `resource` パラメータをサポート（[#57](https://github.com/scottlz0310/mcp-gateway/issues/57), #49 PR-C）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Documentation restructuring for operations and configuration ([#44](https://github.com/scottlz0310/mcp-gateway/issues/44))
+  - Reworked the root README around a front-loaded Getting Started flow and moved detailed reference material out of the main page.
+  - Expanded `docs/operations.md` with start/stop procedures, health checks, structured `slog` field reference, common troubleshooting, and reverse-proxy migration notes.
+  - Added `docs/configuration.md` as the detailed environment variable, `config.yaml`, route, token persistence, reverse proxy, and endpoint reference.
+  - Added `docs/README.md` as an index for guides, runbooks, examples, and spike notes.
+
 ### Fixed
 
 - Audience validation accepts ancestor-scoped tokens for route-scoped resources ([#61](https://github.com/scottlz0310/mcp-gateway/issues/61))

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@ VS Code などの MCP クライアントから見た単一の HTTP エントリ�
 > [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) エコシステムの一部です。
 > `mcp-docker` と `copilot-review-mcp` と組み合わせて利用することを想定しています。
 
-## Getting Started
+## はじめに
 
 ### 1. GitHub OAuth App を作成
 
@@ -208,7 +208,7 @@ environment:
 |------|--------|-------------|
 | `/.well-known/oauth-authorization-server` | GET | Authorization server metadata。 |
 | `/.well-known/oauth-protected-resource` | GET | gateway 全体の Protected Resource Metadata。 |
-| `/.well-known/oauth-protected-resource{prefix}` | GET | ルート単位の Protected Resource Metadata。 |
+| `/.well-known/oauth-protected-resource/<prefix>` | GET | ルート単位の Protected Resource Metadata。例: `/.well-known/oauth-protected-resource/mcp/github` |
 | `/authorize` | GET | OAuth authorization endpoint。 |
 | `/callback` | GET | GitHub OAuth callback。 |
 | `/device_authorization` | POST | Device Authorization Grant endpoint。 |
@@ -250,7 +250,7 @@ go build ./cmd/server
 docker build -t mcp-gateway .
 ```
 
-## Docker Image
+## Docker イメージ
 
 ```text
 ghcr.io/scottlz0310/mcp-gateway:latest
@@ -258,6 +258,6 @@ ghcr.io/scottlz0310/mcp-gateway:latest
 
 image は `gcr.io/distroless/static-debian12:nonroot` ベースで、UID 65532 として動作します。
 
-## License
+## ライセンス
 
 [LICENSE](LICENSE) を参照してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,318 +1,27 @@
 # mcp-gateway
 
-MCP サービス群への統合ゲートウェイ（GitHub OAuth 認証・リクエストルーティング・Fly.io デプロイ対応）
+MCP (Model Context Protocol) サービス群のための統合認証・ルーティングゲートウェイ。
 
-> **[mcp-docker](https://github.com/scottlz0310/Mcp-Docker) エコシステムの一部** — `mcp-docker` および `copilot-review-mcp` と組み合わせて、コンポーザブルなセルフホスト MCP インフラスタックを構成します。
+mcp-gateway は GitHub OAuth 2.0 認証、MCP Authorization メタデータ、複数の
+上流 MCP サーバーへのリバースプロキシを一元管理します。Claude Desktop や
+VS Code などの MCP クライアントから見た単一の HTTP エントリポイントとして動作します。
 
-## 概要
+> [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) エコシステムの一部です。
+> `mcp-docker` と `copilot-review-mcp` と組み合わせて利用することを想定しています。
 
-`mcp-gateway` は複数の MCP サービスへのリクエストルーティングと GitHub OAuth 2.0 認証を一元管理するリバースプロキシです。MCP クライアント（Claude Desktop、VS Code GitHub Copilot など）の単一エントリポイントとして機能し、PKCE 付き OAuth 2.0 認可コードフローを処理してから認証済みリクエストを上流 MCP サーバーへ転送します。
+## Getting Started
 
-`github-oauth-proxy` の後継として設計されています（[Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)）。
+### 1. GitHub OAuth App を作成
 
-## アーキテクチャ
+**GitHub -> Settings -> Developer settings -> OAuth Apps -> New OAuth App** を開きます。
 
-```
-MCP クライアント（Claude Desktop / VS Code / etc.）
-      │
-      ▼
-mcp-gateway (:8080)
-  ├── OAuth ファサード   /authorize  /callback  /token  /register
-  ├── Bearer 検証       (GitHub API キャッシュ付き)
-  └── ルーティング（最長プレフィックスマッチ）
-        ├── /mcp/github           → github-mcp-server  :8082
-        └── /mcp/copilot-review   → copilot-review-mcp :8083
+ローカル開発では callback URL に次を設定します。
+
+```text
+http://127.0.0.1:8080/callback
 ```
 
-### 3リポジトリ構成
-
-| リポジトリ | 役割 |
-|-----------|------|
-| **mcp-gateway**（本リポジトリ） | OAuth 2.0 認証 + ルーティングゲートウェイ |
-| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | MCP スタック全体の Docker Compose オーケストレーション |
-| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot コードレビュー MCP サーバー |
-
-## 初回起動セットアップウィザード
-
-起動時に必須の値（`GITHUB_MCP_CLIENT_ID`・`GITHUB_MCP_CLIENT_SECRET`・最低1件のルート）のいずれかが不足している場合、ゲートウェイは終了せず自動的に**セットアップモード**に移行します。
-
-### 動作の流れ
-
-1. ゲートウェイは通常ポート（デフォルト `:8080`）でセットアップモードとして起動します。
-2. ワンタイムセットアップトークン（TTL 15 分）が標準出力に出力されます:
-   ```
-   {"level":"warn","msg":"mcp-gateway starting in setup mode — configure via /setup",
-    "setup_url":"http://127.0.0.1:8080/setup?token=<TOKEN>",
-    "token":"<TOKEN>"}
-   ```
-3. `/setup` 以外のすべてのルートは `503 {"error":"setup_required","setup_url":"..."}` を返します。
-
-### curl でのセットアップ完了
-
-```bash
-# 1. 不足している設定項目を確認
-curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
-# → {"missing":["client_id","client_secret","routes"],"hint":"POST /setup ..."}
-
-# 2. 設定を送信
-curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "client_id": "Ov23liXXXXXXXXXX",
-    "client_secret": "your-github-oauth-secret",
-    "routes": [
-      {"name": "github", "prefix": "/mcp/github", "upstream": "http://github-mcp:8082"},
-      {"name": "playwright", "prefix": "/mcp/playwright", "upstream": "http://playwright:8931", "no_auth": true}
-    ]
-  }'
-# → {"saved":true,"restart_required":true}
-```
-
-4. ゲートウェイは提供されたフィールドを `config.yaml` に保存し（`client_secret` が POST ボディに含まれる場合は `age` で暗号化）、終了コード `0` で終了します。
-5. プロセススーパーバイザー（例: `restart: unless-stopped` の Docker Compose、systemd など）がゲートウェイを**通常モード**で再起動します。
-
-### API リファレンス
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| `GET` | `/setup?token=<TOKEN>` | 不足している設定項目のリストを `{"missing":[...]}` として返す |
-| `POST` | `/setup?token=<TOKEN>` | JSON ボディを受け取り、config を保存して `os.Exit(0)` を呼び出す |
-
-**POST ボディスキーマ:**
-
-```json
-{
-  "client_id": "string (GET /setup で missing に含まれる場合のみ必須)",
-  "client_secret": "string (GET /setup で missing に含まれる場合のみ必須)",
-  "routes": [
-    {
-      "name": "string (必須)",
-      "prefix": "/スラッシュ始まり (必須)",
-      "upstream": "http(s)://host:port (必須)",
-      "no_auth": false
-    }
-  ]
-}
-```
-
-**エラーコード:** `401` トークン無効 · `408` トークン期限切れ · `409` 設定済み · `422` バリデーションエラー
-
-> **セキュリティ上の注意:** セットアップトークンは成功した `POST /setup` 完了後に無効化され、15 分で期限切れになります。`GET` リクエストや失敗した `POST` は有効期限内であれば再試行可能です。本番環境（HTTPS）では POST リクエストは TLS 経由で行ってください。平文 HTTP で POST を受信した場合、ゲートウェイは警告をログに出力します。
-
-## 設定
-
-### GitHub OAuth 認証情報
-
-起動時、ゲートウェイは GitHub OAuth 認証情報を以下の優先順位で解決します:
-
-| 認証情報 | 優先ソース | フォールバック |
-|---------|------------|--------------|
-| `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` 環境変数 | `config.yaml` の `auth.github_client_id` |
-| `GITHUB_MCP_CLIENT_SECRET` | `config.yaml` の `auth.github_client_secret`（`ENC[age:]...` 形式も可） | `GITHUB_MCP_CLIENT_SECRET` 環境変数 *(初回起動時のシードのみ — config.yaml に値が存在する場合は無視)* |
-
-また、`ROUTE_<NAME>` によるルート設定が最低1つ必要です（未設定の場合は起動時にエラー終了）。
-
-### シークレット暗号化
-
-ゲートウェイは GitHub OAuth クライアントシークレットを [age](https://age-encryption.org/) X25519 暗号化を用いて `config.yaml` に**暗号化して保存**できます。
-
-#### 動作の仕組み
-
-起動時に以下を実行します:
-
-1. `gateway.key`（パス: `MCP_GATEWAY_KEY_PATH`、デフォルト `./gateway.key`）から X25519 キーをロード（または生成）
-2. `config.yaml`（`MCP_CONFIG_FILE`、デフォルト `./config.yaml`）が存在すれば読み込む
-3. 以下の優先順位で `github_client_secret` を解決:
-   - `config.yaml` に `ENC[age:]...` が存在 → 復号して使用
-   - `config.yaml` に平文が存在 → 暗号化してファイルを書き換え、平文を使用
-   - config に値なし + `GITHUB_MCP_CLIENT_SECRET` 環境変数あり → 暗号化して config に保存し使用
-   - いずれもなし → 明確なエラーメッセージで起動失敗
-
-シークレットは**絶対にログに出力されません**（平文・`ENC[...]` 暗号文・キー内容のいずれも）。
-
-#### キーファイル (`gateway.key`)
-
-キーファイルには `age-keygen` 互換の X25519 identity 文字列（`AGE-SECRET-KEY-1...`）が保存されます。
-
-**生成優先順位:**
-
-| 条件 | 結果 |
-|------|------|
-| `gateway.key` が存在する | そのままロード; `MCP_GATEWAY_MASTER_KEY` は**無視** |
-| `gateway.key` なし + `MCP_GATEWAY_MASTER_KEY` 設定済み | HKDF-SHA256 で X25519 キーを決定論的に導出; ファイルに保存 |
-| `gateway.key` なし + マスターキーなし | ランダムな X25519 キーを生成; ファイルに保存 |
-
-> **⚠ 破損は致命的エラー。** `gateway.key` が存在するが空・読み取り不能・形式不正の場合、ゲートウェイは再生成**しません** — 即座に終了します。これは意図しない上書きによる暗号化シークレットの永久消失を防ぐためです。復旧するには `gateway.key` をバックアップから復元するか、既知のキーで `config.yaml` を再暗号化してください。
-
-ファイルは `0600` パーミッションで書き込まれます。`chmod` が期待通り動作しない Windows ボリュームでは警告をログ出力します。
-
-**`gateway.key` を安全にバックアップしてください。** キーファイルを紛失し `MCP_GATEWAY_MASTER_KEY` を使用していなかった場合（ランダム生成時）、`config.yaml` の暗号化シークレットは復元不能になります。
-
-#### `MCP_GATEWAY_MASTER_KEY`
-
-設定されている場合、マスターキーを用いて X25519 キーを決定論的に導出（HKDF-SHA256）します。これにより、別途キーファイルのバックアップなしでシークレット暗号化が可能になります — 同じマスターキーは常に同じ `gateway.key` を生成します。
-
-**要件:**
-- 最低 **32 バイト** — 短い値は起動時に拒否されます
-- 十分にランダムな値を使用してください（例: `openssl rand -hex 32` の出力）
-- **マスターキーの漏えい = 導出キーの漏えい = 暗号化シークレットが復号可能** — シークレットとして厳重に管理してください
-
-> `gateway.key` が存在する場合、`MCP_GATEWAY_MASTER_KEY` は無視されます。キーファイルの初回生成時のみ使用されます。
-
-`MCP_MASTER_KEY` は `MCP_GATEWAY_MASTER_KEY` の後方互換エイリアスとして受け付けます。
-
-#### `config.yaml` の例
-
-```yaml
-auth:
-  github_client_id: "Ov23liXXXX"
-  github_client_secret: "ENC[age:]<base64-ciphertext>"
-gateway:
-  public_url: "http://127.0.0.1:8080"
-  port: "8080"
-  oauth_scopes: "repo,user"
-  trusted_proxies:
-    - "127.0.0.1/32"
-```
-
-`gateway:` 配下はすべてオプションで、対応する環境変数またはデフォルト値にフォールバックします。
-
-#### Docker Compose の設定例
-
-```yaml
-services:
-  mcp-gateway:
-    volumes:
-      - ./data:/data
-    environment:
-      MCP_GATEWAY_KEY_PATH: /data/gateway.key
-      MCP_CONFIG_FILE: /data/config.yaml
-      # 初回のみ — gateway.key が存在すれば省略可:
-      # MCP_GATEWAY_MASTER_KEY: "${MCP_GATEWAY_MASTER_KEY}"
-      GITHUB_MCP_CLIENT_ID: "${GITHUB_MCP_CLIENT_ID}"
-      # GITHUB_MCP_CLIENT_SECRET は初回起動時に config.yaml へシードする場合のみ必要:
-      # GITHUB_MCP_CLIENT_SECRET: "${GITHUB_MCP_CLIENT_SECRET}"
-      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-```
-
-### 必須環境変数
-
-| 変数 | 説明 |
-|------|------|
-| `GITHUB_MCP_CLIENT_ID` | GitHub OAuth App の Client ID |
-| `ROUTE_<NAME>` | ルーティング設定（最低1件必要、下記参照） |
-
-> `GITHUB_MCP_CLIENT_SECRET` は、`config.yaml` に暗号化済みシークレット (`ENC[age:]...`) が存在する場合は不要です。
-> 存在しない場合は、初回起動時のシードとしてこの環境変数が必要です（詳細は「シークレット暗号化」を参照）。
-
-### ルーティング設定
-
-`ROUTE_<NAME>=<prefix>|<upstream_url>` の形式で設定します。
-
-```bash
-ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
-ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
-```
-
-複数のルートを設定した場合、**最長プレフィックスが優先**されます。
-
-特定のルートで Bearer 検証を無効にするには、第3セグメントとして `|auth=none` を追加します（公開エンドポイントや認証前のパスに使用）:
-
-```bash
-ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
-```
-
-### オプション環境変数
-
-| 変数 | デフォルト | 説明 |
-|------|-----------|------|
-| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | X25519 暗号化キーファイルのパス（[シークレット暗号化](#シークレット暗号化) 参照） |
-| `MCP_CONFIG_FILE` | `./config.yaml` | 永続設定を格納する `config.yaml` のパス |
-| `MCP_GATEWAY_MASTER_KEY` | — | 決定論的キー導出に使用するマスターキー（≥32 バイト; [シークレット暗号化](#シークレット暗号化) 参照） |
-| `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | OAuth コールバック・discovery メタデータ・PRM に使用する外部公開 URL（`MCP_GATEWAY_BASE_URL` の後継） |
-| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | HTTP リスナーのバインドアドレス。Docker デプロイでは `0.0.0.0:<port>` に変更する。同一ホスト上のリバースプロキシ経由の場合はデフォルト `127.0.0.1:<port>` のままで良い |
-| `MCP_GATEWAY_TRUSTED_PROXIES` | — | `X-Forwarded-*` を信頼するリバースプロキシの CIDR リスト（カンマ区切り。例: `127.0.0.1/32,10.0.0.0/8`） |
-| `MCP_GATEWAY_BASE_URL` | — | **非推奨** — `MCP_GATEWAY_PUBLIC_URL` のエイリアス。将来のリリースで削除予定 |
-| `MCP_GATEWAY_PORT` | `8080` | `bind_addr` と `public_url` のデフォルト値を導出する際のポート番号。実際の待受アドレスは `MCP_GATEWAY_BIND_ADDR` で制御する |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | 永続トークンストアのファイルパス（[認証状態の永続化](#認証状態の永続化) 参照） |
-| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth スコープ |
-| `LOG_LEVEL` | `info` | ログレベル (`debug`/`info`/`warn`/`error`) |
-| `SESSION_TTL_MIN` | `10` | OAuth セッション有効期間（分） |
-| `TOKEN_CACHE_TTL_MIN` | `30` | トークン検証キャッシュ TTL（分）— `MCP_GATEWAY_TOKEN_STORE_PATH` を空文字に明示設定した場合のみ使用 |
-| `TOKEN_EXPIRES_IN_SEC` | `7776000` | クライアントへ通知するトークン有効期限（秒、デフォルト 90 日）。永続ストアのエントリ TTL にも使用 |
-| `GITHUB_MCP_UPSTREAM_URL` | — | **非推奨**: 単一アップストリーム（`ROUTE_*` 未設定時のフォールバック） |
-
-### リバースプロキシヘッダ
-
-nginx / Caddy / fly.io edge proxy などで TLS を gateway の手前で終端する場合は、
-`MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` をクライアントから見える外部 URL に設定し、
-信頼するプロキシの CIDR を指定します。
-
-```bash
-MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
-MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
-MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
-```
-
-信頼済みプロキシからのリクエストだけが `X-Forwarded-Proto` / `X-Forwarded-Host` /
-`X-Forwarded-For` を後段の request に反映できます。未信頼の送信元から届いた forwarded
-headers は削除されます。不正な CIDR は起動時エラーになります。
-
-信頼済みプロキシは、クライアント由来の `X-Forwarded-For` をそのまま渡さず、上書きまたは
-サニタイズしてください。gateway は XFF を右側から読みますが、このヘッダの所有者は
-プロキシに限定する前提です。
-
-### 認証状態の永続化
-
-> **Docker デフォルト:** デフォルトのストアパス `/data/tokens.json` は Docker 運用向けです。Docker イメージは `/data` を適切なパーミッションで事前作成しています。Docker 以外（`go run` やバイナリ直接実行）では `/data` が存在しないため起動に失敗します。その場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を書き込み可能なパス（例: `./tokens.json`）に設定するか、永続化を無効にするため空文字を設定してください。
-
-デフォルトでは、検証済みトークンの状態は `/data/tokens.json` に永続化されます。通常運用では **gateway を再起動しても MCP クライアント（VS Code、Claude Desktop など）の再認証は不要です**。
-
-ストアパスを変更したい場合は `MCP_GATEWAY_TOKEN_STORE_PATH` を設定します。永続化を無効にしてインメモリのみに戻す場合（本番環境では非推奨）は空文字を設定します：
-
-```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # デフォルト（Docker）
-MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json       # ローカル実行時
-MCP_GATEWAY_TOKEN_STORE_PATH=                   # 永続化を無効化（非推奨）
-```
-
-設定すると gateway は以下を行います：
-
-- 起動時にファイルから検証済みトークン ↔ ユーザー識別子のマッピングを読み込む
-- 認証成功のたびにファイルへ保存（期限は `TOKEN_EXPIRES_IN_SEC`、デフォルト 90 日）
-- 毎分、期限切れエントリを自動削除
-- ファイルパーミッション `0600`（所有者のみ読み書き）で書き込む
-- SHA-256 ハッシュ済みのキーのみ保存（生のトークン値はディスクに書き込まれない）
-
-`MCP_GATEWAY_TOKEN_STORE_PATH` を設定すると、**リフレッシュトークン永続化**が有効になります。初回のリフレッシュトークン発行時（`authorization_code` や device grant の成功時を含み、`refresh_token` グラントを待たずに発生し得ます）に `<path>.refresh`（例: `/data/tokens.json.refresh`）というファイルが書き込まれます（起動直後は存在しない場合があります）。これにより gateway が再起動しても発行済みリフレッシュトークンが引き継がれ、クライアントは `refresh_token` グラントで透過的にセッションを継続できます（ブラウザ再認証不要）。
-
-> **セキュリティ上の注意:** `.refresh` ファイルには、ハッシュ済みのリフレッシュトークンキーに加え、**関連する access token 値が平文で保存されます**。gateway はリフレッシュ時に上流プロバイダーへ access token を再提示する必要があるため、平文保存は不可避です。ファイルはパーミッション `0600`（所有者のみ読み書き）で書き込まれます。プライマリトークンストアファイルと同等の機密性として扱い、高セキュリティ環境では暗号化ボリュームや `tmpfs` マウント上に配置することを推奨します。
-
-> **Docker ユーザー:** ストアパスに named volume をマウントしてコンテナ入れ替え後もデータを保持してください。
-> 推奨の `docker-compose.yml` スニペットは [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) の関連 Issue を参照してください。
-
-全クライアントの認証状態をリセット（再認証を強制）したい場合は、ストアファイルを削除して gateway を再起動してください。
-
-## エンドポイント
-
-| パス | メソッド | 説明 |
-|------|---------|------|
-| `/.well-known/oauth-authorization-server` | GET | RFC 8414 メタデータ |
-| `/authorize` | GET | OAuth 認可エンドポイント |
-| `/callback` | GET | GitHub OAuth コールバック |
-| `/device_authorization` | POST | Device Authorization Grant エンドポイント（RFC 8628） |
-| `/token` | POST | トークンエンドポイント（`authorization_code` + PKCE、`urn:ietf:params:oauth:grant-type:device_code`、`refresh_token` グラント対応） |
-| `/register` | POST | RFC 7591 動的クライアント登録（疑似） |
-| `/health` | GET | ヘルスチェック |
-| `/<prefix>` | ANY | マッチしたルート設定に応じて認証（例: Bearer 検証または `auth=none`）を適用し、対応アップストリームへリバースプロキシ |
-
-## クイックスタート
-
-### 1. GitHub OAuth App の作成
-
-**GitHub → Settings → Developer settings → OAuth Apps → New OAuth App** から:
-
-- **Authorization callback URL**: `http://127.0.0.1:8080/callback` (または `MCP_GATEWAY_PUBLIC_URL` + `/callback`)
+デプロイ環境では `<MCP_GATEWAY_PUBLIC_URL>/callback` を設定します。
 
 ### 2. Docker Compose で起動
 
@@ -332,35 +41,31 @@ services:
       - github-mcp
 ```
 
-### 2a. マルチアップストリーム: github-mcp + copilot-review-mcp
+フル構成の Compose スタックは
+[mcp-docker](https://github.com/scottlz0310/Mcp-Docker) を参照してください。
 
-`ROUTE_*` を複数設定することで、単一ゲートウェイから複数の MCP サービスをルーティングできます。
-`copilot-review-mcp` を含む完全な例は [`examples/copilot-review-routing/`](examples/copilot-review-routing/) を参照してください。
+### 3. MCP クライアントを設定
 
-```yaml
-services:
-  mcp-gateway:
-    image: ghcr.io/scottlz0310/mcp-gateway:latest
-    ports:
-      - "8080:8080"
-    environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
-      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
-      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-      ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
-    depends_on:
-      - github-mcp
-      - copilot-review-mcp
+MCP クライアント設定例:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "http://127.0.0.1:8080/mcp/github",
+      "transport": "http"
+    }
+  }
+}
 ```
 
-> **動作原理**: `copilot-review-mcp` は Go の `ServeMux` サブツリーハンドラ (`/mcp/`) を使用しているため、
-> mcp-gateway が転送する `/mcp/copilot-review` パスは **`copilot-review-mcp` のコード変更なし** で正しくハンドルされます。
+複数の上流を使う場合は `ROUTE_*` を追加し、各 MCP server の URL を対応ルートに向けます。
 
-### 3. MCP クライアントの設定
-
-MCP クライアント設定ファイル（例: `claude_desktop_config.json`）に追加してください:
+```yaml
+environment:
+  ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+  ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
+```
 
 ```json
 {
@@ -377,24 +82,145 @@ MCP クライアント設定ファイル（例: `claude_desktop_config.json`）�
 }
 ```
 
-## 開発
+完全なマルチアップストリーム例は
+[`examples/copilot-review-routing/`](examples/copilot-review-routing/) にあります。
+
+### 4. ヘルスチェック
 
 ```bash
-# テスト
-go test ./...
-
-# ビルド
-go build ./cmd/server
-
-# Docker ビルド
-docker build -t mcp-gateway .
+curl -fsS http://127.0.0.1:8080/health
 ```
+
+期待レスポンス:
+
+```json
+{"status":"ok"}
+```
+
+## 仕組み
+
+```text
+MCP Client (Claude Desktop / VS Code / etc.)
+        |
+        v
+mcp-gateway  :8080
+  |-- OAuth facade       /authorize  /callback  /token  /register
+  |-- MCP auth metadata  /.well-known/oauth-*
+  |-- Bearer validation  GitHub API with local cache and persistence
+  `-- Routing           longest-prefix match
+        |-- /mcp/github          -> github-mcp-server  :8082
+        `-- /mcp/copilot-review  -> copilot-review-mcp :8083
+```
+
+mcp-gateway は `github-oauth-proxy` の後継です
+([Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102))。
+
+### リポジトリ構成
+
+| Repo | 役割 |
+|------|------|
+| **mcp-gateway** | OAuth 2.0 認証、MCP authorization metadata、トークン永続化、ルーティングゲートウェイ。 |
+| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | MCP スタック全体の Docker Compose オーケストレーション。 |
+| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot コードレビュー MCP サーバー。 |
+
+## ドキュメント
+
+| Document | 用途 |
+|----------|------|
+| [docs/README.md](docs/README.md) | ドキュメント index。 |
+| [docs/configuration.md](docs/configuration.md) | 環境変数、`config.yaml`、ルート、トークンストア、リバースプロキシ、エンドポイントの詳細リファレンス。 |
+| [docs/operations.md](docs/operations.md) | 起動停止、ヘルスチェック、構造化ログ、トラブルシュート、移行手順。 |
+| [docs/runbook-e2e-v0.1.0.md](docs/runbook-e2e-v0.1.0.md) | E2E 受け入れランブック。 |
+
+## 初回起動セットアップウィザード
+
+GitHub client ID、GitHub client secret、ルート設定のいずれかが不足している場合、
+gateway は終了せずセットアップモードに入ります。
+
+動作:
+
+1. gateway は通常の bind address で待ち受けます。
+2. 15 分 TTL のワンタイム setup token が stdout に出力されます。
+3. `/setup` 以外のパスは `503 setup_required` を返します。
+
+セットアップ例:
+
+```bash
+curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
+
+curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_id": "Ov23liXXXXXXXXXX",
+    "client_secret": "your-github-oauth-secret",
+    "routes": [
+      {"name": "github", "prefix": "/mcp/github", "upstream": "http://github-mcp:8082"}
+    ]
+  }'
+```
+
+`POST` 成功後、gateway は `config.yaml` を書き込み、secret を age で暗号化し、
+setup token を消費して終了コード 0 で終了します。その後 supervisor が通常モードで再起動します。
+
+運用時の詳細と復旧手順は [docs/operations.md](docs/operations.md) を参照してください。
+
+## 主な機能
+
+- GitHub OAuth 2.0 authorization code + PKCE。
+- Device Authorization Grant と refresh token grant。
+- RFC 8414 authorization server metadata。
+- RFC 9728 Protected Resource Metadata とルート単位 PRM。
+- RFC 8707 `resource` parameter による audience 付き token。
+- MCP クライアント向け dynamic client registration endpoint。
+- 最長 prefix match による複数 upstream ルーティング。
+- 明示的な公開 route 用の `auth=none` bypass。
+- access token / refresh token 状態の永続化。
+- GitHub OAuth client secret の age X25519 暗号化保存。
+- request、auth、setup、proxy event の構造化 JSON log。
+- TLS 終端 proxy 向け trusted reverse proxy header 処理。
+
+## 主要設定
+
+最小 Docker 環境:
+
+```yaml
+environment:
+  GITHUB_MCP_CLIENT_ID: <your-client-id>
+  GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+  MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+  MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
+  ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+```
+
+重要な path:
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `MCP_CONFIG_FILE` | `./config.yaml` | setup 結果と暗号化 secret。 |
+| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity。安全にバックアップしてください。 |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker 向け token 永続化 path。Docker 以外では書き込み可能な path を指定してください。 |
+
+詳細は [docs/configuration.md](docs/configuration.md) を参照してください。
+
+## エンドポイント
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/.well-known/oauth-authorization-server` | GET | Authorization server metadata。 |
+| `/.well-known/oauth-protected-resource` | GET | gateway 全体の Protected Resource Metadata。 |
+| `/.well-known/oauth-protected-resource{prefix}` | GET | ルート単位の Protected Resource Metadata。 |
+| `/authorize` | GET | OAuth authorization endpoint。 |
+| `/callback` | GET | GitHub OAuth callback。 |
+| `/device_authorization` | POST | Device Authorization Grant endpoint。 |
+| `/token` | POST | authorization code、device code、refresh token grant。 |
+| `/register` | POST | Dynamic client registration。 |
+| `/setup` | GET/POST | setup mode 中の初回起動 wizard。 |
+| `/health` | GET | 通常モードの health check。 |
+| `/<prefix>` | ANY | マッチした upstream への reverse proxy。 |
 
 ## 内部設計
 
-### Provider インターフェース
-
-OAuth プロバイダーは `Provider` インターフェースで抽象化されており、auth ハンドラやミドルウェアを変更することなく新しい ID プロバイダー（fly.io、OIDC など）を追加しやすい構造になっています:
+OAuth provider 固有処理は `Provider` interface の後ろに分離されています。
 
 ```go
 type Provider interface {
@@ -405,31 +231,33 @@ type Provider interface {
     ExchangeCode(ctx context.Context, code string) (token string, scopes []string, err error)
     ValidateToken(ctx context.Context, token string) (Identity, error)
 }
-
-type Identity struct {
-    Provider    string
-    Subject     string // 上流に転送する安定したユーザー識別子
-    DisplayName string // ログ用のオプショナルな表示名
-}
 ```
 
-プロキシは上流 MCP サーバーに以下のヘッダーを転送します:
+proxy は認証済み identity を上流 MCP server に転送します。
 
-| ヘッダー | 値 |
-|---------|---|
-| `X-Authenticated-User` | `Identity.Subject`（正規のプロバイダー非依存識別子） |
-| `X-GitHub-Login` | `X-Authenticated-User` と同値（後方互換のため両方送出） |
+| Header | Value |
+|--------|-------|
+| `X-Authenticated-User` | provider 非依存の authenticated subject。 |
+| `X-GitHub-Login` | legacy upstream 互換のため同じ値を送出。 |
 
-なりすまし可能な受信ヘッダー（`X-Authenticated-User`、`X-GitHub-Login`）はプロキシ前にストリップされます。
+なりすまし可能な identity header と forwarded header は proxy 前に削除されます。
 
-## Docker イメージ
+## 開発
 
+```bash
+go test ./...
+go build ./cmd/server
+docker build -t mcp-gateway .
 ```
+
+## Docker Image
+
+```text
 ghcr.io/scottlz0310/mcp-gateway:latest
 ```
 
-`gcr.io/distroless/static-debian12:nonroot` をベースにビルド — シェルなし・パッケージマネージャなし・非 root（UID 65532）で動作します。
+image は `gcr.io/distroless/static-debian12:nonroot` ベースで、UID 65532 として動作します。
 
-## ライセンス
+## License
 
 [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The full reference is in [docs/configuration.md](docs/configuration.md).
 |------|--------|-------------|
 | `/.well-known/oauth-authorization-server` | GET | Authorization server metadata. |
 | `/.well-known/oauth-protected-resource` | GET | Gateway-wide Protected Resource Metadata. |
-| `/.well-known/oauth-protected-resource{prefix}` | GET | Per-route Protected Resource Metadata. |
+| `/.well-known/oauth-protected-resource/<prefix>` | GET | Per-route Protected Resource Metadata, e.g. `/.well-known/oauth-protected-resource/mcp/github`. |
 | `/authorize` | GET | OAuth authorization endpoint. |
 | `/callback` | GET | GitHub OAuth callback. |
 | `/device_authorization` | POST | Device Authorization Grant endpoint. |

--- a/README.md
+++ b/README.md
@@ -1,418 +1,74 @@
 # mcp-gateway
 
-Unified authentication and routing gateway for MCP (Model Context Protocol) services — GitHub OAuth 2.0, multi-upstream reverse proxy, and Fly.io deployment ready.
+Unified authentication and routing gateway for MCP (Model Context Protocol)
+services.
 
-> **Part of the [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) ecosystem** — designed to work alongside `mcp-docker` and `copilot-review-mcp` as a composable self-hosted MCP infrastructure stack.
+mcp-gateway centralizes GitHub OAuth 2.0 authentication, MCP Authorization
+metadata, and reverse proxy routing for multiple upstream MCP servers. It is the
+single HTTP entry point for MCP clients such as Claude Desktop and VS Code.
 
-## Overview
+> Part of the [mcp-docker](https://github.com/scottlz0310/Mcp-Docker)
+> ecosystem, designed to run alongside `mcp-docker` and
+> `copilot-review-mcp`.
 
-`mcp-gateway` is a reverse proxy that centralizes **GitHub OAuth 2.0 authentication** and **request routing** for multiple MCP services. It acts as the single entry point for MCP clients (e.g., Claude Desktop, VS Code GitHub Copilot), handling the full OAuth 2.0 authorization code flow with PKCE before forwarding authenticated requests to upstream MCP servers.
+## Getting Started
 
-It is the successor to `github-oauth-proxy` ([Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)).
+### 1. Create A GitHub OAuth App
 
-## Architecture
+Open **GitHub -> Settings -> Developer settings -> OAuth Apps -> New OAuth App**.
 
-```
-MCP Client (Claude Desktop / VS Code / etc.)
-        │
-        ▼
-mcp-gateway  :8080
-  ├── OAuth façade     /authorize  /callback  /token  /register
-  ├── Bearer validation  (GitHub API with in-memory cache)
-  └── Routing (longest-prefix match)
-        ├── /mcp/github           → github-mcp-server  :8082
-        └── /mcp/copilot-review   → copilot-review-mcp :8083
-```
+Use this callback URL for local development:
 
-### 3-Repo Stack
-
-| Repo | Role |
-|------|------|
-| **mcp-gateway** (this repo) | OAuth 2.0 auth + routing gateway |
-| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | Docker Compose orchestration for the full MCP stack |
-| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot code-review MCP server |
-
-## First-Run Setup Wizard
-
-If any required value (`GITHUB_MCP_CLIENT_ID`, `GITHUB_MCP_CLIENT_SECRET`, or at least one route) is missing on startup, the gateway automatically enters **setup mode** instead of exiting.
-
-### What happens
-
-1. The gateway starts in setup mode on the normal port (`:8080` by default).
-2. A one-time setup token (15-min TTL) is printed to stdout:
-   ```
-   {"level":"warn","msg":"mcp-gateway starting in setup mode — configure via /setup",
-    "setup_url":"http://127.0.0.1:8080/setup?token=<TOKEN>",
-    "token":"<TOKEN>"}
-   ```
-3. All routes except `/setup` return `503 {"error":"setup_required","setup_url":"..."}`.
-
-### Completing setup via curl
-
-```bash
-# 1. Check what fields are missing
-curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
-# → {"missing":["client_id","client_secret","routes"],"hint":"POST /setup ..."}
-
-# 2. Submit your configuration
-curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "client_id": "Ov23liXXXXXXXXXX",
-    "client_secret": "your-github-oauth-secret",
-    "routes": [
-      {"name": "github", "prefix": "/mcp/github", "upstream": "http://github-mcp:8082"},
-      {"name": "playwright", "prefix": "/mcp/playwright", "upstream": "http://playwright:8931", "no_auth": true}
-    ]
-  }'
-# → {"saved":true,"restart_required":true}
+```text
+http://127.0.0.1:8080/callback
 ```
 
-4. The gateway saves only the fields provided in the POST body to `config.yaml` (encrypting `client_secret` via `age` if supplied) and exits with code `0`.
-5. Your process supervisor (e.g., Docker Compose with `restart: unless-stopped`, systemd, etc.) restarts the gateway in **normal mode**.
+For deployed environments, use `<MCP_GATEWAY_PUBLIC_URL>/callback`.
 
-### API reference
+### 2. Run With Docker Compose
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/setup?token=<TOKEN>` | Returns `{"missing":[...]}` listing incomplete fields |
-| `POST` | `/setup?token=<TOKEN>` | Accepts JSON body; saves config; triggers `os.Exit(0)` |
+```yaml
+services:
+  mcp-gateway:
+    image: ghcr.io/scottlz0310/mcp-gateway:latest
+    ports:
+      - "8080:8080"
+    environment:
+      GITHUB_MCP_CLIENT_ID: <your-client-id>
+      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
+      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+    depends_on:
+      - github-mcp
+```
 
-**POST body schema:**
+See [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) for a full Compose
+stack.
+
+### 3. Configure An MCP Client
+
+Example MCP client configuration:
 
 ```json
 {
-  "client_id": "string (required only if listed as missing by GET /setup)",
-  "client_secret": "string (required only if listed as missing by GET /setup)",
-  "routes": [
-    {
-      "name": "string (required)",
-      "prefix": "/must-start-with-slash (required)",
-      "upstream": "http(s)://host:port (required)",
-      "no_auth": false
+  "mcpServers": {
+    "github": {
+      "url": "http://127.0.0.1:8080/mcp/github",
+      "transport": "http"
     }
-  ]
+  }
 }
 ```
 
-**Error codes:** `401` invalid token · `408` token expired · `409` already configured · `422` validation error
-
-> **Security note:** The setup token is consumed (invalidated) only after a successful `POST /setup`; GET requests and failed POST attempts remain valid until expiry (15 minutes). In production (HTTPS), POST requests should go over TLS. The gateway logs a warning if POST is received over plain HTTP.
-
-## Configuration
-
-### GitHub OAuth Credentials
-
-At startup, the gateway resolves the GitHub OAuth credentials as follows:
-
-| Credential | Primary source | Fallback |
-|-----------|----------------|---------|
-| `GITHUB_MCP_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` env var | `auth.github_client_id` in `config.yaml` |
-| `GITHUB_MCP_CLIENT_SECRET` | `auth.github_client_secret` in `config.yaml` (may be `ENC[age:]...`) | `GITHUB_MCP_CLIENT_SECRET` env var *(first-startup seeding only — ignored once a value exists in config.yaml)* |
-
-At least one route must also be configured — via `ROUTE_<NAME>` env vars, `routes:` in `config.yaml` (written by the setup wizard), or the legacy `GITHUB_MCP_UPSTREAM_URL` — the server exits on startup if no routes are defined after all sources are checked.
-
-### Secret Encryption
-
-The gateway can store the GitHub OAuth client secret **encrypted at rest** in `config.yaml` using [age](https://age-encryption.org/) X25519 encryption.
-
-#### How it works
-
-On startup, the gateway:
-
-1. Loads (or generates) an X25519 key from `gateway.key` (path: `MCP_GATEWAY_KEY_PATH`, default `./gateway.key`)
-2. Reads `config.yaml` (`MCP_CONFIG_FILE`, default `./config.yaml`) if it exists
-3. Resolves `github_client_secret` using this priority:
-   - `ENC[age:]...` in `config.yaml` → decrypts and uses the plaintext
-   - Plaintext in `config.yaml` → encrypts it, rewrites the file, uses the plaintext
-   - No secret in config + `GITHUB_MCP_CLIENT_SECRET` env var → encrypts it, writes to config, uses the plaintext
-   - Neither → startup fails with a clear error message
-
-Secrets are **never logged** — neither the plaintext value, nor the `ENC[...]` ciphertext, nor the key contents.
-
-#### Key file (`gateway.key`)
-
-The key file stores a standard `age-keygen`-compatible X25519 identity string (`AGE-SECRET-KEY-1...`).
-
-**Generation priority:**
-
-| Condition | Result |
-|-----------|--------|
-| `gateway.key` exists | Load and use as-is; `MCP_GATEWAY_MASTER_KEY` is **ignored** |
-| `gateway.key` absent + `MCP_GATEWAY_MASTER_KEY` set | Deterministically derive X25519 key via HKDF-SHA256; save to file |
-| `gateway.key` absent + no master key | Generate a random X25519 key; save to file |
-
-> **⚠ Corruption is fatal.** If `gateway.key` exists but is empty, unreadable, or malformed, the gateway will **not** regenerate it — it will exit immediately. This protects against accidental data loss (overwriting the key would permanently destroy any encrypted secrets in `config.yaml`). To recover, restore `gateway.key` from backup or re-encrypt `config.yaml` with a known key.
-
-The file is written with `0600` permissions. On Windows volumes where `chmod` is not supported, a warning is logged.
-
-**Back up `gateway.key` securely.** If the key file is lost and `MCP_GATEWAY_MASTER_KEY` was not used (random generation), the encrypted secrets in `config.yaml` cannot be recovered.
-
-#### `MCP_GATEWAY_MASTER_KEY`
-
-When set, the master key is used to deterministically derive the X25519 key (HKDF-SHA256). This enables secret encryption without a separate key file backup — the same master key always produces the same `gateway.key`.
-
-**Requirements:**
-- Minimum **32 bytes** — shorter values are rejected at startup
-- Use a sufficiently random value (e.g. output of `openssl rand -hex 32`)
-- **Leaked master key = leaked derived key = encrypted secrets can be decrypted** — treat it as a secret
-
-> Once `gateway.key` exists, `MCP_GATEWAY_MASTER_KEY` is ignored. It is only used when generating the key file for the first time.
-
-`MCP_MASTER_KEY` is accepted as a legacy alias for `MCP_GATEWAY_MASTER_KEY`.
-
-#### Example `config.yaml`
+For multiple upstreams, add more `ROUTE_*` entries and point each client server
+at its route:
 
 ```yaml
-auth:
-  github_client_id: "Ov23liXXXX"
-  github_client_secret: "ENC[age:]<base64-ciphertext>"
-gateway:
-  public_url: "http://127.0.0.1:8080"
-  port: "8080"
-  oauth_scopes: "repo,user"
-  trusted_proxies:
-    - "127.0.0.1/32"
+environment:
+  ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+  ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
 ```
-
-All `gateway:` fields are optional — values fall back to the corresponding env vars and then to the built-in defaults.
-
-#### Docker Compose setup
-
-```yaml
-services:
-  mcp-gateway:
-    volumes:
-      - ./data:/data
-    environment:
-      MCP_GATEWAY_KEY_PATH: /data/gateway.key
-      MCP_CONFIG_FILE: /data/config.yaml
-      # On first run only — omit once gateway.key exists:
-      # MCP_GATEWAY_MASTER_KEY: "${MCP_GATEWAY_MASTER_KEY}"
-      GITHUB_MCP_CLIENT_ID: "${GITHUB_MCP_CLIENT_ID}"
-      # GITHUB_MCP_CLIENT_SECRET only needed on first run to seed config.yaml:
-      # GITHUB_MCP_CLIENT_SECRET: "${GITHUB_MCP_CLIENT_SECRET}"
-      # At least one ROUTE_* is required — the gateway will fail to start without routes:
-      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-```
-
-
-### Route Configuration
-
-Routes are defined via `ROUTE_<NAME>=<prefix>|<upstream_url>` environment variables.
-
-```bash
-ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
-ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
-```
-
-- Prefixes **must** start with `/`
-- Upstream URLs must be absolute `http` or `https`
-- When multiple routes match, the **longest prefix wins**
-- Append `|auth=none` as a third segment to disable Bearer validation for a specific route (e.g., for public or pre-auth endpoints):
-
-  ```bash
-  ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
-  ```
-
-### Optional Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the X25519 encryption key file (see [Secret Encryption](#secret-encryption)) |
-| `MCP_CONFIG_FILE` | `./config.yaml` | Path to `config.yaml` for persisted configuration |
-| `MCP_GATEWAY_MASTER_KEY` | — | Master key for deterministic key derivation (≥32 bytes; see [Secret Encryption](#secret-encryption)) |
-| `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:8080` | Canonical base URL for OAuth callback, discovery metadata, and PRM (replaces `MCP_GATEWAY_BASE_URL`) |
-| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:8080` | TCP address the HTTP listener binds to. Set to `0.0.0.0:<port>` for Docker deployments. For reverse-proxy on the same host, keep the default `127.0.0.1:<port>` |
-| `MCP_GATEWAY_TRUSTED_PROXIES` | — | Comma-separated CIDR allowlist for reverse proxies whose `X-Forwarded-*` headers are trusted (e.g. `127.0.0.1/32,10.0.0.0/8`) |
-| `MCP_GATEWAY_BASE_URL` | — | **Deprecated** — alias for `MCP_GATEWAY_PUBLIC_URL`; will be removed in a future release |
-| `MCP_GATEWAY_PORT` | `8080` | Default port used when deriving `bind_addr` and `public_url`. The actual listen address is controlled by `MCP_GATEWAY_BIND_ADDR` |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Path to the persistent token store file (see [Persistent Auth State](#persistent-auth-state)) |
-| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes |
-| `LOG_LEVEL` | `info` | Log level: `debug` / `info` / `warn` / `error` |
-| `SESSION_TTL_MIN` | `10` | OAuth session lifetime (minutes) |
-| `TOKEN_CACHE_TTL_MIN` | `30` | Token validation cache TTL in minutes — used only when `MCP_GATEWAY_TOKEN_STORE_PATH` is explicitly set to empty |
-| `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients (seconds; default 90 days). Also used as the TTL for persistent token entries |
-| `GITHUB_MCP_UPSTREAM_URL` | — | **Deprecated** — single upstream fallback when no `ROUTE_*` is set |
-
-### Reverse Proxy Headers
-
-When TLS terminates in front of mcp-gateway (nginx, Caddy, fly.io edge proxy, etc.),
-set `MCP_GATEWAY_PUBLIC_URL` / `gateway.public_url` to the externally visible
-URL and configure trusted proxy CIDRs:
-
-```bash
-MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
-MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
-MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
-```
-
-Equivalent `config.yaml`:
-
-```yaml
-gateway:
-  public_url: "https://mcp.example.com"
-  bind_addr: "127.0.0.1:8080"
-  trusted_proxies:
-    - "127.0.0.1/32"
-    - "10.0.0.0/8"
-```
-
-Only requests whose immediate peer IP matches `trusted_proxies` may influence the
-request seen by downstream handlers:
-
-| Header | Effect |
-|--------|--------|
-| `X-Forwarded-Proto` | Sets the request scheme when the value is `http` or `https` |
-| `X-Forwarded-Host` | Sets `r.Host` after basic host validation |
-| `X-Forwarded-For` | Sets `r.RemoteAddr` to the rightmost valid IP supplied by the trusted proxy |
-
-If the peer is not trusted, incoming forwarded headers are stripped before later
-middleware and handlers run. `trusted_proxies` entries must be valid CIDR strings;
-invalid values cause startup to fail.
-
-Configure your reverse proxy to overwrite or sanitize `X-Forwarded-For` instead of
-passing client-provided values through unchanged. The gateway reads the header from the
-right as a defense against appended spoofed entries, but the proxy should still own this
-header.
-
-### Persistent Auth State
-
-> **Docker default:** The default store path `/data/tokens.json` is designed for Docker deployments — the Docker image pre-creates `/data` with the correct permissions. If you run the gateway with `go run` or a bare binary outside Docker, `/data` likely does not exist and the gateway will fail to start. In that case set `MCP_GATEWAY_TOKEN_STORE_PATH` to a writable path (e.g. `./tokens.json`) or set it to empty to disable persistence.
-
-By default, validated token state is persisted to `/data/tokens.json`. This means MCP clients (VS Code, Claude Desktop, etc.) **do not need to re-authenticate after gateway restarts** under normal operation.
-
-To change the store path, set `MCP_GATEWAY_TOKEN_STORE_PATH`. To disable persistence and revert to in-memory-only storage (not recommended for production), set it to an empty string:
-
-```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=/data/tokens.json  # default (Docker)
-MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json       # local run
-MCP_GATEWAY_TOKEN_STORE_PATH=                   # disable persistence (not recommended)
-```
-
-The gateway will:
-- Load previously validated token ↔ identity mappings on startup
-- Save new mappings on each successful authentication
-- Automatically sweep expired entries every minute
-- Write the file with mode `0600` (owner read/write only)
-- Store only SHA-256-hashed token keys — raw token values never appear on disk
-
-Setting `MCP_GATEWAY_TOKEN_STORE_PATH` also enables refresh token persistence: on the first refresh token issuance (which can occur during the initial `authorization_code` or device grant, not only on a subsequent `refresh_token` grant), a sibling file at `<path>.refresh` (e.g. `/data/tokens.json.refresh`) is created (the file may not exist immediately after startup until the first refresh token is issued). This ensures that gateway-issued refresh tokens survive container restarts, so clients can transparently continue their session via the `refresh_token` grant without triggering a full browser re-authentication.
-
-> **Security note:** The `.refresh` file stores the **associated access token value in plaintext** alongside a hashed refresh token key. The gateway must re-present the access token to the upstream provider on refresh, so the plaintext value is required. The file is written with mode `0600` (owner read/write only) and should be treated with the same sensitivity as the primary token store file — store both files on an encrypted volume or a `tmpfs` mount in high-security environments.
-
-> **Docker users:** mount a named volume at the store path so data survives container replacement.
-> See the companion issue in [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) for the recommended `docker-compose.yml` snippet.
-
-To reset all authentication state (force re-auth for all clients), delete the store file and restart the gateway.
-
-## Endpoints
-
-| Path | Method | Description |
-|------|--------|-------------|
-| `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server metadata |
-| `/.well-known/oauth-protected-resource` | GET | RFC 9728 Protected Resource Metadata for the gateway as a whole (resource = `public_url`). Also serves root-prefix (`/`) routes |
-| `/.well-known/oauth-protected-resource{prefix}` | GET | Per-route PRM (MCP Authorization Spec 2025-06-18) — `resource` is the route's absolute URL `<public_url>{prefix}` (e.g. for prefix `/mcp/copilot-review` the well-known path is `/.well-known/oauth-protected-resource/mcp/copilot-review` and the resource is `<public_url>/mcp/copilot-review`). Registered for every authenticated route **except root-prefix routes (`/`)**, which fall back to the gateway-wide PRM above |
-| `/authorize` | GET | OAuth 2.0 authorization endpoint |
-| `/callback` | GET | GitHub OAuth callback |
-| `/device_authorization` | POST | Device Authorization Grant endpoint (RFC 8628) |
-| `/token` | POST | Token endpoint — supports `authorization_code` + PKCE, `urn:ietf:params:oauth:grant-type:device_code`, and `refresh_token` grants |
-| `/register` | POST | RFC 7591 dynamic client registration (pseudo) |
-| `/health` | GET | Health check — returns `{"status":"ok"}` |
-| `/<prefix>` | ANY | Reverse proxy to the matched upstream — Bearer-validated unless `auth=none` is set for the matched route. 401 responses point `WWW-Authenticate.resource_metadata` at the route's per-route PRM (or at the gateway-wide PRM for root-prefix routes) |
-
-## Internal Design
-
-### Provider Interface
-
-The OAuth provider is abstracted behind a `Provider` interface, making it straightforward to add new identity providers (fly.io, OIDC, etc.) without touching the auth handler or middleware:
-
-```go
-type Provider interface {
-    Name() string
-    ClientID() string
-    Scopes() string
-    AuthorizeURL(state, codeChallenge string) string
-    ExchangeCode(ctx context.Context, code string) (token string, scopes []string, err error)
-    ValidateToken(ctx context.Context, token string) (Identity, error)
-}
-
-type Identity struct {
-    Provider    string
-    Subject     string // stable user identifier forwarded upstream
-    DisplayName string // optional human-readable name for logging
-}
-```
-
-The proxy forwards two identity headers to upstream MCP servers:
-
-| Header | Value |
-|--------|-------|
-| `X-Authenticated-User` | `Identity.Subject` (canonical, provider-agnostic) |
-| `X-GitHub-Login` | same as `X-Authenticated-User` (legacy compatibility; both set from `Identity.Subject`) |
-
-Spoofable incoming headers (`X-Authenticated-User`, `X-GitHub-Login`, `Forwarded`,
-`X-Forwarded-*`, `X-Real-IP`) are stripped before proxying.
-
-## Quick Start
-
-### 1. Create a GitHub OAuth App
-
-Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**:
-
-- **Authorization callback URL**: `http://127.0.0.1:8080/callback` (or your `MCP_GATEWAY_PUBLIC_URL` + `/callback`)
-
-### 2. Run with Docker Compose
-
-```yaml
-services:
-  mcp-gateway:
-    image: ghcr.io/scottlz0310/mcp-gateway:latest
-    ports:
-      - "8080:8080"
-    environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
-      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
-      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-    depends_on:
-      - github-mcp
-```
-
-See [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) for a full Compose stack.
-
-### 2a. Multi-Upstream: github-mcp + copilot-review-mcp
-
-Route multiple MCP services through a single gateway by adding more `ROUTE_*` entries.
-A complete example that includes `copilot-review-mcp` is provided in
-[`examples/copilot-review-routing/`](examples/copilot-review-routing/):
-
-```yaml
-services:
-  mcp-gateway:
-    image: ghcr.io/scottlz0310/mcp-gateway:latest
-    ports:
-      - "8080:8080"
-    environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
-      MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
-      ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-      ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
-    depends_on:
-      - github-mcp
-      - copilot-review-mcp
-```
-
-> **How it works**: `copilot-review-mcp` uses a Go `ServeMux` subtree handler (`/mcp/`),
-> so the path `/mcp/copilot-review` forwarded by mcp-gateway is caught correctly without
-> any code changes to `copilot-review-mcp`.
-
-### 3. Configure your MCP Client
-
-Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 
 ```json
 {
@@ -429,26 +85,184 @@ Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
 }
 ```
 
+A complete multi-upstream example is available in
+[`examples/copilot-review-routing/`](examples/copilot-review-routing/).
+
+### 4. Check Health
+
+```bash
+curl -fsS http://127.0.0.1:8080/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## How It Works
+
+```text
+MCP Client (Claude Desktop / VS Code / etc.)
+        |
+        v
+mcp-gateway  :8080
+  |-- OAuth facade       /authorize  /callback  /token  /register
+  |-- MCP auth metadata  /.well-known/oauth-*
+  |-- Bearer validation  GitHub API with local cache and persistence
+  `-- Routing           longest-prefix match
+        |-- /mcp/github          -> github-mcp-server  :8082
+        `-- /mcp/copilot-review  -> copilot-review-mcp :8083
+```
+
+mcp-gateway is the successor to `github-oauth-proxy`
+([Mcp-Docker#102](https://github.com/scottlz0310/Mcp-Docker/issues/102)).
+
+### Repository Stack
+
+| Repo | Role |
+|------|------|
+| **mcp-gateway** | OAuth 2.0 auth, MCP authorization metadata, token persistence, and routing gateway. |
+| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | Docker Compose orchestration for the full MCP stack. |
+| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot code-review MCP server. |
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [docs/README.md](docs/README.md) | Documentation index. |
+| [docs/configuration.md](docs/configuration.md) | Full environment variable, `config.yaml`, route, token store, reverse proxy, and endpoint reference. |
+| [docs/operations.md](docs/operations.md) | Start/stop procedures, health checks, structured logs, troubleshooting, and migration notes. |
+| [docs/runbook-e2e-v0.1.0.md](docs/runbook-e2e-v0.1.0.md) | End-to-end acceptance runbook. |
+
+## First-Run Setup Wizard
+
+If the GitHub client ID, GitHub client secret, or route configuration is missing,
+the gateway enters setup mode instead of exiting.
+
+What happens:
+
+1. The gateway listens on the normal bind address.
+2. A one-time setup token with a 15-minute TTL is printed to stdout.
+3. All paths except `/setup` return `503 setup_required`.
+
+Example setup flow:
+
+```bash
+curl "http://127.0.0.1:8080/setup?token=<TOKEN>"
+
+curl -X POST "http://127.0.0.1:8080/setup?token=<TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_id": "Ov23liXXXXXXXXXX",
+    "client_secret": "your-github-oauth-secret",
+    "routes": [
+      {"name": "github", "prefix": "/mcp/github", "upstream": "http://github-mcp:8082"}
+    ]
+  }'
+```
+
+On successful `POST`, the gateway writes `config.yaml`, encrypts the secret with
+age, consumes the token, and exits with code 0 so the process supervisor can
+restart it in normal mode.
+
+Operational details and recovery procedures are in
+[docs/operations.md](docs/operations.md).
+
+## Key Features
+
+- GitHub OAuth 2.0 authorization code + PKCE.
+- Device Authorization Grant and refresh token grant.
+- RFC 8414 authorization server metadata.
+- RFC 9728 Protected Resource Metadata, including per-route PRM documents.
+- RFC 8707 `resource` parameter support for audience-bound tokens.
+- Dynamic client registration endpoint for MCP clients.
+- Multi-upstream reverse proxy routing with longest-prefix matching.
+- Route-level `auth=none` bypass for explicitly public upstreams.
+- Persistent token and refresh-token state.
+- age X25519 encryption for stored GitHub OAuth client secrets.
+- Structured JSON logs with request, auth, setup, and proxy events.
+- Trusted reverse proxy header handling for TLS-terminating proxies.
+
+## Core Configuration
+
+Minimal Docker environment:
+
+```yaml
+environment:
+  GITHUB_MCP_CLIENT_ID: <your-client-id>
+  GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+  MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
+  MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
+  ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
+```
+
+Important paths:
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `MCP_CONFIG_FILE` | `./config.yaml` | Persisted setup and encrypted secrets. |
+| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity. Back it up securely. |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker-friendly token persistence path. Use a writable local path outside Docker. |
+
+The full reference is in [docs/configuration.md](docs/configuration.md).
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/.well-known/oauth-authorization-server` | GET | Authorization server metadata. |
+| `/.well-known/oauth-protected-resource` | GET | Gateway-wide Protected Resource Metadata. |
+| `/.well-known/oauth-protected-resource{prefix}` | GET | Per-route Protected Resource Metadata. |
+| `/authorize` | GET | OAuth authorization endpoint. |
+| `/callback` | GET | GitHub OAuth callback. |
+| `/device_authorization` | POST | Device Authorization Grant endpoint. |
+| `/token` | POST | Authorization code, device code, and refresh token grants. |
+| `/register` | POST | Dynamic client registration. |
+| `/setup` | GET/POST | First-run setup wizard, available in setup mode. |
+| `/health` | GET | Health check in normal mode. |
+| `/<prefix>` | ANY | Reverse proxy to the matched upstream. |
+
+## Internal Design
+
+OAuth provider-specific behavior is behind a `Provider` interface:
+
+```go
+type Provider interface {
+    Name() string
+    ClientID() string
+    Scopes() string
+    AuthorizeURL(state, codeChallenge string) string
+    ExchangeCode(ctx context.Context, code string) (token string, scopes []string, err error)
+    ValidateToken(ctx context.Context, token string) (Identity, error)
+}
+```
+
+The proxy forwards the authenticated identity to upstream MCP servers:
+
+| Header | Value |
+|--------|-------|
+| `X-Authenticated-User` | Provider-agnostic authenticated subject. |
+| `X-GitHub-Login` | Same value, retained for legacy upstream compatibility. |
+
+Spoofable incoming identity and forwarded headers are stripped before proxying.
+
 ## Development
 
 ```bash
-# Run tests
 go test ./...
-
-# Build binary
 go build ./cmd/server
-
-# Build Docker image
 docker build -t mcp-gateway .
 ```
 
 ## Docker Image
 
-```
+```text
 ghcr.io/scottlz0310/mcp-gateway:latest
 ```
 
-Built on `gcr.io/distroless/static-debian12:nonroot` — no shell, no package manager, runs as non-root (UID 65532).
+The image is based on `gcr.io/distroless/static-debian12:nonroot` and runs as
+UID 65532.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Documentation
+
+This directory contains operational and reference documentation for
+mcp-gateway.
+
+## Guides
+
+| Document | Purpose |
+|----------|---------|
+| [Operations Guide](operations.md) | Start/stop procedures, health checks, structured logs, troubleshooting, and deployment migration notes. |
+| [Configuration Reference](configuration.md) | Environment variables, `config.yaml`, route syntax, token persistence, reverse proxy settings, and endpoint reference. |
+| [v0.1.0 E2E Runbook](runbook-e2e-v0.1.0.md) | End-to-end acceptance runbook for setup wizard, encryption, routing, token persistence, and device flow. |
+| [Copilot API Auth Spike](spike-18-copilot-api-auth.md) | Investigation notes for the Copilot API upstream authentication model. |
+
+## Examples
+
+| Path | Purpose |
+|------|---------|
+| [`../examples/copilot-review-routing/`](../examples/copilot-review-routing/) | Docker Compose example for routing both `github-mcp-server` and `copilot-review-mcp` through one gateway. |
+
+## README Split
+
+The root [README](../README.md) is intentionally focused on the first-run path,
+architecture overview, and links into these documents. Detailed configuration
+and operations material should live here to keep the README scannable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,248 @@
+# Configuration Reference
+
+This page is the detailed configuration reference for mcp-gateway. The README
+keeps only the quick-start path and links here for full operational settings.
+
+## Required Startup Inputs
+
+mcp-gateway needs all of the following before it can run in normal mode:
+
+| Requirement | Environment source | `config.yaml` source |
+|-------------|--------------------|----------------------|
+| GitHub OAuth client ID | `GITHUB_MCP_CLIENT_ID` | `auth.github_client_id` |
+| GitHub OAuth client secret | `GITHUB_MCP_CLIENT_SECRET` for first-start seeding | `auth.github_client_secret` |
+| At least one route | `ROUTE_<NAME>` | `routes:` |
+
+If any required value is missing, the gateway enters setup mode and prints a
+one-time `/setup` URL to stdout.
+
+## Precedence
+
+Configuration is resolved in this order:
+
+| Setting | Precedence |
+|---------|------------|
+| GitHub client ID | `GITHUB_MCP_CLIENT_ID` > `auth.github_client_id` |
+| GitHub client secret | encrypted/plain `auth.github_client_secret` > non-empty `GITHUB_MCP_CLIENT_SECRET` used to seed `config.yaml` |
+| Routes | `ROUTE_<NAME>` env vars > `routes:` in `config.yaml` > deprecated `GITHUB_MCP_UPSTREAM_URL` fallback |
+| Public URL | `MCP_GATEWAY_PUBLIC_URL` > deprecated `MCP_GATEWAY_BASE_URL` > `gateway.public_url` > deprecated `gateway.base_url` > default |
+| Bind address | `MCP_GATEWAY_BIND_ADDR` > `gateway.bind_addr` > `127.0.0.1:<resolved-port>` |
+| OAuth scopes | `GITHUB_MCP_OAUTH_SCOPES` > `gateway.oauth_scopes` > `repo,user` |
+| Trusted proxies | `MCP_GATEWAY_TRUSTED_PROXIES` > `gateway.trusted_proxies` > none |
+| Token audience strict mode | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` > `gateway.token_audience_strict` > `false` |
+
+The GitHub client secret is intentionally special: once `config.yaml` contains a
+secret, `GITHUB_MCP_CLIENT_SECRET` is ignored except during first-start seeding.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITHUB_MCP_CLIENT_ID` | none | GitHub OAuth App client ID. Required unless `auth.github_client_id` is set. |
+| `GITHUB_MCP_CLIENT_SECRET` | none | GitHub OAuth App client secret. Used to seed encrypted `config.yaml` when no config secret exists. |
+| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes requested by the gateway. |
+| `ROUTE_<NAME>` | none | Route definition in `<prefix>|<upstream_url>[|auth=none]` form. At least one route is required unless configured in `config.yaml`. |
+| `MCP_CONFIG_FILE` | `./config.yaml` | Path to persisted YAML configuration. |
+| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the age X25519 identity used to encrypt `auth.github_client_secret`. |
+| `MCP_GATEWAY_MASTER_KEY` | none | Optional deterministic key seed. Must be at least 32 bytes. Used only when creating `gateway.key`. |
+| `MCP_MASTER_KEY` | none | Legacy alias for `MCP_GATEWAY_MASTER_KEY`. |
+| `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:<port>` | Canonical client-visible URL used for OAuth callbacks, discovery metadata, and Protected Resource Metadata. |
+| `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:<port>` | TCP listener address. Use `0.0.0.0:<port>` inside Docker when publishing ports. |
+| `MCP_GATEWAY_PORT` | `8080` | Port used to derive default `public_url` and `bind_addr` when those settings are not explicit. |
+| `MCP_GATEWAY_BASE_URL` | none | Deprecated alias for `MCP_GATEWAY_PUBLIC_URL`. Emits a startup warning when set. |
+| `MCP_GATEWAY_TRUSTED_PROXIES` | none | Comma-separated CIDR list for immediate reverse proxies whose `X-Forwarded-*` headers are trusted. |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. |
+| `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
+| `LOG_LEVEL` | `info` | JSON log level: `debug`, `info`, `warn`, or `error`. |
+| `SESSION_TTL_MIN` | `10` | OAuth authorization session lifetime in minutes. |
+| `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
+| `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients and persistent token entry TTL. Default is 90 days. |
+| `GITHUB_MCP_UPSTREAM_URL` | none | Deprecated single-upstream fallback when no `ROUTE_*` or `routes:` entries exist. |
+
+## `config.yaml`
+
+Example:
+
+```yaml
+auth:
+  github_client_id: "Ov23liXXXX"
+  github_client_secret: "ENC[age:]<base64-ciphertext>"
+
+gateway:
+  public_url: "http://127.0.0.1:8080"
+  bind_addr: "127.0.0.1:8080"
+  port: "8080"
+  oauth_scopes: "repo,user"
+  trusted_proxies:
+    - "127.0.0.1/32"
+  token_audience_strict: false
+
+routes:
+  - name: github
+    prefix: /mcp/github
+    upstream: http://github-mcp:8082
+  - name: public
+    prefix: /public
+    upstream: http://public-svc:8083
+    no_auth: true
+
+setup:
+  completed: true
+```
+
+### YAML Keys
+
+| Key | Description |
+|-----|-------------|
+| `auth.github_client_id` | GitHub OAuth App client ID. |
+| `auth.github_client_secret` | GitHub OAuth App client secret. May be encrypted as `ENC[age:]...`; plaintext is encrypted and rewritten on startup. |
+| `gateway.public_url` | Canonical public URL visible to OAuth and MCP clients. |
+| `gateway.bind_addr` | TCP listener address. |
+| `gateway.base_url` | Deprecated alias for `gateway.public_url`. |
+| `gateway.port` | Port used when deriving defaults. |
+| `gateway.oauth_scopes` | OAuth scopes requested from GitHub. |
+| `gateway.trusted_proxies` | CIDR list for trusted reverse proxy peers. |
+| `gateway.token_audience_strict` | Strict legacy-token audience enforcement. |
+| `routes[].name` | Route name. Must be non-empty. |
+| `routes[].prefix` | URL path prefix. Must start with `/`; trailing slashes are trimmed except for `/`. |
+| `routes[].upstream` | Absolute `http` or `https` upstream URL. |
+| `routes[].no_auth` | When true, skips Bearer validation for this route. |
+| `setup.completed` | Setup wizard state written by the gateway. Operators normally do not edit it directly. |
+
+Unknown YAML fields and comments are not preserved when the gateway rewrites
+`config.yaml` during secret migration or setup completion.
+
+## Route Configuration
+
+Environment routes use:
+
+```bash
+ROUTE_<NAME>=<prefix>|<upstream_url>
+```
+
+Examples:
+
+```bash
+ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
+ROUTE_COPILOT_REVIEW=/mcp/copilot-review|http://copilot-review-mcp:8083
+```
+
+Rules:
+
+- `NAME` must not be empty.
+- `prefix` must start with `/`.
+- `prefix` must not contain whitespace.
+- `upstream_url` must be an absolute `http` or `https` URL.
+- Duplicate prefixes are rejected.
+- Routes are sorted by longest prefix first.
+
+Disable auth for a route by adding `|auth=none`:
+
+```bash
+ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
+```
+
+Use `auth=oauth` only when you need to be explicit; it is the default.
+
+## Secret Encryption
+
+The gateway stores `auth.github_client_secret` encrypted at rest with
+`filippo.io/age` X25519.
+
+Startup behavior:
+
+1. Load or generate `gateway.key` from `MCP_GATEWAY_KEY_PATH`.
+2. Load `config.yaml` from `MCP_CONFIG_FILE`.
+3. Resolve the secret:
+   - `ENC[age:]...` in config: decrypt and use.
+   - Plaintext in config: encrypt, rewrite config, and use.
+   - No config secret plus `GITHUB_MCP_CLIENT_SECRET`: encrypt, save to config, and use.
+   - No source: fail startup.
+
+Key generation priority:
+
+| Condition | Result |
+|-----------|--------|
+| `gateway.key` exists | Load and use it; `MCP_GATEWAY_MASTER_KEY` is ignored. |
+| `gateway.key` absent and `MCP_GATEWAY_MASTER_KEY` set | Derive the X25519 identity with HKDF-SHA256 and save it. |
+| `gateway.key` absent and no master key | Generate a random X25519 identity and save it. |
+
+Secrets and key material are not logged. A corrupt, empty, or unreadable
+`gateway.key` is fatal; it is not regenerated automatically.
+
+## Token Persistence
+
+By default, validated token state is stored in `/data/tokens.json`, which is
+created in the Docker image. For non-Docker runs, set a writable path:
+
+```bash
+MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
+```
+
+Set the variable to an empty value to disable persistence:
+
+```bash
+MCP_GATEWAY_TOKEN_STORE_PATH=
+```
+
+The primary token store:
+
+- Loads token-to-identity mappings on startup.
+- Saves mappings after successful authentication.
+- Sweeps expired entries every minute.
+- Writes with mode `0600` where supported.
+- Stores SHA-256-hashed token keys, not raw token values.
+
+When token persistence is enabled, refresh tokens are stored in
+`<path>.refresh`. That file stores hashed refresh token keys and the associated
+access token value in plaintext because the gateway must re-present the access
+token to GitHub during refresh. Treat it as sensitive data.
+
+## Reverse Proxy Headers
+
+When TLS terminates before mcp-gateway:
+
+```bash
+MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
+MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
+MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
+```
+
+Only requests whose immediate peer IP is in `trusted_proxies` may affect:
+
+| Header | Effect |
+|--------|--------|
+| `X-Forwarded-Proto` | Sets the request scheme when the value is `http` or `https`. |
+| `X-Forwarded-Host` | Sets `r.Host` after basic host validation. |
+| `X-Forwarded-For` | Sets `r.RemoteAddr` to the rightmost valid IP supplied by the trusted proxy. |
+
+Untrusted forwarded headers are stripped before auth, setup checks, access logs,
+and proxying run.
+
+## OAuth And MCP Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server metadata. |
+| `/.well-known/oauth-protected-resource` | GET | Gateway-wide RFC 9728 Protected Resource Metadata. Also covers root-prefix routes. |
+| `/.well-known/oauth-protected-resource{prefix}` | GET | Per-route Protected Resource Metadata for authenticated non-root routes. |
+| `/authorize` | GET | OAuth 2.0 authorization endpoint. |
+| `/callback` | GET | GitHub OAuth callback. |
+| `/device_authorization` | POST | Device Authorization Grant endpoint (RFC 8628). |
+| `/token` | POST | Token endpoint for authorization code + PKCE, device code, and refresh token grants. |
+| `/register` | POST | RFC 7591-style dynamic client registration. |
+| `/setup` | GET/POST | First-run setup wizard endpoint, available only in setup mode. |
+| `/health` | GET | Health check in normal mode. |
+| `/<prefix>` | ANY | Reverse proxy to the matched upstream. Bearer-validated unless `auth=none` is set. |
+
+## OAuth Resource Parameters
+
+The gateway supports RFC 8707 `resource` parameters on:
+
+- `/authorize`
+- `/device_authorization`
+- `/token` with `grant_type=refresh_token`
+
+The resource must match a registered gateway or route audience. During the
+migration grace period, legacy tokens without recorded audience metadata are
+accepted while `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=false`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ secret, `GITHUB_MCP_CLIENT_SECRET` is ignored except during first-start seeding.
 | `ROUTE_<NAME>` | none | Route definition in `<prefix>|<upstream_url>[|auth=none]` form. At least one route is required unless configured in `config.yaml`. |
 | `MCP_CONFIG_FILE` | `./config.yaml` | Path to persisted YAML configuration. |
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the age X25519 identity used to encrypt `auth.github_client_secret`. |
-| `MCP_GATEWAY_MASTER_KEY` | none | Optional deterministic key seed. Must be at least 32 bytes. Used only when creating `gateway.key`. |
+| `MCP_GATEWAY_MASTER_KEY` | none | Optional deterministic key seed. Use 32+ random bytes encoded as a string, for example `openssl rand -base64 32`. Used only when creating `gateway.key`. |
 | `MCP_MASTER_KEY` | none | Legacy alias for `MCP_GATEWAY_MASTER_KEY`. |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:<port>` | Canonical client-visible URL used for OAuth callbacks, discovery metadata, and Protected Resource Metadata. |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:<port>` | TCP listener address. Use `0.0.0.0:<port>` inside Docker when publishing ports. |
@@ -58,6 +58,10 @@ secret, `GITHUB_MCP_CLIENT_SECRET` is ignored except during first-start seeding.
 | `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients and persistent token entry TTL. Default is 90 days. |
 | `GITHUB_MCP_UPSTREAM_URL` | none | Deprecated single-upstream fallback when no `ROUTE_*` or `routes:` entries exist. |
+
+`MCP_GATEWAY_MASTER_KEY` is checked as the byte length of the supplied string
+after trimming whitespace. A base64 string generated with `openssl rand -base64
+32` is accepted as-is; the gateway does not base64-decode it before validation.
 
 ## `config.yaml`
 
@@ -225,7 +229,7 @@ and proxying run.
 |------|--------|-------------|
 | `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server metadata. |
 | `/.well-known/oauth-protected-resource` | GET | Gateway-wide RFC 9728 Protected Resource Metadata. Also covers root-prefix routes. |
-| `/.well-known/oauth-protected-resource{prefix}` | GET | Per-route Protected Resource Metadata for authenticated non-root routes. |
+| `/.well-known/oauth-protected-resource/<prefix>` | GET | Per-route Protected Resource Metadata for authenticated non-root routes, e.g. `/.well-known/oauth-protected-resource/mcp/github`. |
 | `/authorize` | GET | OAuth 2.0 authorization endpoint. |
 | `/callback` | GET | GitHub OAuth callback. |
 | `/device_authorization` | POST | Device Authorization Grant endpoint (RFC 8628). |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,87 +1,25 @@
 # Operations Guide
 
-This guide covers deployment, migration, and operational considerations for mcp-gateway.
+This guide covers day-to-day operation, health checks, log inspection, migration
+notes, and common recovery procedures for mcp-gateway.
 
----
+For the full configuration reference, see [configuration.md](configuration.md).
 
-## bind_addr vs public_url
+## Start And Stop
 
-mcp-gateway v0.3.0 separates the **listen address** from the **public URL**:
+### Docker Compose
 
-| Config | Env var | YAML key | Default | Purpose |
-|--------|---------|----------|---------|---------|
-| Bind address | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | Network interface/port the HTTP server listens on |
-| Public URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | Canonical URL used in OAuth callbacks, discovery metadata, and PRM |
+Use Docker Compose for the normal self-hosted stack.
 
-Before v0.3.0, `MCP_GATEWAY_BASE_URL` / `gateway.base_url` controlled only the **public URL**
-(OAuth callbacks and discovery metadata). The server always listened on all interfaces
-(`:<port>`) regardless of this setting.
-That setting is now **deprecated** and will be removed in a future release.
-
-### Why the split matters
-
-In Docker deployments the gateway binds to `0.0.0.0:8080` (all interfaces) so the host can
-reach it via port-forwarding, but the OAuth callback URL registered with GitHub must be an
-address that the **user's browser** can reach—typically `http://127.0.0.1:8080` on the
-developer's machine.
-
-Before v0.3.0 there was no clean way to express this difference: the server always
-listened on all interfaces (`:<port>`), but `BASE_URL` only influenced the public URL
-advertised to OAuth clients—there was no way to configure the bind address independently.
-
----
-
-## Migrating from MCP_GATEWAY_BASE_URL
-
-### 1. Update your environment variables
-
-| Old | New |
-|-----|-----|
-| `MCP_GATEWAY_BASE_URL=http://localhost:<port>` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:<port>` |
-| *(implicit: bind on all interfaces `:<port>`)* | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:<port>` (local) or `0.0.0.0:<port>` (Docker) |
-
-> Replace `<port>` with the port your gateway uses (default: `8080`).
-
-### 2. Update config.yaml (if used)
-
-```yaml
-# Before
-gateway:
-  base_url: "http://localhost:<port>"   # replace <port> with your actual port
-
-# After
-gateway:
-  public_url: "http://127.0.0.1:<port>"
-  bind_addr: "127.0.0.1:<port>"   # omit for Docker; set to 0.0.0.0:<port> there
+```bash
+docker compose up -d mcp-gateway
+docker compose logs -f mcp-gateway
+docker compose stop mcp-gateway
+docker compose restart mcp-gateway
 ```
 
-### 3. Update the GitHub OAuth App callback URL
-
-Go to **GitHub → Settings → Developer settings → OAuth Apps → [your app] → Edit**:
-
-| Field | Old value | New value |
-|-------|-----------|-----------|
-| Authorization callback URL | `http://localhost:<port>/callback` | `http://127.0.0.1:<port>/callback` |
-
-> **Note:** `localhost` and `127.0.0.1` are treated the same by most browsers, but GitHub
-> OAuth validates the exact callback URL, so the registered URL must match what the gateway
-> sends in the OAuth redirect.
-
-### 4. Cutover procedure
-
-1. Merge or deploy the updated gateway binary / image.
-2. Update the GitHub OAuth App callback URL (step 3 above).
-3. Update your `docker-compose.yml` or systemd unit / `.env` file (steps 1–2 above).
-4. Restart the gateway.
-5. Existing tokens remain valid—clients do **not** need to re-authenticate unless the
-   token store was cleared.
-
----
-
-## Docker deployment
-
-The gateway default bind address is `127.0.0.1:8080` (loopback only).
-Docker port-forwarding requires binding on all interfaces:
+Docker port forwarding requires the gateway to listen on all interfaces inside
+the container:
 
 ```yaml
 services:
@@ -92,29 +30,404 @@ services:
     environment:
       GITHUB_MCP_CLIENT_ID: <your-client-id>
       GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
-      # Bind on all interfaces so Docker port-forwarding works
       MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
-      # Public URL is what the user's browser (and GitHub OAuth) will call
       MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
-    depends_on:
-      - github-mcp
 ```
 
-If you are deploying behind a reverse proxy (nginx, Caddy, etc.) and exposing the gateway
-on a public domain, set `MCP_GATEWAY_PUBLIC_URL` to the full public URL, e.g.:
+`MCP_GATEWAY_PUBLIC_URL` must be the URL that OAuth clients and the user's
+browser can reach. It is often `http://127.0.0.1:8080` for local Docker
+deployments even when `MCP_GATEWAY_BIND_ADDR` is `0.0.0.0:8080`.
 
-```
-MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
-MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
-```
+### Bare Binary Or `go run`
 
-### Trusted proxy headers
-
-If the proxy terminates HTTPS or rewrites the externally visible host, also configure the
-proxy IP ranges that mcp-gateway may trust:
+When running outside Docker, the default token store path (`/data/tokens.json`)
+usually does not exist. Point runtime files at writable local paths:
 
 ```bash
+export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
+export MCP_CONFIG_FILE=./config.yaml
+export MCP_GATEWAY_KEY_PATH=./gateway.key
+export GITHUB_MCP_CLIENT_ID=<your-client-id>
+export GITHUB_MCP_CLIENT_SECRET=<your-client-secret>
+export ROUTE_GITHUB=/mcp/github|http://127.0.0.1:8082
+
+go run ./cmd/server
+```
+
+Build and run a local binary:
+
+```bash
+go build -o mcp-gateway ./cmd/server
+./mcp-gateway
+```
+
+Stop the process with the supervisor that started it (`Ctrl-C`, `docker compose
+stop`, `systemctl stop`, etc.). mcp-gateway does not require a special shutdown
+endpoint.
+
+## Health Checks
+
+In normal mode:
+
+```bash
+curl -fsS http://127.0.0.1:8080/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+If the gateway is in setup mode, `/health` returns `503 setup_required` because
+only `/setup` is available until the required configuration is saved.
+
+For container health checks, use the same endpoint from the host or from another
+container that can reach the published port:
+
+```bash
+curl -fsS http://mcp-gateway:8080/health
+```
+
+## Reading Logs
+
+mcp-gateway writes JSON logs with Go `log/slog` to stdout. Set `LOG_LEVEL` to
+`debug`, `info`, `warn`, or `error`; the default is `info`.
+
+Each log entry includes the standard `slog` fields:
+
+| Field | Meaning |
+|-------|---------|
+| `time` | Timestamp emitted by the JSON handler |
+| `level` | `DEBUG`, `INFO`, `WARN`, or `ERROR` |
+| `msg` | Event name |
+
+### HTTP Access Logs
+
+Every HTTP request emits one `"http request"` log after the handler returns.
+
+| Field | Meaning |
+|-------|---------|
+| `method` | Request method |
+| `path` | Request path without query string |
+| `status` | Final HTTP status code |
+| `latency_ms` | Request duration in milliseconds |
+| `remote_addr` | Client address after trusted proxy processing |
+
+5xx responses are logged at `ERROR`; other status ranges are logged at `INFO`.
+
+Example:
+
+```json
+{"level":"INFO","msg":"http request","method":"GET","path":"/health","status":200,"latency_ms":0,"remote_addr":"127.0.0.1:53321"}
+```
+
+### Startup And Routing Logs
+
+Startup emits `"registered route"` for each route and `"mcp-gateway starting"`
+after the server is ready to listen.
+
+| Message | Important fields |
+|---------|------------------|
+| `registered route` | `name`, `prefix`, `upstream`, `auth_required` |
+| `mcp-gateway starting` | `bind_addr`, `public_url`, `provider`, `routes`, `trusted_proxies`, `token_audience_strict` |
+| `setup wizard listening` | `bind_addr` |
+
+### Proxy Logs
+
+Authenticated upstream requests emit:
+
+| Message | Important fields |
+|---------|------------------|
+| `proxy request` | `user`, `method`, `path`, `token_hash` |
+| `proxy response` | `upstream_status`, `path` |
+| `upstream rejected token; cache invalidated` | `path`, `token_hash` |
+
+`token_hash` is the first 8 hex characters of `SHA-256(token)`. It is only for
+correlation; raw token values are not logged.
+
+### Auth And Setup Logs
+
+Common authentication and setup messages:
+
+| Message | Meaning |
+|---------|---------|
+| `auth failed` | Bearer token validation failed |
+| `upstream error during auth` | Provider validation returned a transient upstream error |
+| `token exchange rejected` | OAuth authorization-code exchange was invalid |
+| `refresh token rejected` | Refresh token was missing, expired, or already consumed |
+| `token without audience accepted during grace period` | Legacy token was accepted while `token_audience_strict` is disabled |
+| `mcp-gateway starting in setup mode` | Required config is missing; follow `setup_url` |
+| `setup complete; restarting to apply configuration` | Setup POST succeeded and the process is exiting with code 0 |
+
+The setup-mode log includes `setup_url` and `token`. Treat the token as a
+short-lived secret.
+
+### Useful Log Commands
+
+```bash
+docker compose logs mcp-gateway | jq 'select(.msg=="http request")'
+docker compose logs mcp-gateway | jq 'select(.level=="ERROR" or .level=="WARN")'
+docker compose logs mcp-gateway | jq 'select(.msg=="proxy response" and .upstream_status>=500)'
+```
+
+If `jq` is not available, follow the raw logs:
+
+```bash
+docker compose logs -f mcp-gateway
+```
+
+## Common Problems
+
+### `setup_required`
+
+Symptoms:
+
+- Non-`/setup` paths return `503 {"error":"setup_required","setup_url":"..."}`
+- Logs contain `mcp-gateway starting in setup mode`
+
+Cause:
+
+- One or more required values are missing: GitHub client ID, GitHub client
+  secret, or at least one route.
+
+Fix:
+
+1. Open the `setup_url` from logs, or run `GET /setup?token=<TOKEN>`.
+2. POST the missing `client_id`, `client_secret`, and/or `routes`.
+3. Let the supervisor restart the gateway after it exits with code 0.
+
+### Setup Token Expired
+
+Symptoms:
+
+- `GET /setup?token=<TOKEN>` or `POST /setup?token=<TOKEN>` returns `408`.
+
+Cause:
+
+- Setup tokens are valid for 15 minutes.
+
+Fix:
+
+1. Restart the gateway while it is still missing required config.
+2. Read the new `setup_url` and `token` from stdout.
+3. Repeat the setup request.
+
+### `gateway.key` Is Corrupt Or Unreadable
+
+Symptoms:
+
+- Startup exits before serving traffic.
+- Logs contain `failed to load gateway encryption key`.
+
+Cause:
+
+- `gateway.key` exists but is empty, malformed, or unreadable. The gateway
+  refuses to regenerate it automatically because doing so could permanently
+  orphan encrypted secrets in `config.yaml`.
+
+Fix:
+
+1. Restore `gateway.key` from backup.
+2. If the key was originally derived from `MCP_GATEWAY_MASTER_KEY`, remove the
+   bad key file and restart with the same master key so the same identity is
+   regenerated.
+3. If no backup or master key exists, remove or replace the encrypted
+   `auth.github_client_secret` in `config.yaml`, provide
+   `GITHUB_MCP_CLIENT_SECRET` again, and let the gateway write a new encrypted
+   value with a new key.
+
+Do not delete `gateway.key` as a first response unless you know how the current
+encrypted `config.yaml` can be recovered.
+
+### `github_client_secret is unavailable`
+
+Symptoms:
+
+- Startup logs `github_client_secret is unavailable`.
+
+Cause:
+
+- Neither `auth.github_client_secret` in `config.yaml` nor
+  `GITHUB_MCP_CLIENT_SECRET` is available.
+
+Fix:
+
+- Provide `GITHUB_MCP_CLIENT_SECRET` once so the gateway can encrypt and persist
+  it, or restore a valid encrypted `auth.github_client_secret` and matching
+  `gateway.key`.
+
+### No Routes Configured
+
+Symptoms:
+
+- Startup logs `no routes configured: set ROUTE_<NAME>=<prefix>|<upstream_url>`.
+
+Fix:
+
+- Set at least one `ROUTE_<NAME>` environment variable, or add a `routes:` entry
+  to `config.yaml`.
+
+Example:
+
+```bash
+ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
+```
+
+### Docker Port Is Published But The Gateway Is Unreachable
+
+Symptoms:
+
+- `docker compose ps` shows a published port, but host requests fail.
+
+Cause:
+
+- The gateway is bound to the loopback default (`127.0.0.1:8080`) inside the
+  container.
+
+Fix:
+
+```bash
+MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080
+```
+
+Keep `MCP_GATEWAY_PUBLIC_URL` set to the browser-visible URL, for example
+`http://127.0.0.1:8080`.
+
+### GitHub OAuth Callback Mismatch
+
+Symptoms:
+
+- GitHub rejects the OAuth callback URL.
+- Browser auth flow fails before returning to `/callback`.
+
+Fix:
+
+Update the GitHub OAuth App callback URL to exactly match:
+
+```text
+<MCP_GATEWAY_PUBLIC_URL>/callback
+```
+
+For the local default this is:
+
+```text
+http://127.0.0.1:8080/callback
+```
+
+### Bare Binary Fails Because `/data` Does Not Exist
+
+Symptoms:
+
+- Local `go run ./cmd/server` or a bare binary fails while opening the token
+  store.
+
+Fix:
+
+```bash
+export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
+export MCP_CONFIG_FILE=./config.yaml
+export MCP_GATEWAY_KEY_PATH=./gateway.key
+```
+
+### Invalid Trusted Proxy CIDR
+
+Symptoms:
+
+- Startup logs `invalid trusted proxy configuration`.
+
+Fix:
+
+- Ensure every `MCP_GATEWAY_TRUSTED_PROXIES` entry or
+  `gateway.trusted_proxies` item is a valid CIDR such as `127.0.0.1/32` or
+  `10.0.0.0/8`.
+
+### Token Audience Mismatch
+
+Symptoms:
+
+- Authenticated route requests return 401 with `invalid_token`.
+- Logs mention an audience mismatch or legacy audience grace-period acceptance.
+
+Fix:
+
+1. Make sure the client follows the `WWW-Authenticate.resource_metadata` URL.
+2. Re-authenticate the client so it obtains a token for the route resource.
+3. Keep `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=false` until legacy no-audience
+   tokens have disappeared from logs.
+
+## bind_addr vs public_url
+
+mcp-gateway v0.3.0 separates the listen address from the public URL:
+
+| Config | Env var | YAML key | Default | Purpose |
+|--------|---------|----------|---------|---------|
+| Bind address | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | Network interface and port the HTTP server listens on |
+| Public URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | Canonical URL used in OAuth callbacks, discovery metadata, and PRM |
+
+Before v0.3.0, `MCP_GATEWAY_BASE_URL` / `gateway.base_url` controlled only the
+public URL. The server always listened on all interfaces (`:<port>`) regardless
+of that setting. The old setting is deprecated and will be removed in a future
+release.
+
+### Why The Split Matters
+
+In Docker deployments the gateway binds to `0.0.0.0:8080` so the host can reach
+it via port forwarding, but the OAuth callback URL registered with GitHub must
+be an address that the user's browser can reach. For local development that is
+usually `http://127.0.0.1:8080`.
+
+### Migrating From MCP_GATEWAY_BASE_URL
+
+Update environment variables:
+
+| Old | New |
+|-----|-----|
+| `MCP_GATEWAY_BASE_URL=http://localhost:<port>` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:<port>` |
+| implicit bind on all interfaces `:<port>` | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:<port>` for local runs or `0.0.0.0:<port>` for Docker |
+
+Update `config.yaml` if used:
+
+```yaml
+# Before
+gateway:
+  base_url: "http://localhost:<port>"
+
+# After
+gateway:
+  public_url: "http://127.0.0.1:<port>"
+  bind_addr: "127.0.0.1:<port>"
+```
+
+Update the GitHub OAuth App callback URL:
+
+| Field | Old value | New value |
+|-------|-----------|-----------|
+| Authorization callback URL | `http://localhost:<port>/callback` | `http://127.0.0.1:<port>/callback` |
+
+GitHub validates the exact callback URL, so the registered value must match the
+URL sent by the gateway.
+
+### Cutover Procedure
+
+1. Deploy the updated gateway binary or image.
+2. Update the GitHub OAuth App callback URL.
+3. Update `docker-compose.yml`, a systemd unit, or `.env` with the new variables.
+4. Restart the gateway.
+5. Confirm `/health` returns `{"status":"ok"}`.
+
+Existing access and refresh tokens remain valid unless the token store was
+deleted or the provider has revoked the upstream token.
+
+## Reverse Proxy Deployments
+
+If TLS terminates in front of mcp-gateway, set the public URL to the external
+origin and trust only the immediate proxy CIDRs:
+
+```bash
+MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
+MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
 MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 ```
 
@@ -133,17 +446,17 @@ When the immediate peer IP matches `trusted_proxies`, mcp-gateway reflects:
 
 | Header | Reflected request field |
 |--------|-------------------------|
-| `X-Forwarded-Proto` | `r.URL.Scheme` (`http` or `https` only) |
-| `X-Forwarded-Host` | `r.Host` |
-| `X-Forwarded-For` | `r.RemoteAddr` (rightmost valid IP supplied by the trusted proxy) |
+| `X-Forwarded-Proto` | `r.URL.Scheme`, only when the value is `http` or `https` |
+| `X-Forwarded-Host` | `r.Host` after basic host validation |
+| `X-Forwarded-For` | `r.RemoteAddr`, using the rightmost valid IP supplied by the trusted proxy |
 
-When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are stripped
-before later middleware and handlers run. This prevents direct clients from spoofing the
-scheme, host, or client IP in logs and setup-mode HTTPS checks.
+When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are
+stripped before later middleware and handlers run.
 
-Configure the reverse proxy to overwrite or sanitize `X-Forwarded-For` instead of passing
-client-provided values through unchanged. The gateway reads the header from the right as
-a defense against appended spoofed entries, but the proxy should still own this header.
+Configure the reverse proxy to overwrite or sanitize `X-Forwarded-For` instead
+of passing client-provided values through unchanged. The gateway reads the
+header from the right as a defense against appended spoofed entries, but the
+proxy should still own this header.
 
 Example nginx location:
 
@@ -157,31 +470,5 @@ location / {
 }
 ```
 
-`MCP_GATEWAY_PUBLIC_URL` remains the canonical OAuth/discovery/PRM URL. Keep it set to
-the same external origin that clients use, for example `https://mcp.example.com`.
-
----
-
-## Non-Docker / bare binary
-
-When running the binary directly (not in Docker) the `/data` directory may not exist.
-Override the storage paths to writable locations:
-
-```bash
-export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
-export MCP_CONFIG_FILE=./config.yaml
-export MCP_GATEWAY_KEY_PATH=./gateway.key
-```
-
-Or disable token persistence entirely (not recommended for production):
-
-```bash
-export MCP_GATEWAY_TOKEN_STORE_PATH=
-```
-
----
-
-## Token store persistence
-
-See [README.md — Authentication state persistence](../README.md#authentication-state-persistence)
-for full details on the token store, refresh token store, and how to reset auth state.
+`MCP_GATEWAY_PUBLIC_URL` remains the canonical OAuth, discovery, and PRM URL.
+Keep it set to the same external origin that clients use.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -82,6 +82,8 @@ Expected response:
 
 If the gateway is in setup mode, `/health` returns `503 setup_required` because
 only `/setup` is available until the required configuration is saved.
+Use `curl -i http://127.0.0.1:8080/health` when checking setup mode; `curl -f`
+exits non-zero for the expected 503 and may hide the response body.
 
 For container health checks, use the same endpoint from the host or from another
 container that can reach the published port:
@@ -359,7 +361,7 @@ Fix:
 
 ## bind_addr vs public_url
 
-mcp-gateway v0.3.0 separates the listen address from the public URL:
+mcp-gateway separates the listen address from the public URL:
 
 | Config | Env var | YAML key | Default | Purpose |
 |--------|---------|----------|---------|---------|

--- a/docs/runbook-e2e-v0.1.0.md
+++ b/docs/runbook-e2e-v0.1.0.md
@@ -778,7 +778,8 @@ docker compose up -d mcp-gateway
 
 ## 8. 参考
 
-- [README.md](../README.md) — 通常運用ドキュメント
+- [README.md](../README.md) — クイックスタートと概要
+- [docs/operations.md](operations.md) — 通常運用ドキュメント
 - [CHANGELOG.md](../CHANGELOG.md) — v0.1.0 変更点
 - [docs/spike-18-copilot-api-auth.md](spike-18-copilot-api-auth.md) — Copilot API 認証調査
 - [tasks.md](../tasks.md) — タスク全体管理（v0.2.0 ロードマップ含む）

--- a/tasks.md
+++ b/tasks.md
@@ -11,7 +11,7 @@
 
 ---
 
-## 推奨消化順（2026-05-05 更新）
+## 推奨消化順（2026-05-07 更新）
 
 ### v0.1.0 リリース済み（2026-04-30）
 
@@ -43,12 +43,12 @@ v0.2.0 の実装項目はすべてマージ済み。v0.1.0 E2E ランブック�
 
 | 優先 | 項目 | 種別 | Issue | 状態 |
 |---|---|---|---|---|
-| 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | 🗒️ 計画段階 |
+| 1 | **観測性整備**（構造化ログ統一・基礎メトリクス） | enhancement | [#42](https://github.com/scottlz0310/mcp-gateway/issues/42) | ✅ [PR #47](https://github.com/scottlz0310/mcp-gateway/pull/47) マージ済み（2026-05-06） |
 | 2 | **CI 強化**（govulncheck・golangci-lint 設定・カバレッジ閾値） | infra | [#43](https://github.com/scottlz0310/mcp-gateway/issues/43) | ✅ [PR #62](https://github.com/scottlz0310/mcp-gateway/pull/62) マージ済み（2026-05-07） |
-| 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | 🗒️ 計画段階 |
-| 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) マージ済み / 🚧 PR-B [#56](https://github.com/scottlz0310/mcp-gateway/issues/56) 実装中 / PR-C [#57](https://github.com/scottlz0310/mcp-gateway/issues/57) 起票済み |
+| 3 | **ドキュメント整備**（運用ガイド・README 構造見直し） | docs | [#44](https://github.com/scottlz0310/mcp-gateway/issues/44) | ✅ 本PRで実装済み（operations/configuration/docs index/README 整理） |
+| 4 | **per-route PRM・reverse proxy 対応**（MCP Auth Spec 2025-06-18 準拠） | enhancement | [#49](https://github.com/scottlz0310/mcp-gateway/issues/49) | ✅ PR-A [#58](https://github.com/scottlz0310/mcp-gateway/pull/58) / PR-B [#59](https://github.com/scottlz0310/mcp-gateway/pull/59) / PR-C [#60](https://github.com/scottlz0310/mcp-gateway/pull/60) マージ済み（2026-05-06） |
 | 5 | **保留 issue 最終判断**（#3/#4/#5/#6） | triage | [#45](https://github.com/scottlz0310/mcp-gateway/issues/45) | ✅ 完了（2026-05-07） |
-| 6 | **audience 検証の祖先一致対応**（Codex 互換性 fix） | bug | [#61](https://github.com/scottlz0310/mcp-gateway/issues/61) | 🚧 [PR #63](https://github.com/scottlz0310/mcp-gateway/pull/63) レビュー対応中（実環境検証完了） |
+| 6 | **audience 検証の祖先一致対応**（Codex 互換性 fix） | bug | [#61](https://github.com/scottlz0310/mcp-gateway/issues/61) | ✅ [PR #63](https://github.com/scottlz0310/mcp-gateway/pull/63) マージ済み（2026-05-07） |
 | 7 | **v0.3.0 リリース** | release | — | 上記完了後 |
 
 ### v0.4.0 延期（#45 トリアージ 2026-05-07 確定）
@@ -451,86 +451,89 @@ v0.1.0 リリース後の次フェーズ。**コードベースの大規模追�
 
 #### v0.2.0-RM1: v0.1.0 E2E 動作検証（リリースゲート）
 
-**状態**: 🎯 次着手
-**成果物**: [`docs/runbook-e2e-v0.1.0.md`](docs/runbook-e2e-v0.1.0.md)（作成済み・実行待ち）
+**状態**: ✅ 完了（v0.2.0 リリースゲート通過）
+**成果物**: [`docs/runbook-e2e-v0.1.0.md`](docs/runbook-e2e-v0.1.0.md)
 
 v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境（Docker Compose）で踏破する。
 すべて green になったら v0.2.0 リリース判断材料の最大ピースが揃う。
 
 ##### サブタスク
 
-- [ ] ランブックに従い E2E 動作検証を実施
-- [ ] 失敗・回帰があれば fix PR を切り、ランブックに「観測された挙動」セクションを追記
-- [ ] CHANGELOG.md に「v0.1.0 E2E 検証完了」セクションを追加
+- [x] ランブックに従い E2E 動作検証を実施
+- [x] 失敗・回帰があれば fix PR を切り、ランブックに「観測された挙動」セクションを追記
+- [x] CHANGELOG.md に「v0.1.0 E2E 検証完了」セクションを追加
 
 ---
 
 #### v0.2.0-RM2: 観測性整備
 
-**状態**: 🗒️ 計画段階
+**状態**: ✅ 完了（#42 / PR #47 マージ済み）
 **目的**: 障害時に「何が起きたか」を log だけで追えるようにする。メトリクスは最小限。
 
 ##### 想定スコープ
 
-- [ ] 構造化ログ（`log/slog`）の出力フィールドを統一（request_id・route・upstream・latency_ms・status）
-- [ ] `internal/middleware/` への request_id 注入と propagation（X-Request-ID ヘッダ）
-- [ ] エラー分類タグ（`err_kind=upstream_timeout|token_expired|...`）の最小限の整備
-- [ ] 必要性が確認できた場合のみ Prometheus エンドポイント追加（YAGNI 判定優先）
-- [ ] 個別 issue 化は着手直前に判断
+- [x] 構造化ログ（`log/slog`）の出力フィールドを統一（`method`・`path`・`status`・`latency_ms`・`remote_addr`）
+- [x] HTTP request logger middleware を `internal/middleware/` に追加
+- [x] 認証・proxy・setup 周辺の主要イベントを `slog` に統一
+- [-] request_id / X-Request-ID propagation は #42 の確定スコープ外として未実装（必要化した時点で別 issue）
+- [-] Prometheus エンドポイントは YAGNI 判定で未実装（必要化した時点で別 issue）
 
 ---
 
 #### v0.2.0-RM3: CI 強化
 
-**状態**: 🗒️ 計画段階
+**状態**: ✅ 完了（#43 / PR #62 マージ済み）
 **目的**: 変更時の安全性をプラットフォーム任せにし、レビュー負荷を下げる。
 
 ##### 想定スコープ
 
-- [ ] `go test -coverprofile` をワークフローに組み込み・閾値（暫定 60%）を設定
-- [ ] `golangci-lint` の有効ルール拡張（gosec・errcheck・govet 強化）
-- [ ] govulncheck をワークフローに追加
-- [ ] 個別 issue 化は着手直前に判断
+- [x] `go test -coverprofile` をワークフローに組み込み・Codecov patch target 75% を設定
+- [x] `golangci-lint` 設定を追加（`errcheck`・`govet`・`staticcheck`・`unused`・`revive`）
+- [x] `govulncheck` をワークフローに追加
+- [x] 個別 issue #43 と PR #62 で完了
 
 ---
 
 #### v0.2.0-RM4: ドキュメント整備
 
-**状態**: 🗒️ 計画段階
+**状態**: ✅ 本PRで実装済み（#44）
 **目的**: README が機能追加で肥大化しているため、構造を再設計する。
 
 ##### 想定スコープ
 
-- [ ] README.md の章立て見直し（クイックスタート・運用・トラブルシュートを分離）
-- [ ] Setup wizard / config 暗号化 / token 永続化のクックブックを `docs/` に分離
+- [x] README.md / README.ja.md の章立て見直し（Getting Started を冒頭へ移動）
+- [x] 運用・トラブルシュートを `docs/operations.md` に分離
+- [x] 設定リファレンスを `docs/configuration.md` に分離
+- [x] `docs/README.md` を追加
+- [ ] PR マージ後に #44 を close
 - [ ] CHANGELOG.md からリリースノートを `docs/release-notes/` に分離（v0.1.0 から）
-- [ ] 個別 issue 化は着手直前に判断
+- [x] 個別 issue #44 として起票済み
 
 ---
 
 #### v0.2.0-RM5: 保留 issue 最終判断（triage）
 
-**状態**: 🗒️ 計画段階
+**状態**: ✅ 完了（#45 トリアージ 2026-05-07）
 
 ##### 検討対象
 
-- [ ] **#3** fly.io 調査 — 結論 Issue 本文に記載済み・open のままで実害は無いが、close するか判断
-- [ ] **#4** fly.io OAuth — fly.io との直接調整見込みが立たない場合は close
-- [ ] **#5** env var 移行（`OAUTH_*` 系） — 追加プロバイダ未定のため close 候補
-- [ ] **#6** 汎用 OIDC — Entra ID 不適合・対象 MCP 未定のため close 候補
+- [x] **#3** fly.io 調査 — Close (completed)
+- [x] **#4** fly.io OAuth — Close (wontfix)
+- [-] **#5** env var 移行（`OAUTH_*` 系） — v0.4.0 延期
+- [-] **#6** 汎用 OIDC — v0.4.0 延期
 
-各 issue について「open 維持 / close」を判断し、close する場合は判断理由をコメントで残す。
+各 issue について「open 維持 / close」を判断し、close する場合は判断理由をコメントで残した。
 
 ---
 
 #### v0.2.0-RM6: v0.2.0 リリース
 
-**状態**: 🗒️ RM1〜RM5 完了後
+**状態**: ✅ 完了（2026-05-05）
 
-- [ ] CHANGELOG.md に v0.2.0 セクションを記載
-- [ ] tag `v0.2.0` を作成・push
-- [ ] GitHub Release 公開
-- [ ] tasks.md に v0.3.0 の枠（あれば）を追加
+- [x] CHANGELOG.md に v0.2.0 セクションを記載
+- [x] tag `v0.2.0` を作成・push
+- [x] GitHub Release 公開
+- [x] tasks.md に v0.3.0 の枠を追加
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -475,8 +475,8 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 - [x] 構造化ログ（`log/slog`）の出力フィールドを統一（`method`・`path`・`status`・`latency_ms`・`remote_addr`）
 - [x] HTTP request logger middleware を `internal/middleware/` に追加
 - [x] 認証・proxy・setup 周辺の主要イベントを `slog` に統一
-- [-] request_id / X-Request-ID propagation は #42 の確定スコープ外として未実装（必要化した時点で別 issue）
-- [-] Prometheus エンドポイントは YAGNI 判定で未実装（必要化した時点で別 issue）
+- Deferred: request_id / X-Request-ID propagation は #42 の確定スコープ外として未実装（必要化した時点で別 issue）
+- Deferred: Prometheus エンドポイントは YAGNI 判定で未実装（必要化した時点で別 issue）
 
 ---
 
@@ -519,8 +519,8 @@ v0.1.0 で大幅に増えた永続化・暗号化・wizard まわりを実環境
 
 - [x] **#3** fly.io 調査 — Close (completed)
 - [x] **#4** fly.io OAuth — Close (wontfix)
-- [-] **#5** env var 移行（`OAUTH_*` 系） — v0.4.0 延期
-- [-] **#6** 汎用 OIDC — v0.4.0 延期
+- Deferred: **#5** env var 移行（`OAUTH_*` 系） — v0.4.0 延期
+- Deferred: **#6** 汎用 OIDC — v0.4.0 延期
 
 各 issue について「open 維持 / close」を判断し、close する場合は判断理由をコメントで残した。
 


### PR DESCRIPTION
## Summary

Closes #44.

- Rework the root README and README.ja.md around a front-loaded Getting Started flow.
- Add docs/configuration.md as the full environment variable, config.yaml, route, token persistence, reverse proxy, and endpoint reference.
- Expand docs/operations.md with start/stop procedures, health checks, structured slog field reference, troubleshooting, and deployment migration notes.
- Add docs/README.md as the docs index and update tasks.md / CHANGELOG entries for the current #42/#44/#49 state.

## Validation

- go test ./...
- git diff --check
- lefthook pre-commit: vet
- lefthook pre-push: test, lint, build