### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-18
+
 ### Added
 
 - Generic OAuth environment variables to decouple configuration from GitHub-specific naming ([#5](https://github.com/scottlz0310/mcp-gateway/issues/5)).
@@ -179,7 +181,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
 - Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/mcp-gateway/releases/tag/v0.1.0


### PR DESCRIPTION
## 概要

`mcp-gateway v0.4.0` のリリース PR です。

## 主な変更点

### ⚠️ 破壊的変更（後方互換フォールバックあり）

OAuth 環境変数を汎用的な `OAUTH_*` プレフィックスへ移行:

| 旧変数名 | 新変数名 |
|---|---|
| `GITHUB_MCP_CLIENT_ID` | `OAUTH_CLIENT_ID` |
| `GITHUB_MCP_CLIENT_SECRET` | `OAUTH_CLIENT_SECRET` |
| `GITHUB_MCP_OAUTH_SCOPES` | `OAUTH_SCOPES` |
| `GITHUB_MCP_PROVIDER` | `OAUTH_PROVIDER`（デフォルト: `github`） |

> 旧変数名は引き続き動作しますが、deprecated 警告が出力されます。

### ✨ 新機能

- **Phase A** — `MCP_GATEWAY_GITHUB_REFRESH_ENABLED`（デフォルト `false`）: 透過的アクセストークンローテーション
- **Phase B** — `MCP_GATEWAY_INTERNAL_SECRET` + `MCP_GATEWAY_INTERNAL_PORT`: バックグラウンドワーカー向けループバック内部 API (`/internal/v1/whoami`)

## リリース後の作業

1. このPRをマージ
2. `v0.4.0` タグを付与して GitHub Release を作成

## 関連

- `copilot-review-mcp v3.2.0` がこのリリースに依存しています（Phase B client 実装）