### PR TITLE
fix(router): skip empty ROUTE_* env vars instead of erroring

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,6 +46,11 @@ func parseRoutes(env []string) ([]Route, error) {
 		if name == "" {
 			return nil, fmt.Errorf("%s: route name must not be empty (use ROUTE_<NAME>=...)", key)
 		}
+		// Skip empty values: supports docker-compose conditional patterns like
+		// ${TOKEN:+route_definition} where an absent token yields an empty string.
+		if strings.TrimSpace(val) == "" {
+			continue
+		}
 		prefix, rest, found := strings.Cut(val, "|")
 		if !found {
 			return nil, fmt.Errorf("%s: expected <prefix>|<upstream_url>, got %q", key, val)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -386,3 +386,24 @@ func TestParseRoutesAuthOAuthWithUpstreamBearerTokenEnv(t *testing.T) {
 		t.Errorf("UpstreamBearerTokenEnv: got %q, want %q", routes[0].UpstreamBearerTokenEnv, "MY_API_TOKEN")
 	}
 }
+
+func TestParseRoutesEmptyValueSkipped(t *testing.T) {
+	// Empty ROUTE_* values must be silently skipped.
+	// This supports docker-compose conditional patterns like
+	// ${TOKEN:+route_definition} where an absent token yields an empty string.
+	env := []string{
+		"ROUTE_CLOUDFLARE=",
+		"ROUTE_GITHUB=/mcp/github|http://github-mcp:8082",
+		"ROUTE_EMPTY=   ",
+	}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route (non-empty only), got %d", len(routes))
+	}
+	if routes[0].Name != "github" {
+		t.Errorf("expected route name %q, got %q", "github", routes[0].Name)
+	}
+}


### PR DESCRIPTION
## 背景

`docker-compose.yml` でオプショナルなルートを環境変数で制御したい場合、Docker Compose の `:+` 構文が最もクリーンな方法です:

```yaml
- ROUTE_CLOUDFLARE=${CLOUDFLARE_API_TOKEN:+/mcp/cloudflare|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_bearer_token_env=CLOUDFLARE_API_TOKEN}
```

`CLOUDFLARE_API_TOKEN` が未設定の場合、この展開は空文字列になります。しかし従来の `parseRoutes` は `ROUTE_CLOUDFLARE=`（空値）に対してエラーを返していたため、ユーザーは `docker-compose.yml` の行を手動でコメントアウト/解除する必要があり、git 差分ノイズが発生していました。

## 変更内容

`parseRoutes` において、値が空またはホワイトスペースのみの `ROUTE_*` 変数をエラーではなくスキップするよう変更しました。

- `ROUTE_FOO=` → スキップ（ルート未登録）
- `ROUTE_FOO=   ` → スキップ（ルート未登録）
- `ROUTE_FOO=/prefix|http://upstream` → 従来通り登録

## テスト

`TestParseRoutesEmptyValueSkipped` を追加し、空・ホワイトスペースのみの値を持つ `ROUTE_*` が有効なルートに影響しないことを検証。

## 関連

- scottlz0310/Mcp-Docker での docker-compose.yml 改善と対になる変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)