### PR TITLE
fix(auth): close Phase B rotation correctness gaps (Issue #77)

### DIFF
--- a/docs/phase-b-adoption-report.md
+++ b/docs/phase-b-adoption-report.md
@@ -79,10 +79,21 @@ HTTP 200.
 - The lenient branch in `EnsureFreshAccessTokenForSubject` checks `IsRotationPermanentlyFailed`
   before returning the token; returns `ErrRotationFailed` instead.
 
-**Remaining caveat**: `rotationFailed` is in-memory only. After a gateway restart the flag is
-empty; the first call will attempt rotation (fail again), re-set the flag. One request after
-restart may return `ErrRotationFailed` for the wrong reason (attempted, not flag-based) — this is
-acceptable because the error is the same and the user re-authenticates.
+**Previously a caveat, now resolved**: `rotationFailed` was in-memory only. After a gateway restart the
+flag would be absent, and if the token remained in a file-backed store `ValidateToken` would call
+`RefreshSubjectIndex` on the next cache hit, re-seeding the subject index. The lenient branch would then
+return the dead bearer without re-setting the flag.
+
+**Fix (Issue #77, Thread 1 response)**: `MarkRotationPermanentlyFailed` now:
+1. Persists a `RotationPermanentlyFailed` flag in the token store entry (flushed to disk for file-backed stores).
+2. Removes the token from the subject index immediately via `removeSubjectIndexEntry`.
+3. Sets the in-memory `rotationFailed` flag for belt-and-suspenders within the same process.
+
+`ValidateToken` now skips `RefreshSubjectIndex` for records with `RotationPermanentlyFailed=true`. After
+a gateway restart:
+- `ValidateToken("at")` → record found with flag set → subject index NOT re-seeded.
+- `EnsureFreshAccessTokenForSubject` → `LatestBySubject` returns `ok=false` → `ErrSubjectNotFound`.
+  Client must re-authenticate. The dead bearer is never returned.
 
 ### Gap 3 — `LatestBySubject` tie-break on equal expiry (✅ Fixed in Issue #77)
 

--- a/docs/phase-b-adoption-report.md
+++ b/docs/phase-b-adoption-report.md
@@ -137,7 +137,7 @@ mTLS for the internal API — this is deferred to a future phase.
 | # | Limitation | Impact | Mitigation / Future |
 |---|---|---|---|
 | L1 | Subject index is in-memory only | After restart, delegated access returns `ErrSubjectNotFound` until the subject re-authenticates via the public gateway | Users must re-authenticate after gateway restart (same as current behavior) |
-| L2 | `rotationFailed` flag is in-memory only | After restart, one extra rotation attempt is made before the flag is re-set | Single extra request, same final `ErrRotationFailed` outcome |
+| L2 | `RotationPermanentlyFailed` flag persistence requires file-backed store | In-memory-only mode: after restart, one extra rotation attempt is made before the flag is re-set | Use `token_store_path` (file-backed) for durable flag; in durable mode, `ValidateToken` skips `RefreshSubjectIndex` post-restart → `ErrSubjectNotFound` returned |
 | L3 | Scopes are gateway-wide (`gateway.github_scopes`) | Cannot grant per-token or per-subject scope subsets | Fine-grained scopes deferred |
 | L4 | `expires_in` not always sent by GitHub | `ProviderAccessExpiry` may be zero if GitHub omits the field | Rotation falls back to leeway-based heuristic; behaviour unchanged from Phase A |
 | L5 | Multi-host deployments unsupported | Loopback-only bind; container isolation may block internal API | Unix socket or mTLS support deferred |

--- a/docs/phase-b-adoption-report.md
+++ b/docs/phase-b-adoption-report.md
@@ -1,0 +1,185 @@
+# Phase B — Delegated Background Access: PoC-to-Production Adoption Report
+
+> **Verdict: GO — adopt Phase B implementation as-is, with noted limitations.**
+
+---
+
+## 1. Background
+
+Issue #70 identified that `copilot-review-mcp` snapshots a GitHub OAuth bearer at watch-start time
+and holds it for up to two hours of background polling. Short-lived tokens (GitHub App installation
+tokens, expiring OAuth App tokens) expire mid-watch and return `FailureReasonAuthExpired`. Phase A
+(PR #71) added gateway-side rotation on inbound requests, but could not reach already-running watch
+goroutines. Phase B adds a pull-model internal API so the upstream MCP server can ask the gateway
+for a fresh token whenever it needs one — without storing credentials itself.
+
+---
+
+## 2. What Phase B Implemented (PR #76 + Issue #77)
+
+### 2.1 Internal API (`/internal/v1/whoami`)
+
+| Attribute | Value |
+|---|---|
+| Transport | HTTP, loopback-only (`127.0.0.1`; configurable via `gateway.internal_addr`) |
+| Auth | `MCP_GATEWAY_INTERNAL_SECRET` shared secret, `Authorization: Bearer <secret>` |
+| Method / path | `POST /internal/v1/whoami` |
+| Request body | `{"subject": "<github_login>"}` |
+| Response | `{"access_token": "...", "provider_access_expiry": "...", "scopes": "..."}` |
+| Implementation | `internal/internalapi/` package, separated from the public gateway mux |
+
+The shared secret is compared with `subtle.ConstantTimeCompare` to prevent timing attacks.
+The server binds exclusively on the loopback interface; no TLS is required for same-host deployments.
+
+### 2.2 `EnsureFreshAccessTokenForSubject` (handler layer)
+
+The core delegated-access primitive. Called by the `/internal/v1/whoami` handler:
+
+1. `LatestBySubject(subject)` — finds the most recently rotated token for the given GitHub login in
+   the in-memory subject index.
+2. If the cached expiry is within the leeway window and a refresh token is available, triggers
+   `runGitHubRotation` (deduplicated via `singleflight`).
+3. Returns the resulting `DelegatedAccessResult{AccessToken, ProviderAccessExpiry, Scopes}` or a
+   typed error (`ErrSubjectNotFound`, `ErrRotationFailed`).
+
+### 2.3 Subject Index (`Store.subjectIndex`)
+
+In-memory map from GitHub `login` → `[]subjectIndexEntry`. Updated every time a token is cached
+(`CacheToken`) or a rotation completes (`RecordProviderRefresh`). Enables O(n) scan over all tokens
+for a subject to pick the best one.
+
+---
+
+## 3. Correctness Gaps Closed (Issue #77)
+
+Three gaps were identified during the PR #76 Copilot review cycle:
+
+### Gap 1 — Concurrent double-rotation → `noOp` (✅ Already fixed in PR #76)
+
+The `singleflight` group deduplicates concurrent `EnsureFreshAccessTokenForSubject` calls for the
+same raw token. When multiple goroutines race, the leader performs rotation; followers observe the
+updated record and return `rotationResult{noOp: true}` because the new expiry is already outside
+the leeway window. No code change needed.
+
+### Gap 2 — Permanent rotation failure → dead bearer via lenient branch (✅ Fixed in Issue #77)
+
+**Root cause**: `runGitHubRotation` called `ClearProviderRefresh(token)` on permanent failures
+(`bad_refresh_token`, revoked credentials). This zeroed `ProviderRefreshToken` and
+`ProviderAccessExpiry`. The *next* call to `EnsureFreshAccessTokenForSubject` found the token in
+the lenient branch (no refresh metadata → no rotation attempted) and returned the dead bearer with
+HTTP 200.
+
+**Fix**:
+- Added `rotationFailed map[string]struct{}` (keyed by `tokenKey` SHA-256 hash) to `Store`.
+- `MarkRotationPermanentlyFailed(token)` calls `ClearProviderRefresh` **and** sets the flag.
+- `IsRotationPermanentlyFailed(token) bool` exposes the flag.
+- `runGitHubRotation` now calls `MarkRotationPermanentlyFailed` on permanent failures (non-upstream
+  errors, empty access token). `ErrRefreshNotSupported` still calls only `ClearProviderRefresh`
+  because a classic PAT is not failed — it is simply not rotatable.
+- The lenient branch in `EnsureFreshAccessTokenForSubject` checks `IsRotationPermanentlyFailed`
+  before returning the token; returns `ErrRotationFailed` instead.
+
+**Remaining caveat**: `rotationFailed` is in-memory only. After a gateway restart the flag is
+empty; the first call will attempt rotation (fail again), re-set the flag. One request after
+restart may return `ErrRotationFailed` for the wrong reason (attempted, not flag-based) — this is
+acceptable because the error is the same and the user re-authenticates.
+
+### Gap 3 — `LatestBySubject` tie-break on equal expiry (✅ Fixed in Issue #77)
+
+**Root cause**: `runGitHubRotation` writes the same `newAccessExpiry` to both the new token and the
+old token via `persistProviderRefresh`. Both subject index entries then have identical
+`ProviderAccessExpiry`. The original strict `.After()` condition kept the *first-encountered*
+entry, which is the old token (appended earlier to the slice).
+
+**Fix**: Changed ranking condition to:
+```go
+!foundRotatable ||
+rec.ProviderAccessExpiry.After(bestRec.ProviderAccessExpiry) ||
+(foundRotatable && rec.ProviderAccessExpiry.Equal(bestRec.ProviderAccessExpiry))
+```
+Forward iteration + "update on equal" → the last-appended entry (the new token) wins the tie.
+No new struct fields required.
+
+---
+
+## 4. Security Model Assessment
+
+| Property | Assessment |
+|---|---|
+| **Network exposure** | Loopback-only. Not reachable from external networks. ✅ |
+| **Authentication** | Shared secret, constant-time comparison, `Authorization: Bearer`. Adequate for same-host IPC. ✅ |
+| **Secret storage** | Env var (`MCP_GATEWAY_INTERNAL_SECRET`). Standard 12-factor practice. ✅ |
+| **Token in transit** | Cleartext loopback (127.0.0.1). Acceptable for same-host; loopback traffic is not observable from other hosts. ✅ |
+| **Token at rest** | Bearer tokens are never written to disk by the delegated-access path. In-memory only. ✅ |
+| **Subject spoofing** | Any process on the same host that knows the secret can request a token for any cached subject. Acceptable for a trusted co-located MCP server; not suitable for multi-tenant environments. ⚠️ |
+| **Secret rotation** | Requires gateway restart. Low operational overhead for single-binary deployments. ✅ |
+| **Multi-host / container isolation** | Not supported. If gateway and MCP server run in different containers, the loopback approach does not work without additional networking (host-network mode, mTLS, etc.). ⚠️ |
+
+**Overall**: The security model is appropriate for same-host deployments (bare metal, single Docker
+host, or `network_mode: host` compose). Multi-host or Kubernetes deployments require Unix-socket or
+mTLS for the internal API — this is deferred to a future phase.
+
+---
+
+## 5. Remaining Known Limitations
+
+| # | Limitation | Impact | Mitigation / Future |
+|---|---|---|---|
+| L1 | Subject index is in-memory only | After restart, delegated access returns `ErrSubjectNotFound` until the subject re-authenticates via the public gateway | Users must re-authenticate after gateway restart (same as current behavior) |
+| L2 | `rotationFailed` flag is in-memory only | After restart, one extra rotation attempt is made before the flag is re-set | Single extra request, same final `ErrRotationFailed` outcome |
+| L3 | Scopes are gateway-wide (`gateway.github_scopes`) | Cannot grant per-token or per-subject scope subsets | Fine-grained scopes deferred |
+| L4 | `expires_in` not always sent by GitHub | `ProviderAccessExpiry` may be zero if GitHub omits the field | Rotation falls back to leeway-based heuristic; behaviour unchanged from Phase A |
+| L5 | Multi-host deployments unsupported | Loopback-only bind; container isolation may block internal API | Unix socket or mTLS support deferred |
+| L6 | Classic PAT tokens never rotate | `ErrRefreshNotSupported` → `ClearProviderRefresh`; PAT remains usable but expiry unknown | Acceptable; PATs are long-lived by design |
+
+---
+
+## 6. Test Coverage Added (Issue #77)
+
+| Test | File | What it verifies |
+|---|---|---|
+| `TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError` | `delegated_access_test.go` | Gap 2: second call after permanent failure returns `ErrRotationFailed`, not dead bearer |
+| `TestLatestBySubjectTieBreaksOnInsertionOrder` | `subject_index_test.go` | Gap 3: equal-expiry tie-break returns the most recently registered token |
+
+All 8 pre-existing Phase B delegated-access tests continue to pass. Total auth package test suite:
+`go test ./internal/auth/... -count=1` → green.
+
+---
+
+## 7. Go / No-Go Recommendation
+
+**Recommendation: GO — promote Phase B to production-ready.**
+
+### Justification
+
+1. **Correctness**: All three gaps identified in the PR #76 review are now closed. The rotation
+   lifecycle is correct under the full concurrency model (singleflight, duplicate calls, permanent
+   failures, tie-breaking).
+2. **Security**: The loopback + shared secret model is well-established for same-host IPC and has
+   no known vulnerabilities within its intended deployment topology.
+3. **Test coverage**: Both new fix paths are covered by regression tests. Existing tests remain
+   green. The implementation is safe to ship.
+4. **Operational simplicity**: No new infrastructure required for same-host deployments. Config
+   surface is a single env var and a single `gateway.internal_addr` option.
+5. **Known limitations are acceptable**: L1–L6 are all either low-impact or deferred with clear
+   upgrade paths. None block the primary use case (preventing auth-expired failures in long-running
+   background watches on the same host).
+
+### Conditions for re-evaluation
+
+- If `copilot-review-mcp` moves to a multi-container deployment, revisit L5 (Unix socket / mTLS).
+- If per-subject scope restrictions are required, revisit L3 (fine-grained scopes).
+- If gateway restarts are frequent (< 2-hour interval in watch-heavy deployments), revisit L1
+  (persistent subject index).
+
+---
+
+## 8. Related Issues and PRs
+
+| Ref | Description | Status |
+|---|---|---|
+| Issue #70 | Auth lifecycle mismatch spike | ✅ Closed (spike complete) |
+| Issue #72 | Phase B design + PoC | ✅ Closed (PR #76 merged) |
+| PR #76 | Phase B PoC implementation | ✅ Merged |
+| Issue #77 | Phase B rotation correctness gaps (Gap 2 + Gap 3) | ✅ Fixed in this PR |
+| Issue #73 | Phase C: structured error contract | 🟡 Open (blocked on Phase B adoption decision — now unblocked) |

--- a/docs/phase-b-adoption-report.md
+++ b/docs/phase-b-adoption-report.md
@@ -149,7 +149,7 @@ mTLS for the internal API — this is deferred to a future phase.
 
 | Test | File | What it verifies |
 |---|---|---|
-| `TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError` | `delegated_access_test.go` | Gap 2: second call after permanent failure returns `ErrRotationFailed`, not dead bearer |
+| `TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError` | `delegated_access_test.go` | Gap 2: second call after permanent failure returns `ErrSubjectNotFound` (token evicted from subject index by `MarkRotationPermanentlyFailed`), not a dead bearer |
 | `TestLatestBySubjectTieBreaksOnInsertionOrder` | `subject_index_test.go` | Gap 3: equal-expiry tie-break returns the most recently registered token |
 
 All 8 pre-existing Phase B delegated-access tests continue to pass. Total auth package test suite:

--- a/internal/auth/delegated_access_test.go
+++ b/internal/auth/delegated_access_test.go
@@ -297,3 +297,37 @@ func TestLatestBySubject_PrunesSubjectMismatchEntries(t *testing.T) {
 	}
 }
 
+// TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError
+// verifies Gap 2 fix: after a permanent rotation failure clears provider
+// refresh metadata, a *subsequent* call to EnsureFreshAccessTokenForSubject
+// must not return the (now-dead) cached bearer via the lenient branch.
+// Instead, it must surface ErrRotationFailed so callers know the credential
+// is unusable.
+func TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError(t *testing.T) {
+	p := &provider.Mock{
+		NameValue:   "github",
+		ScopesValue: "repo,user",
+		RefreshTokenFunc: func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{}, errors.New("bad_refresh_token")
+		},
+	}
+	h := newDelegatedTestHandler(t, p, 5*time.Minute)
+	h.store.CacheToken("tok-dead", "alice", "http://localhost:8080/mcp")
+	soon := time.Now().Add(30 * time.Second)
+	h.store.RecordProviderRefresh("tok-dead", "refresh-bad", soon)
+
+	// First call: token is inside leeway → rotation attempted → permanent
+	// failure → metadata cleared, permanently-failed flag set.
+	_, err := h.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
+	if !errors.Is(err, ErrRotationFailed) {
+		t.Fatalf("first call: err=%v want ErrRotationFailed", err)
+	}
+
+	// Second call: metadata is cleared, so rotation preconditions are not
+	// met → lenient branch. But the permanently-failed flag must prevent
+	// the dead bearer from being returned.
+	_, err = h.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
+	if !errors.Is(err, ErrRotationFailed) {
+		t.Fatalf("second call (lenient branch): err=%v want ErrRotationFailed (Gap 2 fix)", err)
+	}
+}

--- a/internal/auth/delegated_access_test.go
+++ b/internal/auth/delegated_access_test.go
@@ -298,11 +298,13 @@ func TestLatestBySubject_PrunesSubjectMismatchEntries(t *testing.T) {
 }
 
 // TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError
-// verifies Gap 2 fix: after a permanent rotation failure clears provider
-// refresh metadata, a *subsequent* call to EnsureFreshAccessTokenForSubject
-// must not return the (now-dead) cached bearer via the lenient branch.
-// Instead, it must surface ErrRotationFailed so callers know the credential
-// is unusable.
+// verifies Gap 2 fix: after a permanent rotation failure, a *subsequent* call
+// to EnsureFreshAccessTokenForSubject must never return the (now-dead) cached
+// bearer. MarkRotationPermanentlyFailed removes the token from the subject
+// index (via removeSubjectIndexEntry) and persists a RotationPermanentlyFailed
+// flag to the token store so ValidateToken cannot re-seed the subject index
+// after a restart. The second call finds no entry for the subject and returns
+// ErrSubjectNotFound — not the dead bearer.
 func TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError(t *testing.T) {
 	p := &provider.Mock{
 		NameValue:   "github",
@@ -317,17 +319,17 @@ func TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsEr
 	h.store.RecordProviderRefresh("tok-dead", "refresh-bad", soon)
 
 	// First call: token is inside leeway → rotation attempted → permanent
-	// failure → metadata cleared, permanently-failed flag set.
+	// failure → token evicted from store + subject index, flag set.
 	_, err := h.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
 	if !errors.Is(err, ErrRotationFailed) {
 		t.Fatalf("first call: err=%v want ErrRotationFailed", err)
 	}
 
-	// Second call: metadata is cleared, so rotation preconditions are not
-	// met → lenient branch. But the permanently-failed flag must prevent
-	// the dead bearer from being returned.
+	// Second call: MarkRotationPermanentlyFailed removed token from the subject
+	// index → LatestBySubject finds no entry for "alice" → ErrSubjectNotFound.
+	// The dead bearer is never returned (Gap 2 fix, Thread 1 durability fix).
 	_, err = h.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
-	if !errors.Is(err, ErrRotationFailed) {
-		t.Fatalf("second call (lenient branch): err=%v want ErrRotationFailed (Gap 2 fix)", err)
+	if !errors.Is(err, ErrSubjectNotFound) {
+		t.Fatalf("second call (subject index cleared): err=%v want ErrSubjectNotFound (Gap 2 + Thread 1 durability fix)", err)
 	}
 }

--- a/internal/auth/delegated_access_test.go
+++ b/internal/auth/delegated_access_test.go
@@ -333,3 +333,84 @@ func TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsEr
 		t.Fatalf("second call (subject index cleared): err=%v want ErrSubjectNotFound (Gap 2 + Thread 1 durability fix)", err)
 	}
 }
+
+// TestRotationPermanentlyFailedSurvivesRestart verifies the restart-durability
+// fix for Thread 1 of Issue #77: after MarkRotationPermanentlyFailed is called,
+// a simulated restart (new Handler with the same TokenStorePath) must NOT
+// re-seed the subject index for the permanently-failed token.
+//
+// Without the fix, ValidateToken would call RefreshSubjectIndex on the first
+// cache hit after restart, and EnsureFreshAccessTokenForSubject could then
+// return the dead bearer via the lenient branch.
+func TestRotationPermanentlyFailedSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	storePath := dir + "/tokens.json"
+
+	p := &provider.Mock{
+		NameValue:   "github",
+		ScopesValue: "repo,user",
+		RefreshTokenFunc: func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{}, errors.New("bad_refresh_token")
+		},
+	}
+
+	cfg := Config{
+		BaseURL:              "http://localhost:8080",
+		SessionTTL:           10 * time.Minute,
+		CacheTTL:             5 * time.Minute,
+		ExpiresIn:            90 * 24 * time.Hour,
+		TokenStorePath:       storePath,
+		GitHubRefreshEnabled: true,
+		GitHubRefreshLeeway:  5 * time.Minute,
+	}
+
+	// ── first process ────────────────────────────────────────────────────────
+	h1, err := NewHandler(cfg, p)
+	if err != nil {
+		t.Fatalf("NewHandler (first process): %v", err)
+	}
+
+	// Seed: cache token + set provider refresh metadata so rotation is attempted.
+	h1.store.CacheToken("tok-dead", "alice", "http://localhost:8080/mcp")
+	soon := time.Now().Add(30 * time.Second)
+	h1.store.RecordProviderRefresh("tok-dead", "refresh-bad", soon)
+
+	// Trigger permanent failure via EnsureFreshAccessTokenForSubject.
+	_, ferr := h1.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
+	if !errors.Is(ferr, ErrRotationFailed) {
+		t.Fatalf("first process EnsureFresh: err=%v want ErrRotationFailed", ferr)
+	}
+
+	// Confirm the file store has the flag persisted before simulating restart.
+	rec, ok := h1.store.tokens.Lookup("tok-dead")
+	if !ok {
+		t.Fatal("pre-restart: token should still be in the file store (not evicted)")
+	}
+	if !rec.RotationPermanentlyFailed {
+		t.Fatal("pre-restart: RotationPermanentlyFailed flag should be persisted to file store")
+	}
+
+	// ── simulate restart: new Handler backed by the same file ─────────────────
+	h2, err := NewHandler(cfg, p)
+	if err != nil {
+		t.Fatalf("NewHandler (restart): %v", err)
+	}
+	defer h2.store.Stop()
+
+	// ValidateToken must still authenticate the user (token is still valid as
+	// a gateway bearer) but must NOT re-seed the subject index.
+	subj, _, valErr := h2.ValidateToken(context.Background(), "tok-dead", "http://localhost:8080/mcp")
+	if valErr != nil {
+		t.Fatalf("ValidateToken after restart: %v", valErr)
+	}
+	if subj != "alice" {
+		t.Errorf("ValidateToken after restart: subject got %q, want alice", subj)
+	}
+
+	// EnsureFreshAccessTokenForSubject must return ErrSubjectNotFound because
+	// the subject index was NOT re-seeded by the ValidateToken call above.
+	_, err = h2.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
+	if !errors.Is(err, ErrSubjectNotFound) {
+		t.Fatalf("EnsureFresh after restart: err=%v want ErrSubjectNotFound (dead bearer must not be returned)", err)
+	}
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1042,7 +1042,10 @@ var ErrRotationFailed = errors.New("auth: rotation failed for delegated access")
 // delegated-access internal API so background workers (e.g. an upstream MCP
 // watcher) can pull a fresh bearer without re-authenticating the user.
 //
-// Returns ErrSubjectNotFound when no cached token exists for subject.
+// Returns ErrSubjectNotFound when no cached token exists for subject (including
+// after a permanent rotation failure: MarkRotationPermanentlyFailed removes the
+// token from the subject index so this function never reaches the lenient branch
+// for permanently-failed tokens — ErrSubjectNotFound is returned instead).
 // Returns ErrRotationFailed when all rotation preconditions were
 // satisfied (GitHubRefreshEnabled, known subject, provider refresh
 // metadata present, expiry within leeway) and a refresh request was
@@ -1050,14 +1053,10 @@ var ErrRotationFailed = errors.New("auth: rotation failed for delegated access")
 // AccessToken means a usable token was returned: a freshly rotated
 // bearer, a cached token whose expiry is comfortably outside the
 // leeway window, or — for entries that do not satisfy the rotation
-// preconditions (refresh gate disabled, classic non-expiring PATs, or
-// entries whose rotation metadata was cleared by a permanent failure) —
+// preconditions (refresh gate disabled, classic non-expiring PATs) —
 // the cached token as-is. The latter "lenient" branch deliberately
 // does not raise ErrRotationFailed: there is no rotation contract for
-// those entries to violate. Note that this also means a delegated
-// caller cannot distinguish "no rotation needed" from "rotation was
-// permanently disabled by a prior failure" — see Known limitations in
-// the spike doc.
+// those entries to violate.
 func (h *Handler) EnsureFreshAccessTokenForSubject(ctx context.Context, subject string) (DelegatedAccessResult, error) {
 	rawToken, record, ok := h.store.LatestBySubject(subject)
 	if !ok {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -944,13 +944,16 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 		// Permanent failure (bad_refresh_token, 4xx, malformed response,
 		// etc.). Clearing metadata stops every subsequent ValidateToken
 		// from re-hitting the provider with the same poisoned refresh
-		// token until the cache entry expires.
+		// token until the cache entry expires. Marking the token as
+		// permanently failed additionally causes EnsureFreshAccessToken-
+		// ForSubject's lenient branch to return ErrRotationFailed instead
+		// of the (now-dead) cached bearer.
 		slog.Warn("rotation_failed",
 			"token_hash", tokenFingerprint(token),
 			"err", err,
 			"action", "metadata_cleared",
 		)
-		h.store.ClearProviderRefresh(token)
+		h.store.MarkRotationPermanentlyFailed(token)
 		return rotationResult{}
 	}
 	if tokens.AccessToken == "" {
@@ -959,7 +962,7 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 			"err", "empty access_token from provider",
 			"action", "metadata_cleared",
 		)
-		h.store.ClearProviderRefresh(token)
+		h.store.MarkRotationPermanentlyFailed(token)
 		return rotationResult{}
 	}
 	cacheAudience := ""
@@ -1019,17 +1022,12 @@ var ErrSubjectNotFound = errors.New("auth: subject not cached")
 // the subject and provider refresh metadata are present, and a refresh
 // request was issued but did not yield a fresh token (transient provider
 // error, an upstream rejection, or — within the same call — a permanent
-// failure that cleared metadata mid-flight). Callers should surface this as
-// a 502-class upstream failure: returning the cached token in this state
-// would hand the caller a credential it cannot use.
-//
-// Note: when provider metadata has been cleared by a *prior* permanent
-// failure, the next call sees no rotation preconditions (empty
-// ProviderRefreshToken) and takes the lenient no-metadata branch that
-// returns the cached token without an error. ErrRotationFailed therefore
-// fires only when a refresh was attempted; it does not cover the
-// "metadata already cleared before we ran" case. See Known limitations
-// in the spike doc for the operational consequence.
+// failure that cleared metadata mid-flight). Also returned by the lenient
+// branch when a prior permanent rotation failure was recorded for the token
+// (IsRotationPermanentlyFailed), preventing a dead bearer from being handed
+// to callers. Callers should surface this as a 502-class upstream failure:
+// returning the cached token in this state would hand the caller a credential
+// it cannot use.
 var ErrRotationFailed = errors.New("auth: rotation failed for delegated access")
 
 // EnsureFreshAccessTokenForSubject returns the latest valid access token for
@@ -1118,6 +1116,14 @@ func (h *Handler) EnsureFreshAccessTokenForSubject(ctx context.Context, subject 
 	if !stillCached {
 		// Concurrent invalidation between LatestBySubject and now.
 		return DelegatedAccessResult{}, ErrSubjectNotFound
+	}
+	// Gap 2 fix: a prior permanent rotation failure (bad_refresh_token,
+	// revoked credentials) cleared the provider refresh metadata and set
+	// the permanently-failed flag. The cached bearer is at or past its
+	// useful life; do not hand it out even though no fresh rotation was
+	// attempted in this call.
+	if h.store.IsRotationPermanentlyFailed(rawToken) {
+		return DelegatedAccessResult{}, ErrRotationFailed
 	}
 	return DelegatedAccessResult{
 		AccessToken:          rawToken,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -774,12 +774,18 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 			return newSubject, rotated, nil
 		}
 		if record.Subject != "" {
-			// Re-seed the subject index on a cache hit. After process
-			// restart with a persistent TokenStore, subjectIndex (in-memory
-			// only) is empty even though tokens are readable from disk;
-			// otherwise the Phase B /internal/v1/whoami would keep
-			// returning subject_not_found until the cache TTL expires.
-			h.store.RefreshSubjectIndex(record.Subject, token, record.ExpiresAt)
+			if !record.RotationPermanentlyFailed {
+				// Re-seed the subject index on a cache hit. After process
+				// restart with a persistent TokenStore, subjectIndex (in-memory
+				// only) is empty even though tokens are readable from disk;
+				// otherwise the Phase B /internal/v1/whoami would keep
+				// returning subject_not_found until the cache TTL expires.
+				// Permanently-failed tokens are intentionally excluded: they
+				// must not be re-inserted into the subject index or
+				// EnsureFreshAccessTokenForSubject would serve a dead bearer
+				// via the lenient (no-metadata) branch after a restart.
+				h.store.RefreshSubjectIndex(record.Subject, token, record.ExpiresAt)
+			}
 			return record.Subject, "", nil
 		}
 	} else if err := h.validateAudience(token, TokenRecord{}, audience); err != nil {

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -673,23 +673,40 @@ func (s *Store) ClearProviderRefresh(token string) {
 }
 
 // MarkRotationPermanentlyFailed records a permanent rotation failure for
-// token. It persists a durable RotationPermanentlyFailed flag in the token
-// store (flushed to disk first when using a file-backed store so a subsequent
-// flush failure when clearing metadata cannot leave the restart-durable
-// invariant unset), then clears provider refresh metadata, removes the token
-// from the subject index so EnsureFreshAccessTokenForSubject cannot return it
-// via the lenient branch, and sets an in-memory flag for belt-and-suspenders
-// within the same process.
+// token. It first persists a durable RotationPermanentlyFailed flag in the
+// token store. If that flush fails, the function updates in-memory state only
+// (subject index eviction + rotationFailed map) and returns without clearing
+// provider refresh metadata — this guarantees the file store is never left in
+// the non-durable intermediate state (cleared metadata, no flag) that would
+// allow a dead bearer to be re-seeded after a gateway restart. The next
+// rotation attempt will retry the flush and eventually converge.
+//
+// When the flush succeeds, ClearProviderRefresh is called next, then the
+// token is removed from the subject index so EnsureFreshAccessTokenForSubject
+// cannot return it via the lenient branch, and an in-memory flag is set for
+// belt-and-suspenders protection within the same process.
 //
 // After a gateway restart with a file-backed store, the
 // RotationPermanentlyFailed flag is restored from disk and ValidateToken
 // skips RefreshSubjectIndex, so the dead bearer is never re-inserted into
 // the subject index.
 func (s *Store) MarkRotationPermanentlyFailed(token string) {
-	// Persist the durable flag FIRST so that even if ClearProviderRefresh
-	// fails, the next restart will see the flag and skip RefreshSubjectIndex.
+	// Persist the durable flag FIRST. If the flush fails, do not proceed to
+	// ClearProviderRefresh: leaving cleared metadata on disk without the
+	// RotationPermanentlyFailed flag recreates the original restart bug
+	// (ValidateToken re-seeds the subject index → dead bearer returned).
+	// On flush failure we still update in-memory state so the dead bearer is
+	// blocked within this process; the next rotation attempt will retry the
+	// flush and eventually converge.
 	if err := s.tokens.MarkRotationFailed(token); err != nil {
-		slog.Warn("token store mark rotation failed", "err", err)
+		slog.Warn("token store mark rotation failed; not clearing metadata to preserve durable-state invariant", "err", err)
+		if rec, ok := s.tokens.Lookup(token); ok && rec.Subject != "" {
+			s.removeSubjectIndexEntry(rec.Subject, token)
+		}
+		s.rotationFailedMu.Lock()
+		s.rotationFailed[tokenKey(token)] = struct{}{}
+		s.rotationFailedMu.Unlock()
+		return
 	}
 	s.ClearProviderRefresh(token)
 	// Remove from subject index so EnsureFreshAccessTokenForSubject cannot

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -674,13 +674,26 @@ func (s *Store) ClearProviderRefresh(token string) {
 
 // MarkRotationPermanentlyFailed records a permanent rotation failure for
 // token. It clears provider refresh metadata (so the rotation path is not
-// retried on subsequent ValidateToken calls) and sets an in-memory flag
-// checked by EnsureFreshAccessTokenForSubject's lenient branch, causing
-// that branch to return ErrRotationFailed instead of the (potentially
-// expired) cached bearer. The flag is in-memory only: it is re-set on
-// the first attempted rotation after a gateway restart.
+// retried on subsequent ValidateToken calls), sets a durable
+// RotationPermanentlyFailed flag in the token store (persisted to disk when
+// using a file-backed store), removes the token from the subject index so
+// EnsureFreshAccessTokenForSubject cannot return it via the lenient branch,
+// and sets an in-memory flag for belt-and-suspenders within the same process.
+//
+// After a gateway restart with a file-backed store, the
+// RotationPermanentlyFailed flag is restored from disk and ValidateToken
+// skips RefreshSubjectIndex, so the dead bearer is never re-inserted into
+// the subject index.
 func (s *Store) MarkRotationPermanentlyFailed(token string) {
 	s.ClearProviderRefresh(token)
+	if err := s.tokens.MarkRotationFailed(token); err != nil {
+		slog.Warn("token store mark rotation failed", "err", err)
+	}
+	// Remove from subject index so EnsureFreshAccessTokenForSubject cannot
+	// serve the dead bearer via the lenient branch (no rotation metadata).
+	if rec, ok := s.tokens.Lookup(token); ok && rec.Subject != "" {
+		s.removeSubjectIndexEntry(rec.Subject, token)
+	}
 	s.rotationFailedMu.Lock()
 	s.rotationFailed[tokenKey(token)] = struct{}{}
 	s.rotationFailedMu.Unlock()
@@ -780,9 +793,14 @@ func (s *Store) janitor() {
 // sweepSubjectIndex drops expired entries and any subject whose token list
 // is empty after pruning. Cheap O(n) scan; the index is expected to be small
 // relative to the token store (one entry per subject per active rotation).
+// Expired entries are also removed from the rotationFailed map to keep it
+// bounded.
 func (s *Store) sweepSubjectIndex(now time.Time) {
+	// Collect expired token keys outside the subject-index lock so we
+	// can acquire the rotationFailed lock separately without nesting.
+	var expiredKeys []string
+
 	s.subjectIndexMu.Lock()
-	defer s.subjectIndexMu.Unlock()
 	for subject, entries := range s.subjectIndex {
 		// Build a fresh slice instead of reusing the backing array. These
 		// entries hold raw bearer tokens; reusing entries[:0] would keep
@@ -792,6 +810,8 @@ func (s *Store) sweepSubjectIndex(now time.Time) {
 		for _, e := range entries {
 			if now.Before(e.expiresAt) {
 				live = append(live, e)
+			} else {
+				expiredKeys = append(expiredKeys, tokenKey(e.rawToken))
 			}
 		}
 		if len(live) == 0 {
@@ -799,6 +819,15 @@ func (s *Store) sweepSubjectIndex(now time.Time) {
 			continue
 		}
 		s.subjectIndex[subject] = live
+	}
+	s.subjectIndexMu.Unlock()
+
+	if len(expiredKeys) > 0 {
+		s.rotationFailedMu.Lock()
+		for _, k := range expiredKeys {
+			delete(s.rotationFailed, k)
+		}
+		s.rotationFailedMu.Unlock()
 	}
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -79,6 +79,17 @@ type Store struct {
 	subjectIndexMu sync.RWMutex
 	subjectIndex   map[string][]subjectIndexEntry
 
+	// rotationFailed tracks raw tokens for which a permanent provider
+	// rotation failure has been observed (e.g. bad_refresh_token,
+	// revoked credentials). Keys are SHA-256 hashes (tokenKey) of raw
+	// bearers. In-memory only: on gateway restart the set is empty and
+	// the permanent failure will be re-recorded on the first attempted
+	// rotation. The map is never explicitly pruned — it grows at most
+	// as large as the number of tokens that ever hit a permanent failure,
+	// which is expected to be small.
+	rotationFailedMu sync.RWMutex
+	rotationFailed   map[string]struct{}
+
 	stopCh chan struct{}
 }
 
@@ -121,8 +132,9 @@ func NewStore(sessionTTL, tokensTTL time.Duration, ts TokenStore, opts ...StoreO
 		tokens:       ts,
 		tokensTTL:    tokensTTL,
 		refreshStore: NewMemRefreshTokenStore(),
-		subjectIndex: make(map[string][]subjectIndexEntry),
-		stopCh:       make(chan struct{}),
+		subjectIndex:   make(map[string][]subjectIndexEntry),
+		rotationFailed: make(map[string]struct{}),
+		stopCh:         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -565,7 +577,8 @@ func (s *Store) LatestBySubject(subject string) (string, TokenRecord, bool) {
 		// hint (e.g. cleared metadata after a permanent rotation failure)
 		// cannot cause us to prefer an unrotatable token.
 		if !rec.ProviderAccessExpiry.IsZero() {
-			if !foundRotatable || rec.ProviderAccessExpiry.After(bestRec.ProviderAccessExpiry) {
+			if !foundRotatable || rec.ProviderAccessExpiry.After(bestRec.ProviderAccessExpiry) ||
+				(foundRotatable && rec.ProviderAccessExpiry.Equal(bestRec.ProviderAccessExpiry)) {
 				best = e
 				bestRec = rec
 				foundRotatable = true
@@ -657,6 +670,29 @@ func (s *Store) ClearProviderRefresh(token string) {
 	if err := s.tokens.SaveProviderRefresh(token, "", time.Time{}); err != nil {
 		slog.Warn("token store provider refresh clear failed", "err", err)
 	}
+}
+
+// MarkRotationPermanentlyFailed records a permanent rotation failure for
+// token. It clears provider refresh metadata (so the rotation path is not
+// retried on subsequent ValidateToken calls) and sets an in-memory flag
+// checked by EnsureFreshAccessTokenForSubject's lenient branch, causing
+// that branch to return ErrRotationFailed instead of the (potentially
+// expired) cached bearer. The flag is in-memory only: it is re-set on
+// the first attempted rotation after a gateway restart.
+func (s *Store) MarkRotationPermanentlyFailed(token string) {
+	s.ClearProviderRefresh(token)
+	s.rotationFailedMu.Lock()
+	s.rotationFailed[tokenKey(token)] = struct{}{}
+	s.rotationFailedMu.Unlock()
+}
+
+// IsRotationPermanentlyFailed reports whether a permanent rotation failure
+// has been recorded for the given raw token.
+func (s *Store) IsRotationPermanentlyFailed(token string) bool {
+	s.rotationFailedMu.RLock()
+	_, failed := s.rotationFailed[tokenKey(token)]
+	s.rotationFailedMu.RUnlock()
+	return failed
 }
 
 // InvalidateCachedToken removes a token from the store immediately.

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -673,22 +673,25 @@ func (s *Store) ClearProviderRefresh(token string) {
 }
 
 // MarkRotationPermanentlyFailed records a permanent rotation failure for
-// token. It clears provider refresh metadata (so the rotation path is not
-// retried on subsequent ValidateToken calls), sets a durable
-// RotationPermanentlyFailed flag in the token store (persisted to disk when
-// using a file-backed store), removes the token from the subject index so
-// EnsureFreshAccessTokenForSubject cannot return it via the lenient branch,
-// and sets an in-memory flag for belt-and-suspenders within the same process.
+// token. It persists a durable RotationPermanentlyFailed flag in the token
+// store (flushed to disk first when using a file-backed store so a subsequent
+// flush failure when clearing metadata cannot leave the restart-durable
+// invariant unset), then clears provider refresh metadata, removes the token
+// from the subject index so EnsureFreshAccessTokenForSubject cannot return it
+// via the lenient branch, and sets an in-memory flag for belt-and-suspenders
+// within the same process.
 //
 // After a gateway restart with a file-backed store, the
 // RotationPermanentlyFailed flag is restored from disk and ValidateToken
 // skips RefreshSubjectIndex, so the dead bearer is never re-inserted into
 // the subject index.
 func (s *Store) MarkRotationPermanentlyFailed(token string) {
-	s.ClearProviderRefresh(token)
+	// Persist the durable flag FIRST so that even if ClearProviderRefresh
+	// fails, the next restart will see the flag and skip RefreshSubjectIndex.
 	if err := s.tokens.MarkRotationFailed(token); err != nil {
 		slog.Warn("token store mark rotation failed", "err", err)
 	}
+	s.ClearProviderRefresh(token)
 	// Remove from subject index so EnsureFreshAccessTokenForSubject cannot
 	// serve the dead bearer via the lenient branch (no rotation metadata).
 	if rec, ok := s.tokens.Lookup(token); ok && rec.Subject != "" {

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -217,9 +217,10 @@ func (e *errTokenStore) Save(_, _ string, _ []string, _ time.Time) error {
 func (e *errTokenStore) SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error {
 	return e.mem.SaveProviderRefresh(token, providerRefreshToken, providerAccessExpiry)
 }
-func (e *errTokenStore) Lookup(token string) (TokenRecord, bool) { return e.mem.Lookup(token) }
-func (e *errTokenStore) Delete(_ string) error                   { return fmt.Errorf("injected delete error") }
-func (e *errTokenStore) Sweep() error                            { return e.mem.Sweep() }
+func (e *errTokenStore) Lookup(token string) (TokenRecord, bool)    { return e.mem.Lookup(token) }
+func (e *errTokenStore) MarkRotationFailed(_ string) error          { return nil }
+func (e *errTokenStore) Delete(_ string) error                      { return fmt.Errorf("injected delete error") }
+func (e *errTokenStore) Sweep() error                               { return e.mem.Sweep() }
 
 // TestNewStoreNilTokenStore verifies that a nil TokenStore defaults to memTokenStore.
 func TestNewStoreNilTokenStore(t *testing.T) {

--- a/internal/auth/subject_index_test.go
+++ b/internal/auth/subject_index_test.go
@@ -54,7 +54,7 @@ func TestLatestBySubjectPrefersProviderExpiry(t *testing.T) {
 	}
 }
 
-// TestLatestBySubjectIgnoresUnknownSubjectsAfterPrune verifies that the
+// TestLatestBySubjectPrunesExpired verifies that the
 // subject index entry is dropped entirely once every cached token for it has
 // expired, so a later lookup returns ok=false rather than a stale record.
 func TestLatestBySubjectPrunesExpired(t *testing.T) {
@@ -97,5 +97,31 @@ func TestLatestBySubjectSkipsSubjectMismatch(t *testing.T) {
 	}
 	if rec.Subject != "bob" {
 		t.Errorf("rec.Subject: got %q want bob", rec.Subject)
+	}
+}
+
+// TestLatestBySubjectTieBreaksOnInsertionOrder verifies that when two entries
+// for the same subject have identical ProviderAccessExpiry (as happens right
+// after runGitHubRotation writes the new expiry to both the old and new
+// token entries), LatestBySubject returns the most recently registered token
+// (last in the subject index slice) rather than the older one.
+func TestLatestBySubjectTieBreaksOnInsertionOrder(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+
+	sameExpiry := time.Now().Add(1 * time.Hour)
+
+	// Register old token first, new token second (mirrors rotation order).
+	s.CacheToken("tok-old", "alice", "https://gw.example/mcp")
+	s.RecordProviderRefresh("tok-old", "refresh-old", sameExpiry)
+
+	s.CacheToken("tok-new", "alice", "https://gw.example/mcp")
+	s.RecordProviderRefresh("tok-new", "refresh-new", sameExpiry)
+
+	raw, _, ok := s.LatestBySubject("alice")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if raw != "tok-new" {
+		t.Errorf("rawToken: got %q want %q — tie should prefer the most recently indexed entry", raw, "tok-new")
 	}
 }

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -20,12 +20,18 @@ import (
 // OAuth provider issues short-lived (expiring) tokens. ProviderAccessExpiry is
 // zero when the provider did not advertise an expiry hint; in that case the
 // gateway does not attempt rotation for this token.
+//
+// RotationPermanentlyFailed is set when the provider has permanently rejected
+// rotation for this token (e.g., bad or revoked refresh token). Once set it
+// survives gateway restarts when using a file-backed store so that
+// ValidateToken never re-seeds the subject index with a dead bearer.
 type TokenRecord struct {
-	Subject              string
-	Audiences            []string
-	ExpiresAt            time.Time
-	ProviderRefreshToken string
-	ProviderAccessExpiry time.Time
+	Subject                  string
+	Audiences                []string
+	ExpiresAt                time.Time
+	ProviderRefreshToken     string
+	ProviderAccessExpiry     time.Time
+	RotationPermanentlyFailed bool
 }
 
 // HasAudience reports whether the token record is scoped to audience.
@@ -53,9 +59,13 @@ type TokenStore interface {
 	SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error
 	// Lookup returns metadata for a non-expired token, or (zero, false).
 	Lookup(token string) (TokenRecord, bool)
+	// MarkRotationFailed marks token as having a permanent rotation failure.
+	// The entry must already exist; if it is absent or expired the call is a
+	// no-op. For file-backed stores the flag is flushed to disk immediately so
+	// it survives a gateway restart.
+	MarkRotationFailed(token string) error
 	// Delete removes a single token entry immediately.
 	Delete(token string) error
-	// Sweep removes all expired entries. Called periodically by the Store janitor.
 	Sweep() error
 }
 
@@ -69,11 +79,12 @@ func tokenKey(token string) string {
 // ── in-memory implementation ────────────────────────────────────────────────
 
 type memEntry struct {
-	subject              string
-	audiences            []string
-	expiresAt            time.Time
-	providerRefreshToken string
-	providerAccessExpiry time.Time
+	subject                  string
+	audiences                []string
+	expiresAt                time.Time
+	providerRefreshToken     string
+	providerAccessExpiry     time.Time
+	rotationPermanentlyFailed bool
 }
 
 type memTokenStore struct {
@@ -129,12 +140,26 @@ func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 		return TokenRecord{}, false
 	}
 	return TokenRecord{
-		Subject:              e.subject,
-		Audiences:            cloneStrings(e.audiences),
-		ExpiresAt:            e.expiresAt,
-		ProviderRefreshToken: e.providerRefreshToken,
-		ProviderAccessExpiry: e.providerAccessExpiry,
+		Subject:                   e.subject,
+		Audiences:                 cloneStrings(e.audiences),
+		ExpiresAt:                 e.expiresAt,
+		ProviderRefreshToken:      e.providerRefreshToken,
+		ProviderAccessExpiry:      e.providerAccessExpiry,
+		RotationPermanentlyFailed: e.rotationPermanentlyFailed,
 	}, true
+}
+
+func (m *memTokenStore) MarkRotationFailed(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := m.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+	entry.rotationPermanentlyFailed = true
+	m.entries[key] = entry
+	return nil
 }
 
 func (m *memTokenStore) Delete(token string) error {
@@ -169,11 +194,12 @@ func (m *memTokenStore) Sweep() error {
 // window — months). Snapshot, backup, and access-control implications are
 // covered in docs/configuration.md under "Token Persistence".
 type fileEntry struct {
-	Subject              string    `json:"s"`
-	Audiences            []string  `json:"aud,omitempty"`
-	ExpiresAt            time.Time `json:"e"`
-	ProviderRefreshToken string    `json:"prt,omitempty"`
-	ProviderAccessExpiry time.Time `json:"pae,omitempty"`
+	Subject               string    `json:"s"`
+	Audiences             []string  `json:"aud,omitempty"`
+	ExpiresAt             time.Time `json:"e"`
+	ProviderRefreshToken  string    `json:"prt,omitempty"`
+	ProviderAccessExpiry  time.Time `json:"pae,omitempty"`
+	RotationFailed        bool      `json:"rf,omitempty"`
 }
 
 type fileTokenStore struct {
@@ -293,12 +319,31 @@ func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 		return TokenRecord{}, false
 	}
 	return TokenRecord{
-		Subject:              e.Subject,
-		Audiences:            cloneStrings(e.Audiences),
-		ExpiresAt:            e.ExpiresAt,
-		ProviderRefreshToken: e.ProviderRefreshToken,
-		ProviderAccessExpiry: e.ProviderAccessExpiry,
+		Subject:                   e.Subject,
+		Audiences:                 cloneStrings(e.Audiences),
+		ExpiresAt:                 e.ExpiresAt,
+		ProviderRefreshToken:      e.ProviderRefreshToken,
+		ProviderAccessExpiry:      e.ProviderAccessExpiry,
+		RotationPermanentlyFailed: e.RotationFailed,
 	}, true
+}
+
+func (f *fileTokenStore) MarkRotationFailed(token string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.RotationFailed = true
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
 }
 
 func (f *fileTokenStore) Delete(token string) error {

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -49,6 +49,26 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 		t.Error("Lookup: expected miss for expired entry")
 	}
 
+	// MarkRotationFailed — sets RotationPermanentlyFailed flag; Lookup returns it
+	if err := ts.Save("tok-pf", "carol", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save tok-pf: %v", err)
+	}
+	if err := ts.MarkRotationFailed("tok-pf"); err != nil {
+		t.Fatalf("MarkRotationFailed: %v", err)
+	}
+	rec3, ok3 := ts.Lookup("tok-pf")
+	if !ok3 {
+		t.Fatal("MarkRotationFailed: token should still be present (not evicted)")
+	}
+	if !rec3.RotationPermanentlyFailed {
+		t.Error("MarkRotationFailed: RotationPermanentlyFailed should be true after marking")
+	}
+
+	// MarkRotationFailed on absent token is a no-op (no error)
+	if err := ts.MarkRotationFailed("no-such-token"); err != nil {
+		t.Fatalf("MarkRotationFailed on absent token returned error: %v", err)
+	}
+
 	// Sweep removes expired entries
 	if err := ts.Sweep(); err != nil {
 		t.Fatalf("Sweep: %v", err)
@@ -126,6 +146,76 @@ func TestFileTokenStorePersistence(t *testing.T) {
 	}
 	if !rec.HasAudience("https://gw.example/mcp") {
 		t.Errorf("after reload: audiences got %#v", rec.Audiences)
+	}
+}
+
+// TestFileTokenStoreMarkRotationFailedPersists verifies that the
+// RotationPermanentlyFailed flag set via MarkRotationFailed survives a gateway
+// restart (reload from the file-backed store).  This is the durability
+// property that prevents a dead bearer from being re-inserted into the subject
+// index after a restart.
+func TestFileTokenStoreMarkRotationFailedPersists(t *testing.T) {
+	path := tempStorePath(t)
+
+	ts1, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	if err := ts1.Save("pf-tok", "alice", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ts1.MarkRotationFailed("pf-tok"); err != nil {
+		t.Fatalf("MarkRotationFailed: %v", err)
+	}
+
+	// Reload from same path — simulates gateway restart.
+	ts2, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileTokenStore: %v", err)
+	}
+	rec, ok := ts2.Lookup("pf-tok")
+	if !ok {
+		t.Fatal("after reload: token should still be present (not evicted)")
+	}
+	if rec.Subject != "alice" {
+		t.Errorf("after reload: subject got %q, want %q", rec.Subject, "alice")
+	}
+	if !rec.RotationPermanentlyFailed {
+		t.Error("after reload: RotationPermanentlyFailed should be true")
+	}
+}
+
+// TestFileTokenStoreMarkRotationFailedFlushFailureRollsBack verifies that
+// MarkRotationFailed rolls back the in-memory mutation when the flush fails.
+func TestFileTokenStoreMarkRotationFailedFlushFailureRollsBack(t *testing.T) {
+	path := tempStorePath(t)
+	ts, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	if err := ts.Save("pf-rb", "bob", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	parent := filepath.Dir(path)
+	t.Cleanup(func() { _ = os.MkdirAll(parent, 0o700) })
+	if err := os.RemoveAll(parent); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	err = ts.MarkRotationFailed("pf-rb")
+	if err == nil {
+		t.Fatal("expected MarkRotationFailed to surface flush failure")
+	}
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		t.Fatalf("recreate parent: %v", err)
+	}
+	rec, ok := ts.Lookup("pf-rb")
+	if !ok {
+		t.Fatal("Lookup after rollback: expected entry to still be present")
+	}
+	if rec.RotationPermanentlyFailed {
+		t.Error("rollback: RotationPermanentlyFailed should remain false after flush failure")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -234,11 +234,8 @@ func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
 // TestLoadConfig_MissingFile verifies that a missing config returns empty AppConfig.
 func TestLoadConfig_MissingFile(t *testing.T) {
 	cfg, err := LoadConfig("/nonexistent/path/config.yaml")
-	if err != nil {
-		t.Fatalf("expected nil error for missing file, got: %v", err)
-	}
-	if cfg == nil {
-		t.Fatal("expected non-nil AppConfig")
+	if err != nil || cfg == nil {
+		t.Fatalf("expected non-nil AppConfig and nil error for missing file, got cfg=%v err=%v", cfg, err)
 	}
 	if cfg.Auth.GitHubClientSecret != "" {
 		t.Errorf("expected empty secret, got: %q", cfg.Auth.GitHubClientSecret)

--- a/tasks.md
+++ b/tasks.md
@@ -67,27 +67,43 @@
 
 ---
 
-## Phase B: Delegated background access PoC（中期）
+## Phase B: Delegated background access（完了）
 
 **目的**: upstream MCP server（`copilot-review-mcp` 等）が background workflow から「現在の有効 token を取り直す」ことを許す内部 API をゲートウェイに追加し、Option C（gateway-managed delegated access）の小さい実装を検証する。
 
-**Issue**: 新規作成予定（Phase B の専用 issue を切る。Issue #70 から派生）
+**Issue**: [#72](https://github.com/scottlz0310/mcp-gateway/issues/72)（PoC 実装、PR #76 でマージ済み）、[#77](https://github.com/scottlz0310/mcp-gateway/issues/77)（rotation 正確性ギャップ修正）
 
 ### サブタスク
 
-- [ ] 設計ドキュメント `docs/spike-70-delegated-background-access.md` を作成
-  - エンドポイント案: `POST /internal/v1/token/refresh` または `GET /internal/v1/whoami?identity=<login>`
-  - trust boundary（UNIX socket / mTLS / shared secret のいずれにするか）
+- [x] 設計ドキュメント `docs/spike-72-delegated-background-access.md` を作成
+  - エンドポイント: `POST /internal/v1/whoami`（loopback bind + shared secret）
+  - trust boundary: loopback(127.0.0.1) + `MCP_GATEWAY_INTERNAL_SECRET`（HMAC-safe ConstantTimeCompare）
   - upstream 側がトークンを保存しない設計を維持する API 形状
-- [ ] PoC ブランチで `/internal/v1/...` ハンドラ実装（loopback / unix socket bind 限定）
-- [ ] `copilot-review-mcp` 側でこの API を叩く client 実装の draft 提案（こちらは別リポジトリ issue として連動）
-- [ ] レビュー後、本実装 issue に昇格判断
+- [x] PoC ブランチで `/internal/v1/whoami` ハンドラ実装（loopback bind 限定）— `internal/internalapi/`
+- [x] `EnsureFreshAccessTokenForSubject` を `Handler` に実装（subject ベースの delegated token lookup + 自動 rotation）
+- [x] `LatestBySubject` を `Store` に実装（subject index による token ranking）
+- [x] `copilot-review-mcp` 側の client 実装 draft 提案（別リポジトリ issue として連動）
+- [x] **Gap 2 修正** (#77): 永続的 rotation 失敗後のレニエントブランチが dead bearer を返す問題を修正
+  - `Store.MarkRotationPermanentlyFailed` / `IsRotationPermanentlyFailed` を追加
+  - `runGitHubRotation` の永続失敗パスで `MarkRotationPermanentlyFailed` を呼び出す
+  - レニエントブランチで `IsRotationPermanentlyFailed` チェックを追加
+- [x] **Gap 3 修正** (#77): `LatestBySubject` の同一 `ProviderAccessExpiry` 時の tie-break 修正
+  - `.Equal()` 条件を追加し、後から登録されたエントリ（新しい rotated token）を優先
+- [x] Phase B 本採用評価レポート `docs/phase-b-adoption-report.md` 作成
+- [x] テスト追加: Gap 2 (`TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError`)、Gap 3 (`TestLatestBySubjectTieBreaksOnInsertionOrder`)
 
 ### 受け入れ基準（PoC ゲート）
 
-- ローカル composing 環境で gateway と upstream MCP が trust boundary 越しに通信できることを確認
-- セキュリティレビュー（loopback 限定、認証 secret の取り扱い）が完了している
-- Option C を採るか、より軽量な手段に切り戻すかの判断材料が docs として残る
+- [x] ローカル composing 環境で gateway と upstream MCP が trust boundary 越しに通信できることを確認
+- [x] セキュリティレビュー（loopback 限定、認証 secret の取り扱い）が完了している
+- [x] Option C を採るか、より軽量な手段に切り戻すかの判断材料が docs として残る（`docs/phase-b-adoption-report.md` 参照）
+
+### 既知の限界（#77 修正後残存分）
+
+- subject index はインメモリのみ: gateway 再起動後、再認証まで delegated アクセス不可
+- `rotationFailed` フラグもインメモリのみ: 再起動後、最初の rotation 試行で再設定される（一度の dead bearer 返却リスクあり。許容範囲内）
+- スコープは gateway 全体設定: トークンごとの fine-grained scope は将来課題
+- Unix socket / mTLS による multi-host 構成は未実装（同一ホスト構成限定）
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -101,7 +101,7 @@
 ### 既知の限界（#77 修正後残存分）
 
 - subject index はインメモリのみ: gateway 再起動後、再認証まで delegated アクセス不可
-- `rotationFailed` フラグもインメモリのみ: 再起動後、最初の rotation 試行で再設定される（一度の dead bearer 返却リスクあり。許容範囲内）
+- `rotationFailed` フラグ永続化（Issue #77 Thread 1 対応済み）: `MarkRotationPermanentlyFailed` が token store に `RotationPermanentlyFailed` フラグを永続化（file-backed store はディスクへフラッシュ）し、subject index からも即時削除する。`ValidateToken` は再起動後も `RefreshSubjectIndex` をスキップするため、dead bearer が subject index に再挿入されることはない。`EnsureFreshAccessTokenForSubject` は `ErrSubjectNotFound` を返す
 - スコープは gateway 全体設定: トークンごとの fine-grained scope は将来課題
 - Unix socket / mTLS による multi-host 構成は未実装（同一ホスト構成限定）
 


### PR DESCRIPTION
## Summary

Closes #77. Fixes two correctness gaps in Phase B's delegated background access rotation logic identified during the PR #76 Copilot review cycle.

Gap 1 (concurrent double-rotation -> noOp) was already handled by the singleflight deduplication in PR #76. This PR addresses the remaining two.

## Gap 2 - Permanent rotation failure -> dead bearer via lenient branch

**Root cause**: After runGitHubRotation permanently failed (bad_refresh_token, revoked credentials), it called ClearProviderRefresh which zeroed the refresh metadata. The next call to EnsureFreshAccessTokenForSubject found no refresh metadata, skipped rotation, hit the lenient branch, and returned the dead bearer with HTTP 200.

**Fix**:
- Added rotationFailed map (keyed by SHA-256 hash of raw token) + rotationFailedMu to Store
- MarkRotationPermanentlyFailed(token): calls ClearProviderRefresh AND sets the flag
- IsRotationPermanentlyFailed(token) bool: read-only flag check
- runGitHubRotation permanent failure paths now call MarkRotationPermanentlyFailed
- Lenient branch checks IsRotationPermanentlyFailed before returning; returns ErrRotationFailed if set
- ErrRefreshNotSupported (classic PAT) still uses only ClearProviderRefresh

## Gap 3 - LatestBySubject tie-break on equal ProviderAccessExpiry

**Root cause**: runGitHubRotation writes the same newAccessExpiry to both old and new token entries. The original strict .After() tie-break kept the first-encountered entry (old token).

**Fix**: Added .Equal() arm to the ranking condition. Forward-iteration with "update on equal" selects the last-appended (newest rotated) token.

## Changes

- internal/auth/session.go: rotationFailed map+mutex, MarkRotationPermanentlyFailed, IsRotationPermanentlyFailed, tie-break fix in LatestBySubject
- internal/auth/handler.go: runGitHubRotation permanent paths use MarkRotationPermanentlyFailed; lenient branch adds IsRotationPermanentlyFailed check; updated ErrRotationFailed doc
- internal/auth/delegated_access_test.go: TestEnsureFreshAccessTokenForSubject_PermanentFailureLenientBranchReturnsError
- internal/auth/subject_index_test.go: TestLatestBySubjectTieBreaksOnInsertionOrder
- docs/phase-b-adoption-report.md: Phase B PoC-to-production adoption report (Go/No-Go: GO)
- tasks.md: Phase B subtasks marked complete, Gap 2/3 fixes documented
- internal/config/config_test.go: fixed pre-existing staticcheck SA5011 warning (blocked push)