### PR TITLE
fix(ci): codecov-action を v6.0.2(SHA固定)に更新し continue-on-error を除去

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Run tests
         run: go test -race -coverprofile=coverage.out ./...
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
-        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

codecov の GPG 鍵不具合は v6.0.2 で修正済み。
`continue-on-error: true`（過剰な抑制）を除去し、SHA 固定で恒久対応する。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action 参照 | `codecov/codecov-action@v6` | `codecov/codecov-action@fb8b3582...` (`# v6.0.2`) |
| continue-on-error | `true`（除去） | — |
| fail_ci_if_error | 未設定 | `true` |

## `continue-on-error: true` を除去する理由

codecov アップロードの失敗理由を問わずすべてのエラーを隠蔽するため、設定ミス（トークン失効・カバレッジファイル未生成等）を検知できない。
`fail_ci_if_error: true` に置き換えることで、GPG/ネットワーク起因以外のエラーは CI を止めるようになる。

Closes #89

Generated with [Claude Code](https://claude.com/claude-code)