### PR TITLE
feat: upstream_bearer_token_env — inject upstream API token from env var (#82)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,4 +1,4 @@
-﻿package main
+package main
 
 import (
 	"fmt"
@@ -270,7 +270,7 @@ func main() {
 			"prefix", route.Prefix,
 			"upstream", route.Upstream.String(),
 			"auth_required", !route.NoAuth,
-"upstream_bearer_token_env", route.UpstreamBearerTokenEnv != "",
+			"upstream_bearer_token_env", route.UpstreamBearerTokenEnv != "",
 		)
 	}
 
@@ -356,16 +356,16 @@ type config struct {
 	// Replaces the deprecated baseURL / MCP_GATEWAY_BASE_URL.
 	publicURL string
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
-	bindAddr            string
-	oauthProvider       string
-	oauthScopes         string
-	port                string
-	logLevel            string
-	upstreamURL         string // deprecated; prefer ROUTE_* env vars
-	trustedProxyCIDRs   []string
-	sessionTTLMin       int
-	tokenCacheTTLMin    int
-	tokenExpiresInSec   int
+	bindAddr             string
+	oauthProvider        string
+	oauthScopes          string
+	port                 string
+	logLevel             string
+	upstreamURL          string // deprecated; prefer ROUTE_* env vars
+	trustedProxyCIDRs    []string
+	sessionTTLMin        int
+	tokenCacheTTLMin     int
+	tokenExpiresInSec    int
 	tokenAudienceStrict  bool
 	githubRefreshEnabled bool
 	tokenStorePath       string
@@ -395,17 +395,17 @@ func loadConfig() config {
 
 	return config{
 		// githubClientID and githubClientSecret are resolved after key/config loading in main().
-		publicURL:           publicURL,
-		bindAddr:            bindAddr,
-		port:                port,
-		oauthProvider:       oauthProvider,
-		oauthScopes:         oauthScopes,
-		logLevel:            getEnv("LOG_LEVEL", "info"),
-		upstreamURL:         getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
-		trustedProxyCIDRs:   splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
-		sessionTTLMin:       getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:    getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
-		tokenExpiresInSec:   getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		publicURL:            publicURL,
+		bindAddr:             bindAddr,
+		port:                 port,
+		oauthProvider:        oauthProvider,
+		oauthScopes:          oauthScopes,
+		logLevel:             getEnv("LOG_LEVEL", "info"),
+		upstreamURL:          getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
+		trustedProxyCIDRs:    splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
+		sessionTTLMin:        getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:     getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
+		tokenExpiresInSec:    getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
 		tokenAudienceStrict:  getEnvBool("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT", false),
 		githubRefreshEnabled: getEnvBool("MCP_GATEWAY_GITHUB_REFRESH_ENABLED", false),
 		tokenStorePath:       lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -236,7 +236,7 @@ func main() {
 	// /.well-known/oauth-protected-resource{prefix}, and 401 responses point
 	// resource_metadata at that route-scoped URL.
 	for _, route := range routes {
-		h := proxy.NewHandler(route.Upstream, oauthHandler)
+		h := proxy.NewHandler(route.Upstream, oauthHandler, route.UpstreamBearerTokenEnv)
 		var wrapped http.Handler
 		if route.NoAuth {
 			wrapped = h
@@ -270,6 +270,7 @@ func main() {
 			"prefix", route.Prefix,
 			"upstream", route.Upstream.String(),
 			"auth_required", !route.NoAuth,
+"upstream_bearer_token_env", route.UpstreamBearerTokenEnv != "",
 		)
 	}
 
@@ -554,3 +555,5 @@ func startInternalAPI(resolver internalapi.TokenResolver) {
 		}
 	}()
 }
+
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,4 +1,4 @@
-package main
+﻿package main
 
 import (
 	"fmt"
@@ -555,5 +555,3 @@ func startInternalAPI(resolver internalapi.TokenResolver) {
 		}
 	}()
 }
-
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-﻿package config
+package config
 
 import (
 	"fmt"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-package config
+﻿package config
 
 import (
 	"fmt"
@@ -157,4 +157,3 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, 
 		return "", fmt.Errorf("github_client_secret is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
 	}
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,9 @@ type RouteConfig struct {
 	Prefix   string `yaml:"prefix"           json:"prefix"`
 	Upstream string `yaml:"upstream"         json:"upstream"`
 	NoAuth   bool   `yaml:"no_auth,omitempty" json:"no_auth,omitempty"`
+	// UpstreamBearerTokenEnv names the env var whose value is injected as the
+	// upstream Authorization Bearer token. When empty, the client OAuth token is used.
+	UpstreamBearerTokenEnv string `yaml:"upstream_bearer_token_env,omitempty" json:"upstream_bearer_token_env,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.
@@ -154,3 +157,4 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, 
 		return "", fmt.Errorf("github_client_secret is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
 	}
 }
+

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,21 +1,21 @@
-﻿package proxy
+package proxy
 
 import (
-"crypto/sha256"
-"fmt"
-"log/slog"
-"net/http"
-"net/http/httputil"
-"net/url"
-"os"
-"strings"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
 
-"github.com/scottlz0310/mcp-gateway/internal/middleware"
+	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
 
 // TokenInvalidator is implemented by auth.Handler.
 type TokenInvalidator interface {
-InvalidateCachedToken(token string)
+	InvalidateCachedToken(token string)
 }
 
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
@@ -31,91 +31,91 @@ InvalidateCachedToken(token string)
 // invalidation events — the failure belongs to the upstream credential,
 // not the client session.
 func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv string) http.Handler {
-rp := &httputil.ReverseProxy{
-Rewrite: func(pr *httputil.ProxyRequest) {
-pr.SetURL(upstream)
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(upstream)
 
-pr.Out.Header.Del("X-Forwarded-For")
-pr.Out.Header.Del("X-Real-Ip")
-pr.Out.Header.Del("Forwarded")
-pr.Out.Header.Del("X-Authenticated-User")
-pr.Out.Header.Del("X-GitHub-Login")
-pr.Out.Header.Del("X-Forwarded-Host")
-pr.Out.Header.Del("X-Forwarded-Proto")
+			pr.Out.Header.Del("X-Forwarded-For")
+			pr.Out.Header.Del("X-Real-Ip")
+			pr.Out.Header.Del("Forwarded")
+			pr.Out.Header.Del("X-Authenticated-User")
+			pr.Out.Header.Del("X-GitHub-Login")
+			pr.Out.Header.Del("X-Forwarded-Host")
+			pr.Out.Header.Del("X-Forwarded-Proto")
 
-// Always strip client-supplied Authorization first to prevent spoofing,
-// then inject the appropriate upstream credential.
-pr.Out.Header.Del("Authorization")
-if upstreamBearerTokenEnv != "" {
-// Upstream credential injection: read the named env var at request time.
-// A warning is emitted when the env var is unset or empty so that
-// rotated or missing credentials are visible in logs.
-if token := strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)); token != "" {
-pr.Out.Header.Set("Authorization", "Bearer "+token)
-} else {
-slog.Warn("upstream credential env var is unset or empty; request forwarded without Authorization",
-"env_var", upstreamBearerTokenEnv,
-"path", pr.Out.URL.Path,
-)
-}
-} else if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
-pr.Out.Header.Set("Authorization", "Bearer "+token)
-}
+			// Always strip client-supplied Authorization first to prevent spoofing,
+			// then inject the appropriate upstream credential.
+			pr.Out.Header.Del("Authorization")
+			if upstreamBearerTokenEnv != "" {
+				// Upstream credential injection: read the named env var at request time.
+				// A warning is emitted when the env var is unset or empty so that
+				// rotated or missing credentials are visible in logs.
+				if token := strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)); token != "" {
+					pr.Out.Header.Set("Authorization", "Bearer "+token)
+				} else {
+					slog.Warn("upstream credential env var is unset or empty; request forwarded without Authorization",
+						"env_var", upstreamBearerTokenEnv,
+						"path", pr.Out.URL.Path,
+					)
+				}
+			} else if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+token)
+			}
 
-if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
-pr.Out.Header.Set("X-Authenticated-User", sanitizeHeaderValue(subject))
-// Legacy header retained during the migration window so that
-// upstream MCP services (github-mcp, copilot-review-mcp) keep
-// working until they migrate to X-Authenticated-User.
-pr.Out.Header.Set("X-GitHub-Login", sanitizeHeaderValue(subject))
-}
+			if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
+				pr.Out.Header.Set("X-Authenticated-User", sanitizeHeaderValue(subject))
+				// Legacy header retained during the migration window so that
+				// upstream MCP services (github-mcp, copilot-review-mcp) keep
+				// working until they migrate to X-Authenticated-User.
+				pr.Out.Header.Set("X-GitHub-Login", sanitizeHeaderValue(subject))
+			}
 
-slog.Info("proxy request",
-"user", middleware.IdentityFromContext(pr.In.Context()),
-"method", pr.Out.Method,
-"path", pr.Out.URL.Path,
-"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),
-)
-},
+			slog.Info("proxy request",
+				"user", middleware.IdentityFromContext(pr.In.Context()),
+				"method", pr.Out.Method,
+				"path", pr.Out.URL.Path,
+				"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),
+			)
+		},
 
-ModifyResponse: func(resp *http.Response) error {
-if resp.StatusCode == http.StatusUnauthorized {
-if upstreamBearerTokenEnv != "" {
-// The 401 came from an upstream-credential route.
-// This is a problem with the upstream API token, not the
-// client OAuth session — do NOT invalidate the client cache.
-slog.Warn("upstream rejected upstream credential; check env var token",
-"path", resp.Request.URL.Path,
-"env_var", upstreamBearerTokenEnv,
-)
-} else if inv != nil {
-if token := extractBearer(resp.Request); token != "" {
-inv.InvalidateCachedToken(token)
-slog.Warn("upstream rejected token; cache invalidated",
-"path", resp.Request.URL.Path,
-"token_hash", tokenHash(token),
-)
-}
-}
-}
-slog.Info("proxy response",
-"upstream_status", resp.StatusCode,
-"path", resp.Request.URL.Path,
-)
-return nil
-},
-}
+		ModifyResponse: func(resp *http.Response) error {
+			if resp.StatusCode == http.StatusUnauthorized {
+				if upstreamBearerTokenEnv != "" {
+					// The 401 came from an upstream-credential route.
+					// This is a problem with the upstream API token, not the
+					// client OAuth session — do NOT invalidate the client cache.
+					slog.Warn("upstream rejected upstream credential; check env var token",
+						"path", resp.Request.URL.Path,
+						"env_var", upstreamBearerTokenEnv,
+					)
+				} else if inv != nil {
+					if token := extractBearer(resp.Request); token != "" {
+						inv.InvalidateCachedToken(token)
+						slog.Warn("upstream rejected token; cache invalidated",
+							"path", resp.Request.URL.Path,
+							"token_hash", tokenHash(token),
+						)
+					}
+				}
+			}
+			slog.Info("proxy response",
+				"upstream_status", resp.StatusCode,
+				"path", resp.Request.URL.Path,
+			)
+			return nil
+		},
+	}
 
-return rp
+	return rp
 }
 
 func extractBearer(req *http.Request) string {
-auth := req.Header.Get("Authorization")
-const prefix = "Bearer "
-if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
-return auth[len(prefix):]
-}
-return ""
+	auth := req.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
+		return auth[len(prefix):]
+	}
+	return ""
 }
 
 // headerSanitizer is a package-level replacer reused on every proxied request.
@@ -123,14 +123,14 @@ var headerSanitizer = strings.NewReplacer("\r", "", "\n", "")
 
 // sanitizeHeaderValue strips CR and LF to prevent HTTP header injection.
 func sanitizeHeaderValue(s string) string {
-return headerSanitizer.Replace(s)
+	return headerSanitizer.Replace(s)
 }
 
 // tokenHash returns the first 8 hex characters of SHA-256(token) for log correlation.
 func tokenHash(token string) string {
-if token == "" {
-return ""
-}
-sum := sha256.Sum256([]byte(token))
-return fmt.Sprintf("%x", sum[:4])
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", sum[:4])
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,4 +1,4 @@
-package proxy
+﻿package proxy
 
 import (
 "crypto/sha256"
@@ -48,9 +48,15 @@ pr.Out.Header.Del("X-Forwarded-Proto")
 pr.Out.Header.Del("Authorization")
 if upstreamBearerTokenEnv != "" {
 // Upstream credential injection: read the named env var at request time.
-// The token value is never logged; only its absence triggers a warning.
-if token := os.Getenv(upstreamBearerTokenEnv); token != "" {
+// A warning is emitted when the env var is unset or empty so that
+// rotated or missing credentials are visible in logs.
+if token := strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)); token != "" {
 pr.Out.Header.Set("Authorization", "Bearer "+token)
+} else {
+slog.Warn("upstream credential env var is unset or empty; request forwarded without Authorization",
+"env_var", upstreamBearerTokenEnv,
+"path", pr.Out.URL.Path,
+)
 }
 } else if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
 pr.Out.Header.Set("Authorization", "Bearer "+token)

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,20 +1,21 @@
 package proxy
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"log/slog"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"strings"
+"crypto/sha256"
+"fmt"
+"log/slog"
+"net/http"
+"net/http/httputil"
+"net/url"
+"os"
+"strings"
 
-	"github.com/scottlz0310/mcp-gateway/internal/middleware"
+"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
 
 // TokenInvalidator is implemented by auth.Handler.
 type TokenInvalidator interface {
-	InvalidateCachedToken(token string)
+InvalidateCachedToken(token string)
 }
 
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
@@ -22,69 +23,93 @@ type TokenInvalidator interface {
 // injects the verified user identifier as X-Authenticated-User (and the
 // legacy X-GitHub-Login during the migration window), and invalidates the
 // token cache when the upstream returns HTTP 401.
-func NewHandler(upstream *url.URL, inv TokenInvalidator) http.Handler {
-	rp := &httputil.ReverseProxy{
-		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(upstream)
+//
+// When upstreamBearerTokenEnv is non-empty, the named environment variable
+// is read on each request and its value is injected as the upstream
+// Authorization Bearer token instead of the client OAuth context token.
+// In this mode, upstream 401 responses are NOT treated as client token
+// invalidation events — the failure belongs to the upstream credential,
+// not the client session.
+func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv string) http.Handler {
+rp := &httputil.ReverseProxy{
+Rewrite: func(pr *httputil.ProxyRequest) {
+pr.SetURL(upstream)
 
-			pr.Out.Header.Del("X-Forwarded-For")
-			pr.Out.Header.Del("X-Real-Ip")
-			pr.Out.Header.Del("Forwarded")
-			pr.Out.Header.Del("X-Authenticated-User")
-			pr.Out.Header.Del("X-GitHub-Login")
-			pr.Out.Header.Del("X-Forwarded-Host")
-			pr.Out.Header.Del("X-Forwarded-Proto")
+pr.Out.Header.Del("X-Forwarded-For")
+pr.Out.Header.Del("X-Real-Ip")
+pr.Out.Header.Del("Forwarded")
+pr.Out.Header.Del("X-Authenticated-User")
+pr.Out.Header.Del("X-GitHub-Login")
+pr.Out.Header.Del("X-Forwarded-Host")
+pr.Out.Header.Del("X-Forwarded-Proto")
 
-			// Normalize Authorization from context to prevent client spoofing.
-			pr.Out.Header.Del("Authorization")
-			if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
-				pr.Out.Header.Set("Authorization", "Bearer "+token)
-			}
+// Always strip client-supplied Authorization first to prevent spoofing,
+// then inject the appropriate upstream credential.
+pr.Out.Header.Del("Authorization")
+if upstreamBearerTokenEnv != "" {
+// Upstream credential injection: read the named env var at request time.
+// The token value is never logged; only its absence triggers a warning.
+if token := os.Getenv(upstreamBearerTokenEnv); token != "" {
+pr.Out.Header.Set("Authorization", "Bearer "+token)
+}
+} else if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
+pr.Out.Header.Set("Authorization", "Bearer "+token)
+}
 
-			if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
-				pr.Out.Header.Set("X-Authenticated-User", sanitizeHeaderValue(subject))
-				// Legacy header retained during the migration window so that
-				// upstream MCP services (github-mcp, copilot-review-mcp) keep
-				// working until they migrate to X-Authenticated-User.
-				pr.Out.Header.Set("X-GitHub-Login", sanitizeHeaderValue(subject))
-			}
+if subject := middleware.IdentityFromContext(pr.In.Context()); subject != "" {
+pr.Out.Header.Set("X-Authenticated-User", sanitizeHeaderValue(subject))
+// Legacy header retained during the migration window so that
+// upstream MCP services (github-mcp, copilot-review-mcp) keep
+// working until they migrate to X-Authenticated-User.
+pr.Out.Header.Set("X-GitHub-Login", sanitizeHeaderValue(subject))
+}
 
-			slog.Info("proxy request",
-				"user", middleware.IdentityFromContext(pr.In.Context()),
-				"method", pr.Out.Method,
-				"path", pr.Out.URL.Path,
-				"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),
-			)
-		},
+slog.Info("proxy request",
+"user", middleware.IdentityFromContext(pr.In.Context()),
+"method", pr.Out.Method,
+"path", pr.Out.URL.Path,
+"token_hash", tokenHash(middleware.TokenFromContext(pr.In.Context())),
+)
+},
 
-		ModifyResponse: func(resp *http.Response) error {
-			if resp.StatusCode == http.StatusUnauthorized && inv != nil {
-				if token := extractBearer(resp.Request); token != "" {
-					inv.InvalidateCachedToken(token)
-					slog.Warn("upstream rejected token; cache invalidated",
-						"path", resp.Request.URL.Path,
-						"token_hash", tokenHash(token),
-					)
-				}
-			}
-			slog.Info("proxy response",
-				"upstream_status", resp.StatusCode,
-				"path", resp.Request.URL.Path,
-			)
-			return nil
-		},
-	}
+ModifyResponse: func(resp *http.Response) error {
+if resp.StatusCode == http.StatusUnauthorized {
+if upstreamBearerTokenEnv != "" {
+// The 401 came from an upstream-credential route.
+// This is a problem with the upstream API token, not the
+// client OAuth session — do NOT invalidate the client cache.
+slog.Warn("upstream rejected upstream credential; check env var token",
+"path", resp.Request.URL.Path,
+"env_var", upstreamBearerTokenEnv,
+)
+} else if inv != nil {
+if token := extractBearer(resp.Request); token != "" {
+inv.InvalidateCachedToken(token)
+slog.Warn("upstream rejected token; cache invalidated",
+"path", resp.Request.URL.Path,
+"token_hash", tokenHash(token),
+)
+}
+}
+}
+slog.Info("proxy response",
+"upstream_status", resp.StatusCode,
+"path", resp.Request.URL.Path,
+)
+return nil
+},
+}
 
-	return rp
+return rp
 }
 
 func extractBearer(req *http.Request) string {
-	auth := req.Header.Get("Authorization")
-	const prefix = "Bearer "
-	if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
-		return auth[len(prefix):]
-	}
-	return ""
+auth := req.Header.Get("Authorization")
+const prefix = "Bearer "
+if len(auth) > len(prefix) && auth[:len(prefix)] == prefix {
+return auth[len(prefix):]
+}
+return ""
 }
 
 // headerSanitizer is a package-level replacer reused on every proxied request.
@@ -92,14 +117,14 @@ var headerSanitizer = strings.NewReplacer("\r", "", "\n", "")
 
 // sanitizeHeaderValue strips CR and LF to prevent HTTP header injection.
 func sanitizeHeaderValue(s string) string {
-	return headerSanitizer.Replace(s)
+return headerSanitizer.Replace(s)
 }
 
 // tokenHash returns the first 8 hex characters of SHA-256(token) for log correlation.
 func tokenHash(token string) string {
-	if token == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(token))
-	return fmt.Sprintf("%x", sum[:4])
+if token == "" {
+return ""
+}
+sum := sha256.Sum256([]byte(token))
+return fmt.Sprintf("%x", sum[:4])
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -52,7 +52,7 @@ func TestProxyInjectsIdentityHeaders(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{})
+	h := NewHandler(u, &mockInvalidator{}, "")
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice", "tok"))
@@ -88,7 +88,7 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{})
+	h := NewHandler(u, &mockInvalidator{}, "")
 
 	r := requestWithContext("bob", "tok")
 	r.Header.Set("X-Forwarded-For", "1.2.3.4")
@@ -134,7 +134,7 @@ func TestProxyNormalizesAuthorization(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{})
+	h := NewHandler(u, &mockInvalidator{}, "")
 
 	r := requestWithContext("carol", "ctx-token")
 	r.Header.Set("Authorization", "Bearer client-supplied-token")
@@ -153,7 +153,7 @@ func TestProxyInvalidatesCacheOn401(t *testing.T) {
 
 	u, _ := url.Parse(upstream.URL)
 	inv := &mockInvalidator{}
-	h := NewHandler(u, inv)
+	h := NewHandler(u, inv, "")
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("dave", "secret-token"))
@@ -172,7 +172,7 @@ func TestProxySanitizesHeaderInjectionCharacters(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{})
+	h := NewHandler(u, &mockInvalidator{}, "")
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice\r\nevil: injected", "tok"))
@@ -187,7 +187,7 @@ func TestProxyNilInvalidatorDoesNotPanicOn401(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, nil)
+	h := NewHandler(u, nil, "")
 
 	w := httptest.NewRecorder()
 	// Must not panic.
@@ -214,7 +214,7 @@ func TestMiddlewareToProxyInjectsIdentityHeaders(t *testing.T) {
 
 	u, _ := url.Parse(upstream.URL)
 	validator := &testValidator{login: "octocat"}
-	chain := middleware.Auth(validator)(NewHandler(u, &mockInvalidator{}))
+	chain := middleware.Auth(validator)(NewHandler(u, &mockInvalidator{}, ""))
 
 	r := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
 	r.Header.Set("Authorization", "Bearer real-github-token")
@@ -232,5 +232,64 @@ func TestMiddlewareToProxyInjectsIdentityHeaders(t *testing.T) {
 	}
 	if gotAuth != "Bearer real-github-token" {
 		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer real-github-token")
+	}
+}
+
+func TestProxyUpstreamBearerEnvInjectsToken(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	t.Setenv("UPSTREAM_TEST_TOKEN", "env-api-token")
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "client-oauth-token"))
+
+	if gotAuth != "Bearer env-api-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer env-api-token")
+	}
+}
+
+func TestProxyUpstreamBearerEnvStripsClientAuth(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	t.Setenv("UPSTREAM_TEST_TOKEN2", "real-env-token")
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN2")
+
+	req := requestWithContext("bob", "client-token")
+	req.Header.Set("Authorization", "Bearer client-supplied-auth")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if gotAuth != "Bearer real-env-token" {
+		t.Errorf("Authorization: got %q, want %q (client token must not leak through)", gotAuth, "Bearer real-env-token")
+	}
+}
+
+func TestProxyUpstreamBearerEnvDoesNotInvalidateOn401(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	t.Setenv("UPSTREAM_TEST_TOKEN3", "some-api-token")
+	u, _ := url.Parse(upstream.URL)
+	inv := &mockInvalidator{}
+	h := NewHandler(u, inv, "UPSTREAM_TEST_TOKEN3")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("carol", "client-oauth-token"))
+
+	if len(inv.tokens) != 0 {
+		t.Errorf("expected no invalidated tokens for upstream-credential route, got %v", inv.tokens)
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,91 +1,147 @@
 package router
 
 import (
-	"fmt"
-	"net/url"
-	"os"
-	"sort"
-	"strings"
+"fmt"
+"net/url"
+"os"
+"sort"
+"strings"
 
-	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
+appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 )
 
 // Route maps a URL path prefix to an upstream MCP server.
 type Route struct {
-	Name     string
-	Prefix   string
-	Upstream *url.URL
-	NoAuth   bool // true when auth=none is specified; skips OAuth middleware
+Name     string
+Prefix   string
+Upstream *url.URL
+NoAuth   bool   // true when auth=none; skips OAuth middleware
+// UpstreamBearerTokenEnv names an env var whose trimmed value is injected as
+// the upstream Authorization Bearer token on every proxied request.
+// When empty (default), the client OAuth context token is used instead.
+// The env var must be set and non-blank at startup (fail-closed).
+UpstreamBearerTokenEnv string
 }
 
-// ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url> environment variables
-// and returns routes sorted by prefix length (longest first) for correct matching.
+// ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
+// variables and returns routes sorted by prefix length (longest first).
 func ParseEnv() ([]Route, error) {
-	return parseRoutes(os.Environ())
+return parseRoutes(os.Environ())
 }
 
 func parseRoutes(env []string) ([]Route, error) {
-	var routes []Route
-	seen := make(map[string]struct{})
-	for _, entry := range env {
-		key, val, found := strings.Cut(entry, "=")
-		if !found || !strings.HasPrefix(key, "ROUTE_") {
-			continue
-		}
-		name := strings.ToLower(strings.TrimPrefix(key, "ROUTE_"))
-		if name == "" {
-			return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
-		}
-		prefix, rest, found := strings.Cut(val, "|")
-		if !found {
-			return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)
-		}
-		upstreamRaw, authOpt, hasAuthOpt := strings.Cut(rest, "|")
-		var noAuth bool
-		if hasAuthOpt {
-			switch authOpt {
-			case "auth=none":
-				noAuth = true
-			case "auth=oauth":
-				noAuth = false
-			default:
-				return nil, fmt.Errorf("%s: unknown auth option %q (use auth=none or auth=oauth)", key, authOpt)
-			}
-		}
-		// Strip trailing slash(es) only when it won't erase the root prefix.
-		if prefix != "/" {
-			prefix = strings.TrimRight(prefix, "/")
-		}
-		if prefix == "" {
-			return nil, fmt.Errorf("%s: prefix must not be empty", key)
-		}
-		if !strings.HasPrefix(prefix, "/") {
-			return nil, fmt.Errorf("%s: prefix must start with '/' (got %q)", key, prefix)
-		}
-		if strings.ContainsAny(prefix, " \t\n\r") {
-			return nil, fmt.Errorf("%s: prefix must not contain whitespace (got %q)", key, prefix)
-		}
-		u, err := url.Parse(upstreamRaw)
-		if err != nil {
-			return nil, fmt.Errorf("%s: invalid upstream URL: %w", key, err)
-		}
-		if u.Scheme == "" || u.Host == "" {
-			return nil, fmt.Errorf("%s: upstream URL must be absolute with scheme and host (got %q)", key, upstreamRaw)
-		}
-		if u.Scheme != "http" && u.Scheme != "https" {
-			return nil, fmt.Errorf("%s: upstream URL scheme must be http or https (got %q)", key, u.Scheme)
-		}
-		if _, dup := seen[prefix]; dup {
-			return nil, fmt.Errorf("%s: duplicate prefix %q", key, prefix)
-		}
-		seen[prefix] = struct{}{}
-		routes = append(routes, Route{Name: name, Prefix: prefix, Upstream: u, NoAuth: noAuth})
-	}
-	// Longest prefix first for correct matching order.
-	sort.Slice(routes, func(i, j int) bool {
-		return len(routes[i].Prefix) > len(routes[j].Prefix)
-	})
-	return routes, nil
+var routes []Route
+seen := make(map[string]struct{})
+for _, entry := range env {
+key, val, found := strings.Cut(entry, "=")
+if !found || !strings.HasPrefix(key, "ROUTE_") {
+continue
+}
+name := strings.ToLower(strings.TrimPrefix(key, "ROUTE_"))
+if name == "" {
+return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
+}
+prefix, rest, found := strings.Cut(val, "|")
+if !found {
+return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)
+}
+// Split rest into [upstreamURL, option1, option2, ...].
+parts := strings.Split(rest, "|")
+upstreamRaw := parts[0]
+optionParts := parts[1:]
+
+// Parse key=value options; unknown or duplicate keys are fatal (fail-closed).
+options := make(map[string]string, len(optionParts))
+for _, opt := range optionParts {
+k, v, hasVal := strings.Cut(opt, "=")
+if !hasVal {
+return nil, fmt.Errorf("%s: option %q must be in key=value format", key, opt)
+}
+if _, dup := options[k]; dup {
+return nil, fmt.Errorf("%s: duplicate option key %q", key, k)
+}
+options[k] = v
+}
+
+// auth option: controls client → gateway authentication.
+var noAuth bool
+if authVal, ok := options["auth"]; ok {
+switch authVal {
+case "none":
+noAuth = true
+case "oauth":
+noAuth = false
+default:
+return nil, fmt.Errorf("%s: unknown auth value %q (use auth=none or auth=oauth)", key, authVal)
+}
+delete(options, "auth")
+}
+
+// upstream_bearer_token_env: gateway → upstream Bearer token sourced from env.
+// The named env var must be set and non-blank at startup; fail-closed otherwise.
+var upstreamBearerTokenEnv string
+if envName, ok := options["upstream_bearer_token_env"]; ok {
+envName = strings.TrimSpace(envName)
+if envName == "" {
+return nil, fmt.Errorf("%s: upstream_bearer_token_env value must not be empty", key)
+}
+if strings.TrimSpace(os.Getenv(envName)) == "" {
+return nil, fmt.Errorf("%s: upstream_bearer_token_env=%s is not set or empty (fail-closed)", key, envName)
+}
+upstreamBearerTokenEnv = envName
+delete(options, "upstream_bearer_token_env")
+}
+
+// Reject any unrecognised option keys.
+if len(options) > 0 {
+unknown := make([]string, 0, len(options))
+for k := range options {
+unknown = append(unknown, k)
+}
+sort.Strings(unknown)
+return nil, fmt.Errorf("%s: unknown route option(s): %s", key, strings.Join(unknown, ", "))
+}
+
+// Strip trailing slash(es) only when it won't erase the root prefix.
+if prefix != "/" {
+prefix = strings.TrimRight(prefix, "/")
+}
+if prefix == "" {
+return nil, fmt.Errorf("%s: prefix must not be empty", key)
+}
+if !strings.HasPrefix(prefix, "/") {
+return nil, fmt.Errorf("%s: prefix must start with '/' (got %q)", key, prefix)
+}
+if strings.ContainsAny(prefix, " \t\n\r") {
+return nil, fmt.Errorf("%s: prefix must not contain whitespace (got %q)", key, prefix)
+}
+u, err := url.Parse(upstreamRaw)
+if err != nil {
+return nil, fmt.Errorf("%s: invalid upstream URL: %w", key, err)
+}
+if u.Scheme == "" || u.Host == "" {
+return nil, fmt.Errorf("%s: upstream URL must be absolute with scheme and host (got %q)", key, upstreamRaw)
+}
+if u.Scheme != "http" && u.Scheme != "https" {
+return nil, fmt.Errorf("%s: upstream URL scheme must be http or https (got %q)", key, u.Scheme)
+}
+if _, dup := seen[prefix]; dup {
+return nil, fmt.Errorf("%s: duplicate prefix %q", key, prefix)
+}
+seen[prefix] = struct{}{}
+routes = append(routes, Route{
+Name:                   name,
+Prefix:                 prefix,
+Upstream:               u,
+NoAuth:                 noAuth,
+UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
+})
+}
+// Longest prefix first for correct matching order.
+sort.Slice(routes, func(i, j int) bool {
+return len(routes[i].Prefix) > len(routes[j].Prefix)
+})
+return routes, nil
 }
 
 // ParseFromConfig converts persisted RouteConfig entries (from config.yaml) into
@@ -93,44 +149,50 @@ func parseRoutes(env []string) ([]Route, error) {
 // env ROUTE_* variables take precedence over config.yaml routes; this function
 // is only called when ParseEnv returns no routes.
 func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
-	var routes []Route
-	seen := make(map[string]struct{})
-	for _, r := range cfgRoutes {
-		name := strings.ToLower(strings.TrimSpace(r.Name))
-		if name == "" {
-			return nil, fmt.Errorf("route name must not be empty")
-		}
-		prefix := r.Prefix
-		if prefix != "/" {
-			prefix = strings.TrimRight(prefix, "/")
-		}
-		if prefix == "" {
-			return nil, fmt.Errorf("route %q: prefix must not be empty", name)
-		}
-		if !strings.HasPrefix(prefix, "/") {
-			return nil, fmt.Errorf("route %q: prefix must start with '/' (got %q)", name, prefix)
-		}
-		if strings.ContainsAny(prefix, " \t\n\r") {
-			return nil, fmt.Errorf("route %q: prefix must not contain whitespace (got %q)", name, prefix)
-		}
-		u, err := url.Parse(r.Upstream)
-		if err != nil {
-			return nil, fmt.Errorf("route %q: invalid upstream URL: %w", name, err)
-		}
-		if u.Scheme == "" || u.Host == "" {
-			return nil, fmt.Errorf("route %q: upstream URL must be absolute with scheme and host (got %q)", name, r.Upstream)
-		}
-		if u.Scheme != "http" && u.Scheme != "https" {
-			return nil, fmt.Errorf("route %q: upstream URL scheme must be http or https (got %q)", name, u.Scheme)
-		}
-		if _, dup := seen[prefix]; dup {
-			return nil, fmt.Errorf("route %q: duplicate prefix %q", name, prefix)
-		}
-		seen[prefix] = struct{}{}
-		routes = append(routes, Route{Name: name, Prefix: prefix, Upstream: u, NoAuth: r.NoAuth})
-	}
-	sort.Slice(routes, func(i, j int) bool {
-		return len(routes[i].Prefix) > len(routes[j].Prefix)
-	})
-	return routes, nil
+var routes []Route
+seen := make(map[string]struct{})
+for _, r := range cfgRoutes {
+name := strings.ToLower(strings.TrimSpace(r.Name))
+if name == "" {
+return nil, fmt.Errorf("route name must not be empty")
+}
+prefix := r.Prefix
+if prefix != "/" {
+prefix = strings.TrimRight(prefix, "/")
+}
+if prefix == "" {
+return nil, fmt.Errorf("route %q: prefix must not be empty", name)
+}
+if !strings.HasPrefix(prefix, "/") {
+return nil, fmt.Errorf("route %q: prefix must start with '/' (got %q)", name, prefix)
+}
+if strings.ContainsAny(prefix, " \t\n\r") {
+return nil, fmt.Errorf("route %q: prefix must not contain whitespace (got %q)", name, prefix)
+}
+u, err := url.Parse(r.Upstream)
+if err != nil {
+return nil, fmt.Errorf("route %q: invalid upstream URL: %w", name, err)
+}
+if u.Scheme == "" || u.Host == "" {
+return nil, fmt.Errorf("route %q: upstream URL must be absolute with scheme and host (got %q)", name, r.Upstream)
+}
+if u.Scheme != "http" && u.Scheme != "https" {
+return nil, fmt.Errorf("route %q: upstream URL scheme must be http or https (got %q)", name, u.Scheme)
+}
+if _, dup := seen[prefix]; dup {
+return nil, fmt.Errorf("route %q: duplicate prefix %q", name, prefix)
+}
+seen[prefix] = struct{}{}
+routes = append(routes, Route{
+Name:                   name,
+Prefix:                 prefix,
+Upstream:               u,
+NoAuth:                 r.NoAuth,
+UpstreamBearerTokenEnv: r.UpstreamBearerTokenEnv,
+})
+}
+sort.Slice(routes, func(i, j int) bool {
+return len(routes[i].Prefix) > len(routes[j].Prefix)
+})
+return routes, nil
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,4 +1,4 @@
-package router
+﻿package router
 
 import (
 "fmt"
@@ -182,13 +182,23 @@ return nil, fmt.Errorf("route %q: upstream URL scheme must be http or https (got
 if _, dup := seen[prefix]; dup {
 return nil, fmt.Errorf("route %q: duplicate prefix %q", name, prefix)
 }
+// upstream_bearer_token_env: apply same fail-closed validation as parseRoutes.
+upstreamBearerTokenEnv := strings.TrimSpace(r.UpstreamBearerTokenEnv)
+if r.UpstreamBearerTokenEnv != "" {
+if upstreamBearerTokenEnv == "" {
+return nil, fmt.Errorf("route %q: upstream_bearer_token_env value must not be empty", name)
+}
+if strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)) == "" {
+return nil, fmt.Errorf("route %q: upstream_bearer_token_env=%s is not set or empty (fail-closed)", name, upstreamBearerTokenEnv)
+}
+}
 seen[prefix] = struct{}{}
 routes = append(routes, Route{
 Name:                   name,
 Prefix:                 prefix,
 Upstream:               u,
 NoAuth:                 r.NoAuth,
-UpstreamBearerTokenEnv: r.UpstreamBearerTokenEnv,
+UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
 })
 }
 sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,147 +1,154 @@
-﻿package router
+package router
 
 import (
-"fmt"
-"net/url"
-"os"
-"sort"
-"strings"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
 
-appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
+	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 )
 
 // Route maps a URL path prefix to an upstream MCP server.
 type Route struct {
-Name     string
-Prefix   string
-Upstream *url.URL
-NoAuth   bool   // true when auth=none; skips OAuth middleware
-// UpstreamBearerTokenEnv names an env var whose trimmed value is injected as
-// the upstream Authorization Bearer token on every proxied request.
-// When empty (default), the client OAuth context token is used instead.
-// The env var must be set and non-blank at startup (fail-closed).
-UpstreamBearerTokenEnv string
+	Name     string
+	Prefix   string
+	Upstream *url.URL
+	NoAuth   bool // true when auth=none; skips OAuth middleware
+	// UpstreamBearerTokenEnv names an env var whose trimmed value is injected as
+	// the upstream Authorization Bearer token on every proxied request.
+	// When empty (default), the client OAuth context token is used instead.
+	// The env var must be set and non-blank at startup (fail-closed).
+	// Note: the fail-closed guarantee is startup-only. If the env var is
+	// cleared or rotated to empty after the gateway starts, the proxy logs a
+	// warning and forwards requests without an Authorization header rather
+	// than terminating. Operators must restart the gateway after rotating
+	// this credential to restore fail-closed protection.
+	UpstreamBearerTokenEnv string
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
 // variables and returns routes sorted by prefix length (longest first).
 func ParseEnv() ([]Route, error) {
-return parseRoutes(os.Environ())
+	return parseRoutes(os.Environ())
 }
 
 func parseRoutes(env []string) ([]Route, error) {
-var routes []Route
-seen := make(map[string]struct{})
-for _, entry := range env {
-key, val, found := strings.Cut(entry, "=")
-if !found || !strings.HasPrefix(key, "ROUTE_") {
-continue
-}
-name := strings.ToLower(strings.TrimPrefix(key, "ROUTE_"))
-if name == "" {
-return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
-}
-prefix, rest, found := strings.Cut(val, "|")
-if !found {
-return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)
-}
-// Split rest into [upstreamURL, option1, option2, ...].
-parts := strings.Split(rest, "|")
-upstreamRaw := parts[0]
-optionParts := parts[1:]
+	var routes []Route
+	seen := make(map[string]struct{})
+	for _, entry := range env {
+		key, val, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(key, "ROUTE_") {
+			continue
+		}
+		name := strings.ToLower(strings.TrimPrefix(key, "ROUTE_"))
+		if name == "" {
+			return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
+		}
+		prefix, rest, found := strings.Cut(val, "|")
+		if !found {
+			return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)
+		}
+		// Split rest into [upstreamURL, option1, option2, ...].
+		parts := strings.Split(rest, "|")
+		upstreamRaw := parts[0]
+		optionParts := parts[1:]
 
-// Parse key=value options; unknown or duplicate keys are fatal (fail-closed).
-options := make(map[string]string, len(optionParts))
-for _, opt := range optionParts {
-k, v, hasVal := strings.Cut(opt, "=")
-if !hasVal {
-return nil, fmt.Errorf("%s: option %q must be in key=value format", key, opt)
-}
-if _, dup := options[k]; dup {
-return nil, fmt.Errorf("%s: duplicate option key %q", key, k)
-}
-options[k] = v
-}
+		// Parse key=value options; unknown or duplicate keys are fatal (fail-closed).
+		options := make(map[string]string, len(optionParts))
+		for _, opt := range optionParts {
+			k, v, hasVal := strings.Cut(opt, "=")
+			if !hasVal {
+				return nil, fmt.Errorf("%s: option %q must be in key=value format", key, opt)
+			}
+			if _, dup := options[k]; dup {
+				return nil, fmt.Errorf("%s: duplicate option key %q", key, k)
+			}
+			options[k] = v
+		}
 
-// auth option: controls client → gateway authentication.
-var noAuth bool
-if authVal, ok := options["auth"]; ok {
-switch authVal {
-case "none":
-noAuth = true
-case "oauth":
-noAuth = false
-default:
-return nil, fmt.Errorf("%s: unknown auth value %q (use auth=none or auth=oauth)", key, authVal)
-}
-delete(options, "auth")
-}
+		// auth option: controls client → gateway authentication.
+		var noAuth bool
+		if authVal, ok := options["auth"]; ok {
+			switch authVal {
+			case "none":
+				noAuth = true
+			case "oauth":
+				noAuth = false
+			default:
+				return nil, fmt.Errorf("%s: unknown auth value %q (use auth=none or auth=oauth)", key, authVal)
+			}
+			delete(options, "auth")
+		}
 
-// upstream_bearer_token_env: gateway → upstream Bearer token sourced from env.
-// The named env var must be set and non-blank at startup; fail-closed otherwise.
-var upstreamBearerTokenEnv string
-if envName, ok := options["upstream_bearer_token_env"]; ok {
-envName = strings.TrimSpace(envName)
-if envName == "" {
-return nil, fmt.Errorf("%s: upstream_bearer_token_env value must not be empty", key)
-}
-if strings.TrimSpace(os.Getenv(envName)) == "" {
-return nil, fmt.Errorf("%s: upstream_bearer_token_env=%s is not set or empty (fail-closed)", key, envName)
-}
-upstreamBearerTokenEnv = envName
-delete(options, "upstream_bearer_token_env")
-}
+		// upstream_bearer_token_env: gateway → upstream Bearer token sourced from env.
+		// The named env var must be set and non-blank at startup; fail-closed otherwise.
+		// After startup, if the env var is cleared or emptied, the proxy logs a
+		// warning per request and forwards without Authorization (see proxy.NewHandler).
+		var upstreamBearerTokenEnv string
+		if envName, ok := options["upstream_bearer_token_env"]; ok {
+			envName = strings.TrimSpace(envName)
+			if envName == "" {
+				return nil, fmt.Errorf("%s: upstream_bearer_token_env value must not be empty", key)
+			}
+			if strings.TrimSpace(os.Getenv(envName)) == "" {
+				return nil, fmt.Errorf("%s: upstream_bearer_token_env=%s is not set or empty (fail-closed)", key, envName)
+			}
+			upstreamBearerTokenEnv = envName
+			delete(options, "upstream_bearer_token_env")
+		}
 
-// Reject any unrecognised option keys.
-if len(options) > 0 {
-unknown := make([]string, 0, len(options))
-for k := range options {
-unknown = append(unknown, k)
-}
-sort.Strings(unknown)
-return nil, fmt.Errorf("%s: unknown route option(s): %s", key, strings.Join(unknown, ", "))
-}
+		// Reject any unrecognised option keys.
+		if len(options) > 0 {
+			unknown := make([]string, 0, len(options))
+			for k := range options {
+				unknown = append(unknown, k)
+			}
+			sort.Strings(unknown)
+			return nil, fmt.Errorf("%s: unknown route option(s): %s", key, strings.Join(unknown, ", "))
+		}
 
-// Strip trailing slash(es) only when it won't erase the root prefix.
-if prefix != "/" {
-prefix = strings.TrimRight(prefix, "/")
-}
-if prefix == "" {
-return nil, fmt.Errorf("%s: prefix must not be empty", key)
-}
-if !strings.HasPrefix(prefix, "/") {
-return nil, fmt.Errorf("%s: prefix must start with '/' (got %q)", key, prefix)
-}
-if strings.ContainsAny(prefix, " \t\n\r") {
-return nil, fmt.Errorf("%s: prefix must not contain whitespace (got %q)", key, prefix)
-}
-u, err := url.Parse(upstreamRaw)
-if err != nil {
-return nil, fmt.Errorf("%s: invalid upstream URL: %w", key, err)
-}
-if u.Scheme == "" || u.Host == "" {
-return nil, fmt.Errorf("%s: upstream URL must be absolute with scheme and host (got %q)", key, upstreamRaw)
-}
-if u.Scheme != "http" && u.Scheme != "https" {
-return nil, fmt.Errorf("%s: upstream URL scheme must be http or https (got %q)", key, u.Scheme)
-}
-if _, dup := seen[prefix]; dup {
-return nil, fmt.Errorf("%s: duplicate prefix %q", key, prefix)
-}
-seen[prefix] = struct{}{}
-routes = append(routes, Route{
-Name:                   name,
-Prefix:                 prefix,
-Upstream:               u,
-NoAuth:                 noAuth,
-UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
-})
-}
-// Longest prefix first for correct matching order.
-sort.Slice(routes, func(i, j int) bool {
-return len(routes[i].Prefix) > len(routes[j].Prefix)
-})
-return routes, nil
+		// Strip trailing slash(es) only when it won't erase the root prefix.
+		if prefix != "/" {
+			prefix = strings.TrimRight(prefix, "/")
+		}
+		if prefix == "" {
+			return nil, fmt.Errorf("%s: prefix must not be empty", key)
+		}
+		if !strings.HasPrefix(prefix, "/") {
+			return nil, fmt.Errorf("%s: prefix must start with '/' (got %q)", key, prefix)
+		}
+		if strings.ContainsAny(prefix, " \t\n\r") {
+			return nil, fmt.Errorf("%s: prefix must not contain whitespace (got %q)", key, prefix)
+		}
+		u, err := url.Parse(upstreamRaw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: invalid upstream URL: %w", key, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("%s: upstream URL must be absolute with scheme and host (got %q)", key, upstreamRaw)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("%s: upstream URL scheme must be http or https (got %q)", key, u.Scheme)
+		}
+		if _, dup := seen[prefix]; dup {
+			return nil, fmt.Errorf("%s: duplicate prefix %q", key, prefix)
+		}
+		seen[prefix] = struct{}{}
+		routes = append(routes, Route{
+			Name:                   name,
+			Prefix:                 prefix,
+			Upstream:               u,
+			NoAuth:                 noAuth,
+			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
+		})
+	}
+	// Longest prefix first for correct matching order.
+	sort.Slice(routes, func(i, j int) bool {
+		return len(routes[i].Prefix) > len(routes[j].Prefix)
+	})
+	return routes, nil
 }
 
 // ParseFromConfig converts persisted RouteConfig entries (from config.yaml) into
@@ -149,60 +156,60 @@ return routes, nil
 // env ROUTE_* variables take precedence over config.yaml routes; this function
 // is only called when ParseEnv returns no routes.
 func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
-var routes []Route
-seen := make(map[string]struct{})
-for _, r := range cfgRoutes {
-name := strings.ToLower(strings.TrimSpace(r.Name))
-if name == "" {
-return nil, fmt.Errorf("route name must not be empty")
-}
-prefix := r.Prefix
-if prefix != "/" {
-prefix = strings.TrimRight(prefix, "/")
-}
-if prefix == "" {
-return nil, fmt.Errorf("route %q: prefix must not be empty", name)
-}
-if !strings.HasPrefix(prefix, "/") {
-return nil, fmt.Errorf("route %q: prefix must start with '/' (got %q)", name, prefix)
-}
-if strings.ContainsAny(prefix, " \t\n\r") {
-return nil, fmt.Errorf("route %q: prefix must not contain whitespace (got %q)", name, prefix)
-}
-u, err := url.Parse(r.Upstream)
-if err != nil {
-return nil, fmt.Errorf("route %q: invalid upstream URL: %w", name, err)
-}
-if u.Scheme == "" || u.Host == "" {
-return nil, fmt.Errorf("route %q: upstream URL must be absolute with scheme and host (got %q)", name, r.Upstream)
-}
-if u.Scheme != "http" && u.Scheme != "https" {
-return nil, fmt.Errorf("route %q: upstream URL scheme must be http or https (got %q)", name, u.Scheme)
-}
-if _, dup := seen[prefix]; dup {
-return nil, fmt.Errorf("route %q: duplicate prefix %q", name, prefix)
-}
-// upstream_bearer_token_env: apply same fail-closed validation as parseRoutes.
-upstreamBearerTokenEnv := strings.TrimSpace(r.UpstreamBearerTokenEnv)
-if r.UpstreamBearerTokenEnv != "" {
-if upstreamBearerTokenEnv == "" {
-return nil, fmt.Errorf("route %q: upstream_bearer_token_env value must not be empty", name)
-}
-if strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)) == "" {
-return nil, fmt.Errorf("route %q: upstream_bearer_token_env=%s is not set or empty (fail-closed)", name, upstreamBearerTokenEnv)
-}
-}
-seen[prefix] = struct{}{}
-routes = append(routes, Route{
-Name:                   name,
-Prefix:                 prefix,
-Upstream:               u,
-NoAuth:                 r.NoAuth,
-UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
-})
-}
-sort.Slice(routes, func(i, j int) bool {
-return len(routes[i].Prefix) > len(routes[j].Prefix)
-})
-return routes, nil
+	var routes []Route
+	seen := make(map[string]struct{})
+	for _, r := range cfgRoutes {
+		name := strings.ToLower(strings.TrimSpace(r.Name))
+		if name == "" {
+			return nil, fmt.Errorf("route name must not be empty")
+		}
+		prefix := r.Prefix
+		if prefix != "/" {
+			prefix = strings.TrimRight(prefix, "/")
+		}
+		if prefix == "" {
+			return nil, fmt.Errorf("route %q: prefix must not be empty", name)
+		}
+		if !strings.HasPrefix(prefix, "/") {
+			return nil, fmt.Errorf("route %q: prefix must start with '/' (got %q)", name, prefix)
+		}
+		if strings.ContainsAny(prefix, " \t\n\r") {
+			return nil, fmt.Errorf("route %q: prefix must not contain whitespace (got %q)", name, prefix)
+		}
+		u, err := url.Parse(r.Upstream)
+		if err != nil {
+			return nil, fmt.Errorf("route %q: invalid upstream URL: %w", name, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("route %q: upstream URL must be absolute with scheme and host (got %q)", name, r.Upstream)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("route %q: upstream URL scheme must be http or https (got %q)", name, u.Scheme)
+		}
+		if _, dup := seen[prefix]; dup {
+			return nil, fmt.Errorf("route %q: duplicate prefix %q", name, prefix)
+		}
+		// upstream_bearer_token_env: apply same fail-closed validation as parseRoutes.
+		upstreamBearerTokenEnv := strings.TrimSpace(r.UpstreamBearerTokenEnv)
+		if r.UpstreamBearerTokenEnv != "" {
+			if upstreamBearerTokenEnv == "" {
+				return nil, fmt.Errorf("route %q: upstream_bearer_token_env value must not be empty", name)
+			}
+			if strings.TrimSpace(os.Getenv(upstreamBearerTokenEnv)) == "" {
+				return nil, fmt.Errorf("route %q: upstream_bearer_token_env=%s is not set or empty (fail-closed)", name, upstreamBearerTokenEnv)
+			}
+		}
+		seen[prefix] = struct{}{}
+		routes = append(routes, Route{
+			Name:                   name,
+			Prefix:                 prefix,
+			Upstream:               u,
+			NoAuth:                 r.NoAuth,
+			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
+		})
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		return len(routes[i].Prefix) > len(routes[j].Prefix)
+	})
+	return routes, nil
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -310,3 +310,79 @@ func TestParseFromConfig_SortedLongestFirst(t *testing.T) {
 		t.Errorf("first route should be longest prefix, got %q", routes[0].Prefix)
 	}
 }
+
+// Tests for multi-option ROUTE_* parser (upstream_bearer_token_env, duplicates, unknowns)
+
+func TestParseRoutesUpstreamBearerTokenEnv(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_TOKEN", "test-cf-token")
+	env := []string{"ROUTE_CF=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].UpstreamBearerTokenEnv != "CLOUDFLARE_API_TOKEN" {
+		t.Errorf("UpstreamBearerTokenEnv: got %q, want %q", routes[0].UpstreamBearerTokenEnv, "CLOUDFLARE_API_TOKEN")
+	}
+}
+
+func TestParseRoutesUpstreamBearerTokenEnvNotSet(t *testing.T) {
+	t.Setenv("CF_TOKEN_EMPTY", "")
+	env := []string{"ROUTE_CF=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|upstream_bearer_token_env=CF_TOKEN_EMPTY"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for empty env var (fail-closed)")
+	}
+}
+
+func TestParseRoutesUpstreamBearerTokenEnvNameEmpty(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|upstream_bearer_token_env="}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for empty upstream_bearer_token_env value")
+	}
+}
+
+func TestParseRoutesUnknownOption(t *testing.T) {
+	env := []string{"ROUTE_BAD=/mcp/bad|http://bad:9000|foo=bar"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for unknown route option")
+	}
+}
+
+func TestParseRoutesDuplicateOptionKey(t *testing.T) {
+	env := []string{"ROUTE_BAD=/mcp/bad|http://bad:9000|auth=oauth|auth=none"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for duplicate option key")
+	}
+}
+
+func TestParseRoutesOptionWithoutEquals(t *testing.T) {
+	env := []string{"ROUTE_BAD=/mcp/bad|http://bad:9000|auth"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for option without key=value format")
+	}
+}
+
+func TestParseRoutesAuthOAuthWithUpstreamBearerTokenEnv(t *testing.T) {
+	t.Setenv("MY_API_TOKEN", "my-secret-token")
+	env := []string{"ROUTE_EXT=/mcp/ext|https://ext.example.com/mcp|auth=oauth|upstream_bearer_token_env=MY_API_TOKEN"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].NoAuth {
+		t.Error("expected NoAuth=false for auth=oauth")
+	}
+	if routes[0].UpstreamBearerTokenEnv != "MY_API_TOKEN" {
+		t.Errorf("UpstreamBearerTokenEnv: got %q, want %q", routes[0].UpstreamBearerTokenEnv, "MY_API_TOKEN")
+	}
+}


### PR DESCRIPTION
## 概要

Issue #82 の実装。`ROUTE_*` 環境変数に `upstream_bearer_token_env=ENV_NAME` オプションを追加し、mcp-gateway が外部 Remote MCP プロバイダー（Cloudflare 等）へのリクエスト時に環境変数から読み込んだ Bearer トークンを upstream へ注入できるようにする。

これにより Mcp-Docker #146（Cloudflare MCP プロバイダー統合）の前提機能を提供する。

---

## 変更内容

### `internal/router/router.go`

- `ROUTE_*` オプションパーサーを多キー・バリュー形式に拡張
- 対応オプション:
  - `auth=none|oauth` — クライアント→ゲートウェイ認証制御（既存）
  - `upstream_bearer_token_env=ENV_NAME` — ゲートウェイ→upstream Bearer トークン（新規）
- **Fail-closed 設計**:
  - `=` なし形式はエラー
  - 重複キーはエラー
  - 未知キーはエラー
  - 指定 env var が未設定・空文字はエラー
- `Route` struct に `UpstreamBearerTokenEnv string` フィールド追加

### `internal/config/config.go`

- `RouteConfig` struct に `UpstreamBearerTokenEnv string` フィールド追加
- yaml/json タグ: `upstream_bearer_token_env,omitempty`

### `internal/proxy/handler.go`

- `NewHandler` シグネチャ変更: `upstreamBearerTokenEnv string` を第 3 引数として追加
- Authorization 処理:
  - クライアント提供の Authorization を**常に**削除（スプーフィング防止）
  - `upstreamBearerTokenEnv` が設定されている場合: env var の値を Bearer として upstream へ注入
  - 設定されていない場合: 既存の OAuth コンテキストトークンを使用
- **upstream 401 の扱い分離**:
  - `upstreamBearerTokenEnv` あり → 警告ログのみ、クライアント OAuth キャッシュは**無効化しない**
  - `upstreamBearerTokenEnv` なし → 既存の `InvalidateCachedToken` 動作を維持

### `cmd/server/main.go`

- `proxy.NewHandler` 呼び出しに `route.UpstreamBearerTokenEnv` を渡すよう変更
- 起動時の slog に `upstream_bearer_token_env` の設定有無（値は出さない）を追加

### テスト

**`internal/router/router_test.go`** — 7 件の新規テスト:
- `upstream_bearer_token_env` 設定時の正常系
- env var が空/未設定時の fail-closed
- `upstream_bearer_token_env` 値が空文字のエラー
- 未知オプションキーのエラー
- 重複オプションキーのエラー
- `=` なし形式のエラー
- `auth=oauth` と `upstream_bearer_token_env` の組み合わせ

**`internal/proxy/handler_test.go`** — 既存 7 件更新 + 3 件新規:
- 既存の `NewHandler(u, x)` → `NewHandler(u, x, "")` 呼び出しを全更新
- env var トークンが upstream へ注入されることの確認
- クライアント提供 Authorization が upstream へ漏れないことの確認
- upstream 401 時にクライアント OAuth キャッシュが無効化されないことの確認

---

## 設計ノート

```text
ROUTE_CLOUDFLARE=/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN
```

- `auth=oauth` — クライアント→ゲートウェイの認証を要求
- `upstream_bearer_token_env=...` — ゲートウェイ→upstream の認証トークンソース

この 2 軸分離により、将来的に `auth=none` かつ upstream token 注入、OAuth 認証要求かつ固定 API token 送信などの組み合わせにも対応可能。

---

Closes #82

関連: scottlz0310/Mcp-Docker#146