### PR TITLE
feat(config): migrate OAuth env vars to OAUTH_* and deprecate GITHUB_MCP_* (#5)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,17 @@
 
 ### 追加
 
+- 汎用 OAuth 環境変数を追加し、設定を GitHub 固有の命名から分離（[#5](https://github.com/scottlz0310/mcp-gateway/issues/5)）
+  - 新しい canonical 変数: `OAUTH_PROVIDER`（デフォルト `github`）、`OAUTH_CLIENT_ID`、`OAUTH_CLIENT_SECRET`、`OAUTH_SCOPES`
+  - `OAUTH_PROVIDER` は provider factory に渡され、将来の非 GitHub provider (#6) に備える
+  - 移行マップ:
+
+    | 新 | 旧（deprecated） |
+    |---|---|
+    | `OAUTH_PROVIDER` | _(新規; デフォルト `github`)_ |
+    | `OAUTH_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` |
+    | `OAUTH_CLIENT_SECRET` | `GITHUB_MCP_CLIENT_SECRET` |
+    | `OAUTH_SCOPES` | `GITHUB_MCP_OAUTH_SCOPES` |
 - 期限付き GitHub OAuth user access token の透過的ローテーション（[#70](https://github.com/scottlz0310/mcp-gateway/issues/70), Phase A）
   - `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` / `gateway.github_refresh_enabled` フラグで rotation を有効化（デフォルト `false`）
   - upstream provider が `refresh_token` と `expires_in` を返す場合、access token 期限の約 5 分前に refresh token を用いて自動ローテーションし、新 token を upstream MCP server に透過的に転送する
@@ -15,6 +26,7 @@
 
 ### 変更
 
+- OAuth 環境変数の読み込み優先順位を整理: `OAUTH_*` が旧 `GITHUB_MCP_*` より優先される。旧変数のみ設定されている場合は採用するが、process 内で 1 回だけ deprecation 警告を出力する。両方設定されている場合は canonical を採用し旧値は無視（警告あり）。旧名は将来のメジャーリリースで削除予定。YAML 設定キー（`auth.github_client_id`、`auth.github_client_secret`、`gateway.oauth_scopes`）は変更しない（[#5](https://github.com/scottlz0310/mcp-gateway/issues/5)）。
 - `auth.Handler.ValidateToken` がローテーション後の access token を subject と同時に返すよう拡張し、middleware が request context のトークンを差し替えられるようにした。内部 API のみで公開 surface には影響なし。
 
 ## [0.3.0] - 2026-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Generic OAuth environment variables to decouple configuration from GitHub-specific naming ([#5](https://github.com/scottlz0310/mcp-gateway/issues/5)).
+  - New canonical variables: `OAUTH_PROVIDER` (default `github`), `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_SCOPES`.
+  - `OAUTH_PROVIDER` is plumbed through to the provider factory and enables future non-GitHub providers (#6).
+  - Migration map:
+
+    | New | Legacy (deprecated) |
+    |---|---|
+    | `OAUTH_PROVIDER` | _(new; default `github`)_ |
+    | `OAUTH_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` |
+    | `OAUTH_CLIENT_SECRET` | `GITHUB_MCP_CLIENT_SECRET` |
+    | `OAUTH_SCOPES` | `GITHUB_MCP_OAUTH_SCOPES` |
 - Transparent rotation of expiring GitHub OAuth user access tokens ([#70](https://github.com/scottlz0310/mcp-gateway/issues/70), Phase A).
   - New `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` / `gateway.github_refresh_enabled` flag enables the rotation path. Defaults to `false`.
   - When the upstream provider advertises `refresh_token` + `expires_in`, the gateway re-uses the refresh token to rotate the access token within ~5 minutes of expiry. The rotated token is forwarded transparently to upstream MCP servers.
@@ -17,6 +28,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- OAuth environment variables read precedence: `OAUTH_*` wins over legacy `GITHUB_MCP_*`. If only the legacy variable is set the gateway uses it but logs a one-time deprecation warning per process. If both are set the canonical wins and the legacy value is ignored with a warning. The legacy names will be removed in a future major release. YAML config keys (`auth.github_client_id`, `auth.github_client_secret`, `gateway.oauth_scopes`) are unchanged ([#5](https://github.com/scottlz0310/mcp-gateway/issues/5)).
 - `auth.Handler.ValidateToken` now returns a rotated access token alongside the subject so middleware can substitute it in the request context. Internal API only; no public surface affected.
 
 ## [0.3.0] - 2026-05-07

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,8 +32,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      OAUTH_CLIENT_ID: <your-client-id>
+      OAUTH_CLIENT_SECRET: <your-client-secret>
       MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
       MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
@@ -185,8 +185,8 @@ setup token を消費して終了コード 0 で終了します。その後 supe
 
 ```yaml
 environment:
-  GITHUB_MCP_CLIENT_ID: <your-client-id>
-  GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+  OAUTH_CLIENT_ID: <your-client-id>
+  OAUTH_CLIENT_SECRET: <your-client-secret>
   MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
   MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
   ROUTE_GITHUB: /mcp/github|http://github-mcp:8082

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      OAUTH_CLIENT_ID: <your-client-id>
+      OAUTH_CLIENT_SECRET: <your-client-secret>
       MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
       MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
@@ -190,8 +190,8 @@ Minimal Docker environment:
 
 ```yaml
 environment:
-  GITHUB_MCP_CLIENT_ID: <your-client-id>
-  GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+  OAUTH_CLIENT_ID: <your-client-id>
+  OAUTH_CLIENT_SECRET: <your-client-secret>
   MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
   MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
   ROUTE_GITHUB: /mcp/github|http://github-mcp:8082

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,8 +67,8 @@ func main() {
 	}
 
 	// First-run wizard: if any required value is missing, enter setup mode.
-	envClientID := os.Getenv("GITHUB_MCP_CLIENT_ID")
-	envSecret := os.Getenv("GITHUB_MCP_CLIENT_SECRET")
+	envClientID, _ := appconfig.ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	envSecret, _ := appconfig.ResolveOAuthEnv("OAUTH_CLIENT_SECRET", "GITHUB_MCP_CLIENT_SECRET")
 
 	// Deprecation warning: MCP_GATEWAY_BASE_URL is superseded by MCP_GATEWAY_PUBLIC_URL.
 	// Warn whenever BASE_URL is set, regardless of whether PUBLIC_URL is also present.
@@ -115,7 +115,7 @@ func main() {
 			cfg.publicURL = "http://127.0.0.1:" + cfg.port
 		}
 	}
-	if strings.TrimSpace(os.Getenv("GITHUB_MCP_OAUTH_SCOPES")) == "" && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
+	if _, ok := appconfig.ResolveOAuthEnv("OAUTH_SCOPES", "GITHUB_MCP_OAUTH_SCOPES"); !ok && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
 		cfg.oauthScopes = appCfg.Gateway.OAuthScopes
 	}
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")) == "" && len(appCfg.Gateway.TrustedProxies) > 0 {
@@ -143,10 +143,13 @@ func main() {
 	// This prevents a mistyped env var from being encrypted and saved to config.yaml
 	// on a first boot that would otherwise fail (e.g. missing CLIENT_ID or routes).
 
-	// GitHub client ID: env var takes precedence over config file.
-	githubClientID := getEnv("GITHUB_MCP_CLIENT_ID", appCfg.Auth.GitHubClientID)
+	// GitHub client ID: env var (OAUTH_CLIENT_ID or legacy GITHUB_MCP_CLIENT_ID) takes precedence over config file.
+	githubClientID := envClientID
 	if strings.TrimSpace(githubClientID) == "" {
-		slog.Error("required value not set: provide GITHUB_MCP_CLIENT_ID env var or auth.github_client_id in config.yaml")
+		githubClientID = appCfg.Auth.GitHubClientID
+	}
+	if strings.TrimSpace(githubClientID) == "" {
+		slog.Error("required value not set: provide OAUTH_CLIENT_ID env var or auth.github_client_id in config.yaml")
 		os.Exit(1)
 	}
 
@@ -179,7 +182,7 @@ func main() {
 	cfg.githubClientSecret = githubClientSecret
 
 	prov, err := provider.New(provider.Config{
-		Kind:         "github",
+		Kind:         cfg.oauthProvider,
 		ClientID:     cfg.githubClientID,
 		ClientSecret: cfg.githubClientSecret,
 		RedirectURI:  strings.TrimRight(cfg.publicURL, "/") + "/callback",
@@ -346,6 +349,7 @@ type config struct {
 	publicURL string
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
 	bindAddr            string
+	oauthProvider       string
 	oauthScopes         string
 	port                string
 	logLevel            string
@@ -372,12 +376,22 @@ func loadConfig() config {
 	// bindAddr defaults to loopback; Docker deployments should set MCP_GATEWAY_BIND_ADDR=0.0.0.0:<port>.
 	bindAddr := getEnv("MCP_GATEWAY_BIND_ADDR", "127.0.0.1:"+port)
 
+	// OAuth scopes: OAUTH_SCOPES > legacy GITHUB_MCP_OAUTH_SCOPES > default.
+	oauthScopes := "repo,user"
+	if v, ok := appconfig.ResolveOAuthEnv("OAUTH_SCOPES", "GITHUB_MCP_OAUTH_SCOPES"); ok {
+		oauthScopes = v
+	}
+
+	// OAuth provider kind: defaults to "github" for backward compatibility.
+	oauthProvider := getEnv("OAUTH_PROVIDER", "github")
+
 	return config{
 		// githubClientID and githubClientSecret are resolved after key/config loading in main().
 		publicURL:           publicURL,
 		bindAddr:            bindAddr,
 		port:                port,
-		oauthScopes:         getEnv("GITHUB_MCP_OAUTH_SCOPES", "repo,user"),
+		oauthProvider:       oauthProvider,
+		oauthScopes:         oauthScopes,
 		logLevel:            getEnv("LOG_LEVEL", "info"),
 		upstreamURL:         getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
 		trustedProxyCIDRs:   splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,8 +9,8 @@ mcp-gateway needs all of the following before it can run in normal mode:
 
 | Requirement | Environment source | `config.yaml` source |
 |-------------|--------------------|----------------------|
-| GitHub OAuth client ID | `GITHUB_MCP_CLIENT_ID` | `auth.github_client_id` |
-| GitHub OAuth client secret | `GITHUB_MCP_CLIENT_SECRET` for first-start seeding | `auth.github_client_secret` |
+| OAuth client ID | `OAUTH_CLIENT_ID` (legacy: `GITHUB_MCP_CLIENT_ID`) | `auth.github_client_id` |
+| OAuth client secret | `OAUTH_CLIENT_SECRET` for first-start seeding (legacy: `GITHUB_MCP_CLIENT_SECRET`) | `auth.github_client_secret` |
 | At least one route | `ROUTE_<NAME>` | `routes:` |
 
 If any required value is missing, the gateway enters setup mode and prints a
@@ -22,26 +22,37 @@ Configuration is resolved in this order:
 
 | Setting | Precedence |
 |---------|------------|
-| GitHub client ID | `GITHUB_MCP_CLIENT_ID` > `auth.github_client_id` |
-| GitHub client secret | encrypted/plain `auth.github_client_secret` > non-empty `GITHUB_MCP_CLIENT_SECRET` used to seed `config.yaml` |
+| OAuth provider | `OAUTH_PROVIDER` > `github` (default) |
+| OAuth client ID | `OAUTH_CLIENT_ID` > deprecated `GITHUB_MCP_CLIENT_ID` > `auth.github_client_id` |
+| OAuth client secret | encrypted/plain `auth.github_client_secret` > non-empty `OAUTH_CLIENT_SECRET` > deprecated `GITHUB_MCP_CLIENT_SECRET` used to seed `config.yaml` |
 | Routes | `ROUTE_<NAME>` env vars > `routes:` in `config.yaml` > deprecated `GITHUB_MCP_UPSTREAM_URL` fallback |
 | Public URL | `MCP_GATEWAY_PUBLIC_URL` > deprecated `MCP_GATEWAY_BASE_URL` > `gateway.public_url` > deprecated `gateway.base_url` > default |
 | Bind address | `MCP_GATEWAY_BIND_ADDR` > `gateway.bind_addr` > `127.0.0.1:<resolved-port>` |
-| OAuth scopes | `GITHUB_MCP_OAUTH_SCOPES` > `gateway.oauth_scopes` > `repo,user` |
+| OAuth scopes | `OAUTH_SCOPES` > deprecated `GITHUB_MCP_OAUTH_SCOPES` > `gateway.oauth_scopes` > `repo,user` |
 | Trusted proxies | `MCP_GATEWAY_TRUSTED_PROXIES` > `gateway.trusted_proxies` > none |
 | Token audience strict mode | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` > `gateway.token_audience_strict` > `false` |
 | GitHub refresh token rotation | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` > `gateway.github_refresh_enabled` > `false` |
 
-The GitHub client secret is intentionally special: once `config.yaml` contains a
-secret, `GITHUB_MCP_CLIENT_SECRET` is ignored except during first-start seeding.
+The OAuth client secret is intentionally special: once `config.yaml` contains a
+secret, `OAUTH_CLIENT_SECRET` / `GITHUB_MCP_CLIENT_SECRET` are ignored except
+during first-start seeding.
+
+When the legacy `GITHUB_MCP_*` variables are observed at startup, the gateway
+emits a one-time `slog.Warn` per legacy variable. If both the canonical
+`OAUTH_*` and its legacy counterpart are set, the canonical wins and a warning
+is logged that the legacy is ignored.
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITHUB_MCP_CLIENT_ID` | none | GitHub OAuth App client ID. Required unless `auth.github_client_id` is set. |
-| `GITHUB_MCP_CLIENT_SECRET` | none | GitHub OAuth App client secret. Used to seed encrypted `config.yaml` when no config secret exists. |
-| `GITHUB_MCP_OAUTH_SCOPES` | `repo,user` | GitHub OAuth scopes requested by the gateway. |
+| `OAUTH_PROVIDER` | `github` | OAuth provider kind. Currently only `github` is supported. |
+| `OAUTH_CLIENT_ID` | none | OAuth App client ID. Required unless `auth.github_client_id` is set. Supersedes `GITHUB_MCP_CLIENT_ID`. |
+| `OAUTH_CLIENT_SECRET` | none | OAuth App client secret. Used to seed encrypted `config.yaml` when no config secret exists. Supersedes `GITHUB_MCP_CLIENT_SECRET`. |
+| `OAUTH_SCOPES` | `repo,user` | OAuth scopes requested by the gateway. Supersedes `GITHUB_MCP_OAUTH_SCOPES`. |
+| `GITHUB_MCP_CLIENT_ID` | none | **Deprecated** — use `OAUTH_CLIENT_ID`. Still accepted with a startup warning. |
+| `GITHUB_MCP_CLIENT_SECRET` | none | **Deprecated** — use `OAUTH_CLIENT_SECRET`. Still accepted with a startup warning. |
+| `GITHUB_MCP_OAUTH_SCOPES` | none | **Deprecated** — use `OAUTH_SCOPES`. Still accepted with a startup warning. |
 | `ROUTE_<NAME>` | none | Route definition in `<prefix>|<upstream_url>[|auth=none]` form. At least one route is required unless configured in `config.yaml`. |
 | `MCP_CONFIG_FILE` | `./config.yaml` | Path to persisted YAML configuration. |
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the age X25519 identity used to encrypt `auth.github_client_secret`. |
@@ -163,7 +174,7 @@ Startup behavior:
 3. Resolve the secret:
    - `ENC[age:]...` in config: decrypt and use.
    - Plaintext in config: encrypt, rewrite config, and use.
-   - No config secret plus `GITHUB_MCP_CLIENT_SECRET`: encrypt, save to config, and use.
+   - No config secret plus `OAUTH_CLIENT_SECRET` (or legacy `GITHUB_MCP_CLIENT_SECRET`): encrypt, save to config, and use.
    - No source: fail startup.
 
 Key generation priority:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,8 +28,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      GITHUB_MCP_CLIENT_ID: <your-client-id>
-      GITHUB_MCP_CLIENT_SECRET: <your-client-secret>
+      OAUTH_CLIENT_ID: <your-client-id>
+      OAUTH_CLIENT_SECRET: <your-client-secret>
       MCP_GATEWAY_BIND_ADDR: 0.0.0.0:8080
       MCP_GATEWAY_PUBLIC_URL: http://127.0.0.1:8080
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
@@ -48,8 +48,8 @@ usually does not exist. Point runtime files at writable local paths:
 export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
 export MCP_CONFIG_FILE=./config.yaml
 export MCP_GATEWAY_KEY_PATH=./gateway.key
-export GITHUB_MCP_CLIENT_ID=<your-client-id>
-export GITHUB_MCP_CLIENT_SECRET=<your-client-secret>
+export OAUTH_CLIENT_ID=<your-client-id>
+export OAUTH_CLIENT_SECRET=<your-client-secret>
 export ROUTE_GITHUB=/mcp/github|http://127.0.0.1:8082
 
 go run ./cmd/server
@@ -237,7 +237,8 @@ Fix:
    regenerated.
 3. If no backup or master key exists, remove or replace the encrypted
    `auth.github_client_secret` in `config.yaml`, provide
-   `GITHUB_MCP_CLIENT_SECRET` again, and let the gateway write a new encrypted
+   `OAUTH_CLIENT_SECRET` again (legacy `GITHUB_MCP_CLIENT_SECRET` also accepted
+   with a deprecation warning), and let the gateway write a new encrypted
    value with a new key.
 
 Do not delete `gateway.key` as a first response unless you know how the current
@@ -252,13 +253,14 @@ Symptoms:
 Cause:
 
 - Neither `auth.github_client_secret` in `config.yaml` nor
-  `GITHUB_MCP_CLIENT_SECRET` is available.
+  `OAUTH_CLIENT_SECRET` (or legacy `GITHUB_MCP_CLIENT_SECRET`) is available.
 
 Fix:
 
-- Provide `GITHUB_MCP_CLIENT_SECRET` once so the gateway can encrypt and persist
+- Provide `OAUTH_CLIENT_SECRET` once so the gateway can encrypt and persist
   it, or restore a valid encrypted `auth.github_client_secret` and matching
-  `gateway.key`.
+  `gateway.key`. The deprecated `GITHUB_MCP_CLIENT_SECRET` is still accepted
+  for backward compatibility but emits a startup warning.
 
 ### No Routes Configured
 

--- a/examples/copilot-review-routing/.env.example
+++ b/examples/copilot-review-routing/.env.example
@@ -13,9 +13,11 @@ GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #   Homepage URL:              http://127.0.0.1:8080
 #   Authorization callback URL: http://127.0.0.1:8080/callback
 #
-# mcp-gateway uses GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET.
-GITHUB_MCP_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
-GITHUB_MCP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# mcp-gateway uses OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET. The legacy
+# GITHUB_MCP_CLIENT_ID / GITHUB_MCP_CLIENT_SECRET names are still accepted
+# with a deprecation warning and will be removed in a future major release.
+OAUTH_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
+OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # copilot-review-mcp runs behind mcp-gateway by default and trusts
 # X-Authenticated-User. Set COPILOT_REVIEW_AUTH_MODE=standalone only when
@@ -26,7 +28,7 @@ COPILOT_REVIEW_AUTH_MODE=gateway
 # ---- copilot-review-mcp standalone mode credentials (optional) ----
 # Required only when COPILOT_REVIEW_AUTH_MODE=standalone. In gateway mode,
 # copilot-review-mcp reuses mcp-gateway's OAuth token; these are not needed.
-# Can point to the same GitHub OAuth App as GITHUB_MCP_CLIENT_ID/SECRET.
+# Can point to the same GitHub OAuth App as OAUTH_CLIENT_ID/SECRET.
 # GITHUB_CLIENT_ID=Ov23xxxxxxxxxxxxxxxx
 # GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
@@ -48,7 +50,7 @@ MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080
 LOG_LEVEL=info
 # SESSION_TTL_MIN=10
 # TOKEN_CACHE_TTL_MIN=30
-# GITHUB_MCP_OAUTH_SCOPES=repo,user
+# OAUTH_SCOPES=repo,user
 
 # ---- Image overrides (optional) ----
 # GITHUB_MCP_IMAGE=ghcr.io/github/github-mcp-server:main

--- a/examples/copilot-review-routing/README.md
+++ b/examples/copilot-review-routing/README.md
@@ -74,6 +74,7 @@ to the mcp-gateway credentials. See `.env.example` for details.
 
 ### Shared OAuth App credentials
 
-`GITHUB_MCP_CLIENT_ID`/`GITHUB_MCP_CLIENT_SECRET` (mcp-gateway) and
+`OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` (mcp-gateway; legacy
+`GITHUB_MCP_CLIENT_ID`/`GITHUB_MCP_CLIENT_SECRET` still accepted) and
 `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` (copilot-review-mcp, standalone mode only)
 can point to the **same** GitHub OAuth App.

--- a/examples/copilot-review-routing/docker-compose.yml
+++ b/examples/copilot-review-routing/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     ports:
       - "127.0.0.1:${MCP_GATEWAY_PORT:-8080}:${MCP_GATEWAY_PORT:-8080}"
     environment:
-      GITHUB_MCP_CLIENT_ID: ${GITHUB_MCP_CLIENT_ID}
-      GITHUB_MCP_CLIENT_SECRET: ${GITHUB_MCP_CLIENT_SECRET}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:-${GITHUB_MCP_CLIENT_ID:-}}
+      OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET:-${GITHUB_MCP_CLIENT_SECRET:-}}
       # Bind on all interfaces so Docker port-forwarding works (container → host).
       # Port in MCP_GATEWAY_BIND_ADDR must match MCP_GATEWAY_PORT (both default to 8080).
       MCP_GATEWAY_BIND_ADDR: ${MCP_GATEWAY_BIND_ADDR:-0.0.0.0:8080}
@@ -30,7 +30,7 @@ services:
       # Route longest-prefix-first; both routes served from a single gateway port.
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
       ROUTE_COPILOT_REVIEW: /mcp/copilot-review|http://copilot-review-mcp:8083
-      GITHUB_MCP_OAUTH_SCOPES: ${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
+      OAUTH_SCOPES: ${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SESSION_TTL_MIN: ${SESSION_TTL_MIN:-10}
       TOKEN_CACHE_TTL_MIN: ${TOKEN_CACHE_TTL_MIN:-30}
@@ -93,7 +93,7 @@ services:
       AUTH_MODE: ${COPILOT_REVIEW_AUTH_MODE:-gateway}
       BASE_URL: ${COPILOT_REVIEW_BASE_URL:-http://localhost:8083}
       MCP_PORT: ${COPILOT_REVIEW_MCP_PORT:-8083}
-      GITHUB_OAUTH_SCOPES: ${GITHUB_MCP_OAUTH_SCOPES:-repo,user}
+      GITHUB_OAUTH_SCOPES: ${OAUTH_SCOPES:-${GITHUB_MCP_OAUTH_SCOPES:-repo,user}}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SESSION_TTL_MIN: ${SESSION_TTL_MIN:-10}
       TOKEN_CACHE_TTL_MIN: ${TOKEN_CACHE_TTL_MIN:-30}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,11 +105,14 @@ func SaveConfig(path string, cfg *AppConfig) error {
 //
 //  1. cfg.Auth.GitHubClientSecret is "ENC[age:]..." → decrypt and return plaintext
 //  2. cfg.Auth.GitHubClientSecret is non-empty plaintext → encrypt, write back, return plaintext
-//  3. field empty/absent + GITHUB_MCP_CLIENT_SECRET env var set → encrypt, save to config, return
+//  3. field empty/absent + OAUTH_CLIENT_SECRET (or legacy GITHUB_MCP_CLIENT_SECRET) env var set → encrypt, save to config, return
 //  4. field empty + env var absent → return error
 //
 // The config file at configPath is updated in cases 2 and 3.
 // The returned plaintext is never written to the log.
+//
+// When both OAUTH_CLIENT_SECRET and the legacy GITHUB_MCP_CLIENT_SECRET are set,
+// the new variable wins and a deprecation warning is logged for the legacy one.
 func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, error) {
 	secret := cfg.Auth.GitHubClientSecret
 
@@ -134,20 +137,20 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, 
 		return secret, nil
 
 	default:
-		envSecret, ok := os.LookupEnv("GITHUB_MCP_CLIENT_SECRET")
-		if ok && strings.TrimSpace(envSecret) != "" {
+		envSecret, envSource, ok := resolveOAuthEnvSourced("OAUTH_CLIENT_SECRET", "GITHUB_MCP_CLIENT_SECRET")
+		if ok {
 			envSecret = strings.TrimSpace(envSecret)
-			slog.Info("encrypting GITHUB_MCP_CLIENT_SECRET from env and saving to config")
+			slog.Info("encrypting OAuth client secret from env and saving to config", "source", envSource)
 			encrypted, err := EncryptField(km, envSecret)
 			if err != nil {
-				return "", fmt.Errorf("encrypting GITHUB_MCP_CLIENT_SECRET from env: %w", err)
+				return "", fmt.Errorf("encrypting %s from env: %w", envSource, err)
 			}
 			cfg.Auth.GitHubClientSecret = encrypted
 			if err := SaveConfig(configPath, cfg); err != nil {
-				return "", fmt.Errorf("saving config after encrypting GITHUB_MCP_CLIENT_SECRET: %w", err)
+				return "", fmt.Errorf("saving config after encrypting %s: %w", envSource, err)
 			}
 			return envSecret, nil
 		}
-		return "", fmt.Errorf("github_client_secret is required: set GITHUB_MCP_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
+		return "", fmt.Errorf("github_client_secret is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -86,7 +86,7 @@ func TestMigrateSecret_FromEnvVar(t *testing.T) {
 	km := testKeyMaterial(t)
 	envSecret := "secret-from-env-var-xyz"
 	t.Setenv("OAUTH_CLIENT_SECRET", envSecret)
-	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", "")
 	resetLegacyEnvWarnedForTest()
 
 	cfg := &AppConfig{} // no secret in config
@@ -119,7 +119,7 @@ func TestMigrateSecret_FromLegacyEnvVar(t *testing.T) {
 
 	km := testKeyMaterial(t)
 	envSecret := "legacy-secret-abc"
-	_ = os.Unsetenv("OAUTH_CLIENT_SECRET")
+	t.Setenv("OAUTH_CLIENT_SECRET", "")
 	t.Setenv("GITHUB_MCP_CLIENT_SECRET", envSecret)
 	resetLegacyEnvWarnedForTest()
 
@@ -182,8 +182,8 @@ func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
 	configPath := filepath.Join(dir, "config.yaml")
 
 	km := testKeyMaterial(t)
-	_ = os.Unsetenv("OAUTH_CLIENT_SECRET")
-	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	t.Setenv("OAUTH_CLIENT_SECRET", "")
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", "")
 
 	cfg := &AppConfig{}
 	_, err := MigrateSecret(configPath, cfg, km)
@@ -204,7 +204,7 @@ func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
 	km := testKeyMaterial(t)
 	secretValue := "ultrasecret-do-not-log-me-abc123"
 	t.Setenv("OAUTH_CLIENT_SECRET", secretValue)
-	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", "")
 	resetLegacyEnvWarnedForTest()
 
 	cfg := &AppConfig{}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,7 +77,7 @@ func TestMigrateSecret_PlaintextRewritten(t *testing.T) {
 	}
 }
 
-// TestMigrateSecret_FromEnvVar verifies that GITHUB_MCP_CLIENT_SECRET is
+// TestMigrateSecret_FromEnvVar verifies that OAUTH_CLIENT_SECRET is
 // encrypted and saved when the config field is absent.
 func TestMigrateSecret_FromEnvVar(t *testing.T) {
 	dir := t.TempDir()
@@ -85,7 +85,9 @@ func TestMigrateSecret_FromEnvVar(t *testing.T) {
 
 	km := testKeyMaterial(t)
 	envSecret := "secret-from-env-var-xyz"
-	t.Setenv("GITHUB_MCP_CLIENT_SECRET", envSecret)
+	t.Setenv("OAUTH_CLIENT_SECRET", envSecret)
+	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	resetLegacyEnvWarnedForTest()
 
 	cfg := &AppConfig{} // no secret in config
 	if err := SaveConfig(configPath, cfg); err != nil {
@@ -107,6 +109,72 @@ func TestMigrateSecret_FromEnvVar(t *testing.T) {
 	}
 }
 
+// TestMigrateSecret_FromLegacyEnvVar verifies that the deprecated
+// GITHUB_MCP_CLIENT_SECRET env var still seeds the config when the new
+// OAUTH_CLIENT_SECRET is unset, with a deprecation warning logged.
+func TestMigrateSecret_FromLegacyEnvVar(t *testing.T) {
+	logBuf := captureLogs(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	envSecret := "legacy-secret-abc"
+	_ = os.Unsetenv("OAUTH_CLIENT_SECRET")
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", envSecret)
+	resetLegacyEnvWarnedForTest()
+
+	cfg := &AppConfig{}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if got != envSecret {
+		t.Errorf("got %q, want %q", got, envSecret)
+	}
+	out := logBuf.String()
+	if !strings.Contains(out, "GITHUB_MCP_CLIENT_SECRET") {
+		t.Errorf("expected deprecation warning mentioning GITHUB_MCP_CLIENT_SECRET, got: %s", out)
+	}
+	if !strings.Contains(out, "OAUTH_CLIENT_SECRET") {
+		t.Errorf("expected deprecation warning to mention canonical OAUTH_CLIENT_SECRET, got: %s", out)
+	}
+}
+
+// TestMigrateSecret_NewWinsOverLegacy verifies that when both env vars are
+// set, OAUTH_CLIENT_SECRET wins and a warning is logged that the legacy is
+// ignored.
+func TestMigrateSecret_NewWinsOverLegacy(t *testing.T) {
+	logBuf := captureLogs(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	t.Setenv("OAUTH_CLIENT_SECRET", "new-secret-wins")
+	t.Setenv("GITHUB_MCP_CLIENT_SECRET", "old-secret-ignored")
+	resetLegacyEnvWarnedForTest()
+
+	cfg := &AppConfig{}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if got != "new-secret-wins" {
+		t.Errorf("expected OAUTH_CLIENT_SECRET to win, got %q", got)
+	}
+	out := logBuf.String()
+	if !strings.Contains(out, "GITHUB_MCP_CLIENT_SECRET") || !strings.Contains(out, "ignored") {
+		t.Errorf("expected warning that legacy var is ignored, got: %s", out)
+	}
+}
+
 // TestMigrateSecret_NoSecretAnywhere verifies that an error is returned
 // when neither config nor env var has the secret.
 func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
@@ -114,6 +182,7 @@ func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
 	configPath := filepath.Join(dir, "config.yaml")
 
 	km := testKeyMaterial(t)
+	_ = os.Unsetenv("OAUTH_CLIENT_SECRET")
 	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
 
 	cfg := &AppConfig{}
@@ -134,7 +203,9 @@ func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
 
 	km := testKeyMaterial(t)
 	secretValue := "ultrasecret-do-not-log-me-abc123"
-	t.Setenv("GITHUB_MCP_CLIENT_SECRET", secretValue)
+	t.Setenv("OAUTH_CLIENT_SECRET", secretValue)
+	_ = os.Unsetenv("GITHUB_MCP_CLIENT_SECRET")
+	resetLegacyEnvWarnedForTest()
 
 	cfg := &AppConfig{}
 	enc, err := MigrateSecret(configPath, cfg, km)

--- a/internal/config/envcompat.go
+++ b/internal/config/envcompat.go
@@ -12,18 +12,7 @@ import (
 // per process lifetime even when the variable is consulted multiple times.
 var legacyEnvWarned sync.Map
 
-// resetLegacyEnvWarnedForTest clears the legacy-env warning tracker. Tests use
-// it to keep deprecation-warning assertions independent of each other; it is
-// not exported because production code must not reset the once-per-process
-// guarantee.
-func resetLegacyEnvWarnedForTest() {
-	legacyEnvWarned.Range(func(key, _ any) bool {
-		legacyEnvWarned.Delete(key)
-		return true
-	})
-}
-
-// warnLegacyEnvOnce logs a deprecation warning for a legacy env var the first
+// warnLegacyEnvOncelogs a deprecation warning for a legacy env var the first
 // time it is observed. When ignored is true, the warning indicates that the
 // legacy variable was ignored because the canonical variable is also set;
 // otherwise, the warning indicates the legacy variable is in use.

--- a/internal/config/envcompat.go
+++ b/internal/config/envcompat.go
@@ -12,7 +12,7 @@ import (
 // per process lifetime even when the variable is consulted multiple times.
 var legacyEnvWarned sync.Map
 
-// warnLegacyEnvOncelogs a deprecation warning for a legacy env var the first
+// warnLegacyEnvOnce logs a deprecation warning for a legacy env var the first
 // time it is observed. When ignored is true, the warning indicates that the
 // legacy variable was ignored because the canonical variable is also set;
 // otherwise, the warning indicates the legacy variable is in use.
@@ -73,8 +73,9 @@ func lookupNonEmptyEnv(key string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if strings.TrimSpace(v) == "" {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
 		return "", false
 	}
-	return v, true
+	return trimmed, true
 }

--- a/internal/config/envcompat.go
+++ b/internal/config/envcompat.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+// legacyEnvWarned tracks which deprecated environment variables have already
+// emitted a deprecation warning so that operators only see the message once
+// per process lifetime even when the variable is consulted multiple times.
+var legacyEnvWarned sync.Map
+
+// resetLegacyEnvWarnedForTest clears the legacy-env warning tracker. Tests use
+// it to keep deprecation-warning assertions independent of each other; it is
+// not exported because production code must not reset the once-per-process
+// guarantee.
+func resetLegacyEnvWarnedForTest() {
+	legacyEnvWarned.Range(func(key, _ any) bool {
+		legacyEnvWarned.Delete(key)
+		return true
+	})
+}
+
+// warnLegacyEnvOnce logs a deprecation warning for a legacy env var the first
+// time it is observed. When ignored is true, the warning indicates that the
+// legacy variable was ignored because the canonical variable is also set;
+// otherwise, the warning indicates the legacy variable is in use.
+//
+// The warning is emitted at most once per legacy variable per process.
+func warnLegacyEnvOnce(legacyKey, canonicalKey string, ignored bool) {
+	if _, loaded := legacyEnvWarned.LoadOrStore(legacyKey, true); loaded {
+		return
+	}
+	if ignored {
+		slog.Warn("legacy env var ignored because canonical env var is set",
+			"legacy", legacyKey,
+			"canonical", canonicalKey,
+			"hint", legacyKey+" will be removed in a future major release",
+		)
+		return
+	}
+	slog.Warn("legacy env var is deprecated; use canonical env var instead",
+		"legacy", legacyKey,
+		"canonical", canonicalKey,
+		"hint", legacyKey+" will be removed in a future major release",
+	)
+}
+
+// ResolveOAuthEnv returns the value of the canonical OAUTH_* environment
+// variable, falling back to a deprecated legacy variable when the canonical
+// one is unset. The boolean ok indicates whether either variable was set to a
+// non-empty value.
+//
+// Priority:
+//  1. canonicalKey set and non-empty → returned (legacy ignored with warning)
+//  2. only legacyKey set and non-empty → returned with deprecation warning
+//  3. neither set → ("", false)
+func ResolveOAuthEnv(canonicalKey, legacyKey string) (value string, ok bool) {
+	v, _, ok := resolveOAuthEnvSourced(canonicalKey, legacyKey)
+	return v, ok
+}
+
+func resolveOAuthEnvSourced(canonicalKey, legacyKey string) (value, source string, ok bool) {
+	canonical, canonicalSet := lookupNonEmptyEnv(canonicalKey)
+	legacy, legacySet := lookupNonEmptyEnv(legacyKey)
+	switch {
+	case canonicalSet && legacySet:
+		warnLegacyEnvOnce(legacyKey, canonicalKey, true)
+		return canonical, canonicalKey, true
+	case canonicalSet:
+		return canonical, canonicalKey, true
+	case legacySet:
+		warnLegacyEnvOnce(legacyKey, canonicalKey, false)
+		return legacy, legacyKey, true
+	default:
+		return "", "", false
+	}
+}
+
+func lookupNonEmptyEnv(key string) (string, bool) {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return "", false
+	}
+	if strings.TrimSpace(v) == "" {
+		return "", false
+	}
+	return v, true
+}

--- a/internal/config/envcompat_export_test.go
+++ b/internal/config/envcompat_export_test.go
@@ -1,0 +1,11 @@
+package config
+
+// resetLegacyEnvWarnedForTest clears the legacy-env warning tracker. Tests use
+// it to keep deprecation-warning assertions independent of each other. It
+// lives in a *_test.go file so it is excluded from production builds.
+func resetLegacyEnvWarnedForTest() {
+	legacyEnvWarned.Range(func(key, _ any) bool {
+		legacyEnvWarned.Delete(key)
+		return true
+	})
+}

--- a/internal/config/envcompat_test.go
+++ b/internal/config/envcompat_test.go
@@ -87,3 +87,26 @@ func TestResolveOAuthEnv_EmptyTreatedAsUnset(t *testing.T) {
 		t.Fatalf("expected fallback to legacy, got %q ok=%v", v, ok)
 	}
 }
+
+// TestResolveOAuthEnv_TrimsWhitespace verifies values returned by
+// ResolveOAuthEnv have surrounding whitespace trimmed so downstream consumers
+// (e.g. OAuth scopes, client IDs forwarded to GitHub) never see stray
+// whitespace from container env injection or shell heredocs.
+func TestResolveOAuthEnv_TrimsWhitespace(t *testing.T) {
+	resetLegacyEnvWarnedForTest()
+	t.Setenv("OAUTH_CLIENT_ID", "  client-id-with-spaces  ")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "")
+
+	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if !ok || v != "client-id-with-spaces" {
+		t.Fatalf("expected trimmed value, got %q ok=%v", v, ok)
+	}
+
+	resetLegacyEnvWarnedForTest()
+	t.Setenv("OAUTH_CLIENT_ID", "")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "\tlegacy-id\n")
+	v, ok = ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if !ok || v != "legacy-id" {
+		t.Fatalf("expected trimmed legacy value, got %q ok=%v", v, ok)
+	}
+}

--- a/internal/config/envcompat_test.go
+++ b/internal/config/envcompat_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestResolveOAuthEnv_PrefersCanonical verifies the canonical env var wins
+// when both canonical and legacy are set.
+func TestResolveOAuthEnv_PrefersCanonical(t *testing.T) {
+	logBuf := captureLogs(t)
+	resetLegacyEnvWarnedForTest()
+	t.Setenv("OAUTH_CLIENT_ID", "new")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "old")
+
+	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if !ok || v != "new" {
+		t.Fatalf("got %q ok=%v, want \"new\" ok=true", v, ok)
+	}
+	out := logBuf.String()
+	if !strings.Contains(out, "GITHUB_MCP_CLIENT_ID") || !strings.Contains(out, "ignored") {
+		t.Errorf("expected ignored-legacy warning, got: %s", out)
+	}
+}
+
+// TestResolveOAuthEnv_FallsBackToLegacy verifies the legacy var is used and
+// warned about when only it is set.
+func TestResolveOAuthEnv_FallsBackToLegacy(t *testing.T) {
+	logBuf := captureLogs(t)
+	resetLegacyEnvWarnedForTest()
+	_ = os.Unsetenv("OAUTH_CLIENT_ID")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "legacy-id")
+
+	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if !ok || v != "legacy-id" {
+		t.Fatalf("got %q ok=%v, want \"legacy-id\" ok=true", v, ok)
+	}
+	out := logBuf.String()
+	if !strings.Contains(out, "deprecated") || !strings.Contains(out, "GITHUB_MCP_CLIENT_ID") {
+		t.Errorf("expected deprecation warning, got: %s", out)
+	}
+}
+
+// TestResolveOAuthEnv_NeitherSet returns ok=false when neither var is set.
+func TestResolveOAuthEnv_NeitherSet(t *testing.T) {
+	resetLegacyEnvWarnedForTest()
+	_ = os.Unsetenv("OAUTH_CLIENT_ID")
+	_ = os.Unsetenv("GITHUB_MCP_CLIENT_ID")
+
+	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if ok || v != "" {
+		t.Fatalf("got %q ok=%v, want \"\" ok=false", v, ok)
+	}
+}
+
+// TestResolveOAuthEnv_WarnOnce verifies the deprecation warning is emitted at
+// most once per legacy variable even across repeated lookups.
+func TestResolveOAuthEnv_WarnOnce(t *testing.T) {
+	logBuf := captureLogs(t)
+	resetLegacyEnvWarnedForTest()
+	_ = os.Unsetenv("OAUTH_CLIENT_ID")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "legacy-id")
+
+	for i := 0; i < 3; i++ {
+		ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	}
+	count := strings.Count(logBuf.String(), "GITHUB_MCP_CLIENT_ID")
+	// Each warning line mentions the legacy var twice (once in the message
+	// hint, once in the structured field). Allow up to two occurrences total.
+	if count > 2 {
+		t.Errorf("expected the warning to be emitted once, but legacy var was logged %d times: %s", count, logBuf.String())
+	}
+	if count == 0 {
+		t.Errorf("expected at least one deprecation warning, got none")
+	}
+}
+
+// TestResolveOAuthEnv_EmptyTreatedAsUnset verifies an empty-string env var is
+// treated as unset.
+func TestResolveOAuthEnv_EmptyTreatedAsUnset(t *testing.T) {
+	resetLegacyEnvWarnedForTest()
+	t.Setenv("OAUTH_CLIENT_ID", "   ")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "legacy")
+
+	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
+	if !ok || v != "legacy" {
+		t.Fatalf("expected fallback to legacy, got %q ok=%v", v, ok)
+	}
+}

--- a/internal/config/envcompat_test.go
+++ b/internal/config/envcompat_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -29,7 +28,7 @@ func TestResolveOAuthEnv_PrefersCanonical(t *testing.T) {
 func TestResolveOAuthEnv_FallsBackToLegacy(t *testing.T) {
 	logBuf := captureLogs(t)
 	resetLegacyEnvWarnedForTest()
-	_ = os.Unsetenv("OAUTH_CLIENT_ID")
+	t.Setenv("OAUTH_CLIENT_ID", "")
 	t.Setenv("GITHUB_MCP_CLIENT_ID", "legacy-id")
 
 	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
@@ -45,8 +44,8 @@ func TestResolveOAuthEnv_FallsBackToLegacy(t *testing.T) {
 // TestResolveOAuthEnv_NeitherSet returns ok=false when neither var is set.
 func TestResolveOAuthEnv_NeitherSet(t *testing.T) {
 	resetLegacyEnvWarnedForTest()
-	_ = os.Unsetenv("OAUTH_CLIENT_ID")
-	_ = os.Unsetenv("GITHUB_MCP_CLIENT_ID")
+	t.Setenv("OAUTH_CLIENT_ID", "")
+	t.Setenv("GITHUB_MCP_CLIENT_ID", "")
 
 	v, ok := ResolveOAuthEnv("OAUTH_CLIENT_ID", "GITHUB_MCP_CLIENT_ID")
 	if ok || v != "" {
@@ -59,7 +58,7 @@ func TestResolveOAuthEnv_NeitherSet(t *testing.T) {
 func TestResolveOAuthEnv_WarnOnce(t *testing.T) {
 	logBuf := captureLogs(t)
 	resetLegacyEnvWarnedForTest()
-	_ = os.Unsetenv("OAUTH_CLIENT_ID")
+	t.Setenv("OAUTH_CLIENT_ID", "")
 	t.Setenv("GITHUB_MCP_CLIENT_ID", "legacy-id")
 
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
Closes #5.

## Summary

Introduces canonical `OAUTH_*` environment variables to decouple gateway configuration from GitHub-specific naming, in preparation for generic OIDC provider support (#6) and delegated background access (#70/#72).

## Migration map

| New | Legacy (deprecated) |
|---|---|
| `OAUTH_PROVIDER` | _(new; default `github`)_ |
| `OAUTH_CLIENT_ID` | `GITHUB_MCP_CLIENT_ID` |
| `OAUTH_CLIENT_SECRET` | `GITHUB_MCP_CLIENT_SECRET` |
| `OAUTH_SCOPES` | `GITHUB_MCP_OAUTH_SCOPES` |

## Precedence

1. Canonical `OAUTH_*` set → wins.
2. Only legacy `GITHUB_MCP_*` set → used, one-time `slog.Warn` per process.
3. Both set → canonical wins, legacy ignored (with warning).
4. Neither set → existing error path (e.g. missing-client-secret).

The deprecation warning is emitted at most once per legacy variable per process via a `sync.Map` guard.

## What changed

- `internal/config/envcompat.go` (new): `ResolveOAuthEnv(canonical, legacy)` helper + once-only warn.
- `internal/config/config.go`: `MigrateSecret` resolves the env secret via the new helper; error messages mention the resolved source variable.
- `cmd/server/main.go`: all OAuth env lookups go through the helper; `OAUTH_PROVIDER` is plumbed through to `provider.New(Kind:)`.
- Tests: 5 new unit tests for the helper + legacy / canonical / conflict coverage for `MigrateSecret`.
- Docs: `docs/configuration.md` / `docs/operations.md` / `README.md` / `README.ja.md` / `examples/copilot-review-routing/*` updated.
- `CHANGELOG.md` / `CHANGELOG.ja.md`: Unreleased entry with the migration table.

## Out of scope

- Removing the legacy variables entirely (planned for the next major release).
- Renaming YAML keys (`auth.github_client_id` / `auth.github_client_secret` / `gateway.oauth_scopes` stay as-is — the issue explicitly limits the rename to env vars).
- `MCP_GATEWAY_*` rename / `GITHUB_MCP_UPSTREAM_URL` (separate deprecation, untouched).

## Verification

- `go build ./...` ✅
- `go test -count=1 ./...` ✅ (all packages pass)
- `go vet ./...` ✅
- pre-commit / pre-push hooks (vet / test / build / lint) ✅
