### PR TITLE
fix(ci): main push での :latest 発行を止め、:latest をリリース専用タグにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
       - uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
 
       - uses: docker/build-push-action@v7
         with:

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,17 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-10
+
+### 修正
+
+- `ci.yml`: main push で `:latest` が更新されないよう `type=raw,value=latest,enable={{is_default_branch}}` を削除（`:main` + `:sha-*` のみ発行）（[#93](https://github.com/scottlz0310/mcp-gateway/issues/93)）
+- `release.yml`: prerelease タグでも `:latest` が付く問題を修正。`type=raw,value=latest` を削除し `latest=auto`（デフォルト）に委ねることで非 prerelease semver タグにのみ `:latest` を付与（[#93](https://github.com/scottlz0310/mcp-gateway/issues/93)）
+
+### ドキュメント
+
+- `CONTRIBUTING.md` を新規作成し、prerelease タグは semver pre-release 形式（`-` 含む）必須である旨を明記（[#94](https://github.com/scottlz0310/mcp-gateway/pull/94)）
+
 ## [0.5.1] - 2026-06-01
 
 ### 修正
@@ -205,7 +216,8 @@
 - `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
 - `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ci.yml`: main push で `:latest` が更新されないよう `type=raw,value=latest,enable={{is_default_branch}}` を削除（`:main` + `:sha-*` のみ発行）([#93](https://github.com/scottlz0310/mcp-gateway/issues/93))
+- `release.yml`: prerelease タグでも `:latest` が付く問題を修正。`type=raw,value=latest` を削除し `latest=auto`（デフォルト）に委ねることで非 prerelease semver タグにのみ `:latest` を付与 ([#93](https://github.com/scottlz0310/mcp-gateway/issues/93))
+
 ## [0.5.1] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-10
+
 ### Fixed
 
 - `ci.yml`: main push で `:latest` が更新されないよう `type=raw,value=latest,enable={{is_default_branch}}` を削除（`:main` + `:sha-*` のみ発行）([#93](https://github.com/scottlz0310/mcp-gateway/issues/93))
 - `release.yml`: prerelease タグでも `:latest` が付く問題を修正。`type=raw,value=latest` を削除し `latest=auto`（デフォルト）に委ねることで非 prerelease semver タグにのみ `:latest` を付与 ([#93](https://github.com/scottlz0310/mcp-gateway/issues/93))
+
+### Documentation
+
+- `CONTRIBUTING.md` を新規作成し、prerelease タグは semver pre-release 形式（`-` 含む）必須である旨を明記 ([#94](https://github.com/scottlz0310/mcp-gateway/pull/94))
 
 ## [0.5.1] - 2026-06-01
 
@@ -217,7 +223,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
 - Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.3.0...v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Release & Tag Naming
+
+### Prerelease tags
+
+Prerelease tags **must** follow SemVer pre-release format (containing `-`), e.g. `v1.0.0-rc.1`.
+
+This is required because `docker/metadata-action` with `latest=auto` adds `:latest` only to non-prerelease semver tags. A tag like `v1.0.0-hotfix` without a pre-release identifier may not be recognized as a prerelease by some semver libraries, causing `:latest` to be updated unintentionally.
+
+Valid: `v1.0.0-rc.1`, `v1.2.0-beta.2`, `v2.0.0-alpha.1`  
+Invalid: `v1.0.0-hotfix`, `v1.0.0.rc1`


### PR DESCRIPTION
## Summary

- `ci.yml`: `type=raw,value=latest,enable={{is_default_branch}}` を削除。main push は `:main` + `:sha-*` のみ発行し、`:latest` を更新しない
- `release.yml`: `type=raw,value=latest` を削除し、`latest=auto`（metadata-action デフォルト）に委ねることで prerelease タグ（例: `v1.0.0-rc.1`）では `:latest` が付かないようにする

thread-owl#85 と同じ構成に揃え、Mcp-Docker の `start-gateway`（`mcp-gateway:latest` を pull）が安定版を引けることを保証する。

## Test plan

- [ ] main push 後、GHCR で `:main` / `:sha-*` のみ更新され `:latest` が変わらないことを確認
- [ ] semver リリースタグ push（例: `v0.6.0`）後、`:latest` + `:0.6.0` + `:0.6` が発行されることを確認
- [ ] prerelease タグ push（例: `v0.6.0-rc.1`）後、`:latest` が更新されないことを確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)