### PR TITLE
feat: implement OIDC provider support (#6)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -214,6 +214,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	oidcPrivateKey, err := appconfig.MigrateOIDCPrivateKey(cfg.configPath, appCfg, km)
+	if err != nil {
+		slog.Error("OIDC private key migration failed", "err", err)
+		os.Exit(1)
+	}
+
 	oauthHandler, err := auth.NewHandler(auth.Config{
 		BaseURL:              cfg.publicURL,
 		SessionTTL:           time.Duration(cfg.sessionTTLMin) * time.Minute,
@@ -223,6 +229,7 @@ func main() {
 		AllowedAudiences:     routeAudiences(strings.TrimRight(cfg.publicURL, "/"), routes),
 		TokenAudienceStrict:  cfg.tokenAudienceStrict,
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
+		OIDCPrivateKey:       oidcPrivateKey,
 	}, prov)
 	if err != nil {
 		slog.Error("auth handler init failed", "err", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -128,6 +128,18 @@ func main() {
 	if _, set := os.LookupEnv("MCP_GATEWAY_GITHUB_REFRESH_ENABLED"); !set {
 		cfg.githubRefreshEnabled = appCfg.Gateway.GitHubRefreshEnabled
 	}
+	// Apply config.yaml OAuth provider overrides
+	if strings.TrimSpace(os.Getenv("OAUTH_PROVIDER")) == "" && strings.TrimSpace(appCfg.Auth.Provider) != "" {
+		cfg.oauthProvider = appCfg.Auth.Provider
+	}
+	// Apply config.yaml OIDC overrides
+	if strings.TrimSpace(os.Getenv("OAUTH_ISSUER_URL")) == "" && strings.TrimSpace(appCfg.Auth.OIDCIssuerURL) != "" {
+		cfg.oidcIssuerURL = appCfg.Auth.OIDCIssuerURL
+	}
+	if strings.TrimSpace(os.Getenv("OAUTH_AUDIENCE")) == "" && strings.TrimSpace(appCfg.Auth.OIDCAudience) != "" {
+		cfg.oidcAudience = appCfg.Auth.OIDCAudience
+	}
+
 	trustedProxies, err := middleware.ParseTrustedProxyCIDRs(cfg.trustedProxyCIDRs)
 	if err != nil {
 		slog.Error("invalid trusted proxy configuration", "err", err)
@@ -144,13 +156,19 @@ func main() {
 	// This prevents a mistyped env var from being encrypted and saved to config.yaml
 	// on a first boot that would otherwise fail (e.g. missing CLIENT_ID or routes).
 
-	// GitHub client ID: env var (OAUTH_CLIENT_ID or legacy GITHUB_MCP_CLIENT_ID) takes precedence over config file.
-	githubClientID := envClientID
-	if strings.TrimSpace(githubClientID) == "" {
-		githubClientID = appCfg.Auth.GitHubClientID
+	// Client ID: env var (OAUTH_CLIENT_ID or legacy GITHUB_MCP_CLIENT_ID) takes precedence over config file.
+	clientID := envClientID
+	if strings.TrimSpace(clientID) == "" {
+		if cfg.oauthProvider == "oidc" && strings.TrimSpace(appCfg.Auth.ClientID) != "" {
+			clientID = appCfg.Auth.ClientID
+		} else if strings.TrimSpace(appCfg.Auth.GitHubClientID) != "" {
+			clientID = appCfg.Auth.GitHubClientID
+		} else {
+			clientID = appCfg.Auth.ClientID
+		}
 	}
-	if strings.TrimSpace(githubClientID) == "" {
-		slog.Error("required value not set: provide OAUTH_CLIENT_ID env var or auth.github_client_id in config.yaml")
+	if strings.TrimSpace(clientID) == "" {
+		slog.Error("required value not set: provide OAUTH_CLIENT_ID env var or auth.client_id/auth.github_client_id in config.yaml")
 		os.Exit(1)
 	}
 
@@ -171,23 +189,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Resolve the GitHub client secret (and persist it encrypted if sourced from env).
+	// Resolve the client secret (and persist it encrypted if sourced from env).
 	// Only runs after the above validations pass to avoid making a wrong value sticky.
-	githubClientSecret, err := appconfig.MigrateSecret(cfg.configPath, appCfg, km)
+	clientSecret, err := appconfig.MigrateSecret(cfg.configPath, appCfg, km, cfg.oauthProvider)
 	if err != nil {
-		slog.Error("github_client_secret is unavailable", "err", err)
+		slog.Error("client secret is unavailable", "err", err)
 		os.Exit(1)
 	}
 
-	cfg.githubClientID = githubClientID
-	cfg.githubClientSecret = githubClientSecret
+	cfg.githubClientID = clientID
+	cfg.githubClientSecret = clientSecret
 
 	prov, err := provider.New(provider.Config{
-		Kind:         cfg.oauthProvider,
-		ClientID:     cfg.githubClientID,
-		ClientSecret: cfg.githubClientSecret,
-		RedirectURI:  strings.TrimRight(cfg.publicURL, "/") + "/callback",
-		Scopes:       cfg.oauthScopes,
+		Kind:          cfg.oauthProvider,
+		ClientID:      cfg.githubClientID,
+		ClientSecret:  cfg.githubClientSecret,
+		RedirectURI:   strings.TrimRight(cfg.publicURL, "/") + "/callback",
+		Scopes:        cfg.oauthScopes,
+		OIDCIssuerURL: cfg.oidcIssuerURL,
+		OIDCAudience:  cfg.oidcAudience,
 	})
 	if err != nil {
 		slog.Error("provider init failed", "err", err)
@@ -359,6 +379,8 @@ type config struct {
 	bindAddr             string
 	oauthProvider        string
 	oauthScopes          string
+	oidcIssuerURL        string
+	oidcAudience         string
 	port                 string
 	logLevel             string
 	upstreamURL          string // deprecated; prefer ROUTE_* env vars
@@ -400,6 +422,8 @@ func loadConfig() config {
 		port:                 port,
 		oauthProvider:        oauthProvider,
 		oauthScopes:          oauthScopes,
+		oidcIssuerURL:        getEnv("OAUTH_ISSUER_URL", ""),
+		oidcAudience:         getEnv("OAUTH_AUDIENCE", ""),
 		logLevel:             getEnv("LOG_LEVEL", "info"),
 		upstreamURL:          getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
 		trustedProxyCIDRs:    splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -239,6 +239,9 @@ func main() {
 	// inside the route loop below per MCP Authorization Spec 2025-06-18.
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource", oauthHandler.ProtectedResourceMetadata)
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
+	mux.HandleFunc("GET /.well-known/openid-configuration", oauthHandler.OIDCDiscovery)
+	mux.HandleFunc("GET /jwks", oauthHandler.JWKS)
+	mux.HandleFunc("GET /userinfo", oauthHandler.UserInfo)
 	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
 	mux.HandleFunc("GET /callback", oauthHandler.Callback)
 	mux.HandleFunc("POST /token", oauthHandler.Token)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,9 @@ Configuration is resolved in this order:
 
 | Setting | Precedence |
 |---------|------------|
-| OAuth provider | `OAUTH_PROVIDER` > `github` (default) |
-| OAuth client ID | `OAUTH_CLIENT_ID` > deprecated `GITHUB_MCP_CLIENT_ID` > `auth.github_client_id` |
-| OAuth client secret | encrypted/plain `auth.github_client_secret` > non-empty `OAUTH_CLIENT_SECRET` > deprecated `GITHUB_MCP_CLIENT_SECRET` used to seed `config.yaml` |
+| OAuth provider | `OAUTH_PROVIDER` > `auth.provider` > `github` (default) |
+| OAuth client ID | `OAUTH_CLIENT_ID` > deprecated `GITHUB_MCP_CLIENT_ID` > `auth.client_id` > `auth.github_client_id` |
+| OAuth client secret | encrypted/plain `auth.client_secret` > encrypted/plain `auth.github_client_secret` > non-empty `OAUTH_CLIENT_SECRET` > deprecated `GITHUB_MCP_CLIENT_SECRET` used to seed `config.yaml` |
 | Routes | `ROUTE_<NAME>` env vars > `routes:` in `config.yaml` > deprecated `GITHUB_MCP_UPSTREAM_URL` fallback |
 | Public URL | `MCP_GATEWAY_PUBLIC_URL` > deprecated `MCP_GATEWAY_BASE_URL` > `gateway.public_url` > deprecated `gateway.base_url` > default |
 | Bind address | `MCP_GATEWAY_BIND_ADDR` > `gateway.bind_addr` > `127.0.0.1:<resolved-port>` |
@@ -46,10 +46,12 @@ is logged that the legacy is ignored.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OAUTH_PROVIDER` | `github` | OAuth provider kind. Currently only `github` is supported. |
-| `OAUTH_CLIENT_ID` | none | OAuth App client ID. Required unless `auth.github_client_id` is set. Supersedes `GITHUB_MCP_CLIENT_ID`. |
-| `OAUTH_CLIENT_SECRET` | none | OAuth App client secret. Used to seed encrypted `config.yaml` when no config secret exists. Supersedes `GITHUB_MCP_CLIENT_SECRET`. |
+| `OAUTH_PROVIDER` | `github` | OAuth provider kind. Currently `github` and `oidc` are supported. |
+| `OAUTH_CLIENT_ID` | none | OAuth client ID. Required unless `auth.client_id` or `auth.github_client_id` is set. Supersedes `GITHUB_MCP_CLIENT_ID`. |
+| `OAUTH_CLIENT_SECRET` | none | OAuth client secret. Used to seed encrypted `config.yaml` when no config secret exists. Supersedes `GITHUB_MCP_CLIENT_SECRET`. |
 | `OAUTH_SCOPES` | `repo,user` | OAuth scopes requested by the gateway. Supersedes `GITHUB_MCP_OAUTH_SCOPES`. |
+| `OAUTH_ISSUER_URL` | none | OIDC issuer URL (required when `OAUTH_PROVIDER=oidc`). |
+| `OAUTH_AUDIENCE` | none | OIDC audience (optional when `OAUTH_PROVIDER=oidc`). |
 | `GITHUB_MCP_CLIENT_ID` | none | **Deprecated** — use `OAUTH_CLIENT_ID`. Still accepted with a startup warning. |
 | `GITHUB_MCP_CLIENT_SECRET` | none | **Deprecated** — use `OAUTH_CLIENT_SECRET`. Still accepted with a startup warning. |
 | `GITHUB_MCP_OAUTH_SCOPES` | none | **Deprecated** — use `OAUTH_SCOPES`. Still accepted with a startup warning. |
@@ -111,8 +113,13 @@ setup:
 
 | Key | Description |
 |-----|-------------|
+| `auth.provider` | OAuth provider kind (`github` or `oidc`). |
+| `auth.client_id` | Generic OAuth client ID. |
+| `auth.client_secret` | Generic OAuth client secret. May be encrypted as `ENC[age:]...`. |
 | `auth.github_client_id` | GitHub OAuth App client ID. |
-| `auth.github_client_secret` | GitHub OAuth App client secret. May be encrypted as `ENC[age:]...`; plaintext is encrypted and rewritten on startup. |
+| `auth.github_client_secret` | GitHub OAuth App client secret. May be encrypted as `ENC[age:]...`. |
+| `auth.oidc_issuer_url` | OIDC issuer URL. |
+| `auth.oidc_audience` | OIDC audience. |
 | `gateway.public_url` | Canonical public URL visible to OAuth and MCP clients. |
 | `gateway.bind_addr` | TCP listener address. |
 | `gateway.base_url` | Deprecated alias for `gateway.public_url`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ is logged that the legacy is ignored.
 | `OAUTH_CLIENT_SECRET` | none | OAuth client secret. Used to seed encrypted `config.yaml` when no config secret exists. Supersedes `GITHUB_MCP_CLIENT_SECRET`. |
 | `OAUTH_SCOPES` | `repo,user` | OAuth scopes requested by the gateway. Supersedes `GITHUB_MCP_OAUTH_SCOPES`. |
 | `OAUTH_ISSUER_URL` | none | OIDC issuer URL (required when `OAUTH_PROVIDER=oidc`). |
-| `OAUTH_AUDIENCE` | none | OIDC audience (optional when `OAUTH_PROVIDER=oidc`). |
+| `OAUTH_AUDIENCE` | none | OIDC audience (optional when `OAUTH_PROVIDER=oidc`). Reserved for future local JWT validation; currently unused/no-op in UserInfo validation. |
 | `GITHUB_MCP_CLIENT_ID` | none | **Deprecated** — use `OAUTH_CLIENT_ID`. Still accepted with a startup warning. |
 | `GITHUB_MCP_CLIENT_SECRET` | none | **Deprecated** — use `OAUTH_CLIENT_SECRET`. Still accepted with a startup warning. |
 | `GITHUB_MCP_OAUTH_SCOPES` | none | **Deprecated** — use `OAUTH_SCOPES`. Still accepted with a startup warning. |
@@ -119,7 +119,7 @@ setup:
 | `auth.github_client_id` | GitHub OAuth App client ID. |
 | `auth.github_client_secret` | GitHub OAuth App client secret. May be encrypted as `ENC[age:]...`. |
 | `auth.oidc_issuer_url` | OIDC issuer URL. |
-| `auth.oidc_audience` | OIDC audience. |
+| `auth.oidc_audience` | OIDC audience. Reserved for future local JWT validation; currently unused/no-op in UserInfo validation. |
 | `gateway.public_url` | Canonical public URL visible to OAuth and MCP clients. |
 | `gateway.bind_addr` | TCP listener address. |
 | `gateway.base_url` | Deprecated alias for `gateway.public_url`. |

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -2,6 +2,12 @@ package auth
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +94,7 @@ type Handler struct {
 	provider         provider.Provider
 	store            *Store
 	allowedAudiences map[string]struct{}
+	privateKey       *rsa.PrivateKey
 	// rotationGroup serializes concurrent GitHub refresh-token rotations
 	// targeting the same access token. Without this, a burst of requests
 	// arriving inside the leeway window would race to call the provider's
@@ -143,11 +150,17 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 		}
 	}
 
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("auth.NewHandler: generating signing key: %w", err)
+	}
+
 	return &Handler{
 		cfg:              cfg,
 		provider:         p,
 		store:            NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
 		allowedAudiences: audienceSet(cfg.AllowedAudiences),
+		privateKey:       privateKey,
 	}, nil
 }
 
@@ -337,7 +350,15 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	internalCode, err := h.store.CompleteCallback(state, tokens.AccessToken, joinScopes(tokens.Scopes), tokens.RefreshToken, providerAccessExpiry(tokens.AccessTokenExpiresIn))
+	// Resolve provider identity early to get the Subject claim
+	id, err := h.provider.ValidateToken(r.Context(), tokens.AccessToken)
+	if err != nil {
+		slog.Error("OAuth identity resolution failed during callback", "provider", h.provider.Name(), "err", err)
+		http.Error(w, "identity resolution failed", http.StatusBadGateway)
+		return
+	}
+
+	internalCode, err := h.store.CompleteCallback(state, tokens.AccessToken, joinScopes(tokens.Scopes), tokens.RefreshToken, providerAccessExpiry(tokens.AccessTokenExpiresIn), id.Subject)
 	if err != nil {
 		slog.Error("session completion failed", "err", err)
 		http.Error(w, "invalid state", http.StatusBadRequest)
@@ -379,24 +400,24 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
-	result, err := h.store.ExchangeCode(
-		r.FormValue("code"),
-		r.FormValue("redirect_uri"),
-		r.FormValue("code_verifier"),
-	)
-	if err != nil {
-		slog.Warn("token exchange rejected", "err", err)
-		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
-		return
+		result, err := h.store.ExchangeCode(
+			r.FormValue("code"),
+			r.FormValue("redirect_uri"),
+			r.FormValue("code_verifier"),
+		)
+		if err != nil {
+			slog.Warn("token exchange rejected", "err", err)
+			oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+			return
+		}
+		h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
+		h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
+		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
+		if rtErr != nil {
+			slog.Warn("failed to create refresh token", "err", rtErr)
+		}
+		h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject)
 	}
-	h.store.RegisterTokenAudience(result.AccessToken, result.Audience)
-	h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
-	refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
-	if rtErr != nil {
-		slog.Warn("failed to create refresh token", "err", rtErr)
-	}
-	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken)
-}
 
 // persistProviderRefresh writes upstream provider refresh metadata to the
 // token store only when rotation is enabled. The flag is the load-bearing
@@ -468,18 +489,25 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 
 	switch result.Error {
 	case "":
+		// Resolve provider identity early to get the Subject claim
+		id, valErr := h.provider.ValidateToken(r.Context(), result.AccessToken)
+		if valErr != nil {
+			slog.Error("Identity resolution failed during device grant callback", "err", valErr)
+			oauthError(w, "server_error", "failed to resolve identity", http.StatusBadGateway)
+			return
+		}
 		completed, ok := h.store.AuthorizeAndConsumeDevice(deviceCode, result.AccessToken, result.Scope)
 		if !ok {
 			oauthError(w, "invalid_grant", "device code already consumed", http.StatusBadRequest)
 			return
 		}
-		h.store.RegisterTokenAudience(result.AccessToken, completed.Audience)
+		h.store.CacheToken(result.AccessToken, id.Subject, completed.Audience)
 		h.persistProviderRefresh(result.AccessToken, result.RefreshToken, providerAccessExpiry(result.AccessExpiresIn))
 		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, completed.Audience, h.refreshTokenTTL())
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
-		h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken)
+		h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, id.Subject)
 	case "authorization_pending":
 		oauthError(w, "authorization_pending", "user has not yet authorized the device", http.StatusBadRequest)
 	case "slow_down":
@@ -496,7 +524,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refreshToken string) {
+func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refreshToken string, subject string) {
 	expiresIn := max(int64(h.cfg.ExpiresIn/time.Second), 1)
 	resp := map[string]any{
 		"access_token": token,
@@ -508,6 +536,14 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refres
 	}
 	if refreshToken != "" {
 		resp["refresh_token"] = refreshToken
+	}
+	if subject != "" && (strings.Contains(scope, "openid") || h.provider.Name() == "oidc") {
+		idToken, err := h.generateIDToken(h.cfg.BaseURL, subject, h.provider.ClientID())
+		if err == nil {
+			resp["id_token"] = idToken
+		} else {
+			slog.Error("failed to generate id_token", "err", err)
+		}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
@@ -598,7 +634,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeTokenResponse(w, accessToken, "", newRT)
+	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject)
 }
 
 // DeviceAuthorize handles POST /device_authorization (RFC 8628).
@@ -1299,4 +1335,138 @@ func jsonError(w http.ResponseWriter, code, description string, status int) {
 		"error":             code,
 		"error_description": description,
 	})
+}
+
+// OIDCDiscovery returns OpenID Connect Discovery metadata.
+func (h *Handler) OIDCDiscovery(w http.ResponseWriter, r *http.Request) {
+	doc := map[string]any{
+		"issuer":                                h.cfg.BaseURL,
+		"authorization_endpoint":                h.cfg.BaseURL + "/authorize",
+		"token_endpoint":                        h.cfg.BaseURL + "/token",
+		"userinfo_endpoint":                     h.cfg.BaseURL + "/userinfo",
+		"jwks_uri":                              h.cfg.BaseURL + "/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"scopes_supported":                      []string{"openid", "profile", "email"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_post", "client_secret_basic", "none"},
+		"claims_supported":                      []string{"iss", "sub", "aud", "exp", "iat", "name", "preferred_username", "email"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// JWKS returns the JSON Web Key Set containing the gateway's public key for signature verification.
+func (h *Handler) JWKS(w http.ResponseWriter, r *http.Request) {
+	if h.privateKey == nil {
+		http.Error(w, "JWKS not configured", http.StatusInternalServerError)
+		return
+	}
+	pub := h.privateKey.Public().(*rsa.PublicKey)
+	
+	// Encode N and E
+	nStr := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	
+	eBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(eBytes, uint32(pub.E))
+	start := 0
+	for start < len(eBytes) && eBytes[start] == 0 {
+		start++
+	}
+	eStr := base64.RawURLEncoding.EncodeToString(eBytes[start:])
+
+	jwk := map[string]any{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": "RS256",
+		"kid": "gateway-key-1",
+		"n":   nStr,
+		"e":   eStr,
+	}
+
+	doc := map[string]any{
+		"keys": []any{jwk},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// UserInfo returns OIDC UserInfo claims for the authenticated user.
+func (h *Handler) UserInfo(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(authHeader) <= len(prefix) || !strings.HasPrefix(authHeader, prefix) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="Missing or malformed Bearer token"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_token","error_description":"Missing or malformed Bearer token"}`))
+		return
+	}
+	token := authHeader[len(prefix):]
+
+	// Validate the gateway token. Audience is empty for userinfo endpoint.
+	subject, _, err := h.ValidateToken(r.Context(), token, "")
+	if err != nil {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_token", error_description=%q`, err.Error()))
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"error":"invalid_token","error_description":%q}`, err.Error())))
+		return
+	}
+
+	doc := map[string]any{
+		"sub":                subject,
+		"name":               subject,
+		"preferred_username": subject,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// generateIDToken creates a signed RS256 JWT for the given subject.
+func (h *Handler) generateIDToken(issuer, subject, clientID string) (string, error) {
+	if h.privateKey == nil {
+		return "", fmt.Errorf("private key is nil")
+	}
+
+	// 1. Header
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": "gateway-key-1",
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerBytes)
+
+	// 2. Payload
+	now := time.Now().Unix()
+	payload := map[string]any{
+		"iss": issuer,
+		"sub": subject,
+		"aud": clientID,
+		"iat": now,
+		"exp": now + 3600, // 1 hour
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	// 3. Sign
+	signingInput := headerB64 + "." + payloadB64
+	hasher := sha256.New()
+	hasher.Write([]byte(signingInput))
+	hashed := hasher.Sum(nil)
+
+	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, h.privateKey, crypto.SHA256, hashed)
+	if err != nil {
+		return "", fmt.Errorf("signing failed: %w", err)
+	}
+	sigB64 := base64.RawURLEncoding.EncodeToString(sigBytes)
+
+	return signingInput + "." + sigB64, nil
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -79,6 +79,9 @@ type Config struct {
 	// GitHubRefreshLeeway is the lead time before access-token expiry at which
 	// rotation is attempted on the next ValidateToken call. Defaults to 5 min.
 	GitHubRefreshLeeway time.Duration
+	// OIDCPrivateKey is the RSA private key used to sign ID tokens.
+	// When nil, a transient in-memory key is generated and a warning is logged.
+	OIDCPrivateKey *rsa.PrivateKey
 }
 
 // defaultGitHubRefreshLeeway is the head-start used when GitHubRefreshLeeway
@@ -150,9 +153,14 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 		}
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, fmt.Errorf("auth.NewHandler: generating signing key: %w", err)
+	privateKey := cfg.OIDCPrivateKey
+	if privateKey == nil {
+		slog.Warn("OIDC signing key is not persisted; generating a random key. Sessions will become invalid across restarts.")
+		var err error
+		privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return nil, fmt.Errorf("auth.NewHandler: generating signing key: %w", err)
+		}
 	}
 
 	return &Handler{
@@ -400,24 +408,24 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
-		result, err := h.store.ExchangeCode(
-			r.FormValue("code"),
-			r.FormValue("redirect_uri"),
-			r.FormValue("code_verifier"),
-		)
-		if err != nil {
-			slog.Warn("token exchange rejected", "err", err)
-			oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
-			return
-		}
-		h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
-		h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
-		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
-		if rtErr != nil {
-			slog.Warn("failed to create refresh token", "err", rtErr)
-		}
-		h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject)
+	result, err := h.store.ExchangeCode(
+		r.FormValue("code"),
+		r.FormValue("redirect_uri"),
+		r.FormValue("code_verifier"),
+	)
+	if err != nil {
+		slog.Warn("token exchange rejected", "err", err)
+		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
+		return
 	}
+	h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
+	h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
+	refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
+	if rtErr != nil {
+		slog.Warn("failed to create refresh token", "err", rtErr)
+	}
+	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject)
+}
 
 // persistProviderRefresh writes upstream provider refresh metadata to the
 // token store only when rotation is enabled. The flag is the load-bearing

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1409,7 +1409,7 @@ func (h *Handler) UserInfo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_token", error_description=%q`, err.Error()))
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"error":"invalid_token","error_description":%q}`, err.Error())))
+		_, _ = fmt.Fprintf(w, `{"error":"invalid_token","error_description":%q}`, err.Error())
 		return
 	}
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -2184,3 +2185,41 @@ func TestOIDCProviderEndpoints(t *testing.T) {
 		t.Errorf("signature verification failed: %v", err)
 	}
 }
+
+func TestNewHandler_OIDCPrivateKey(t *testing.T) {
+	// Generate a key to pass into Config
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	cfg := Config{
+		BaseURL:        "http://localhost:8080",
+		OIDCPrivateKey: privKey,
+	}
+
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID: "test-client-id",
+	})
+	h, err := NewHandler(cfg, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	if h.privateKey != privKey {
+		t.Error("expected Handler to use the provided OIDCPrivateKey")
+	}
+
+	// Now check if it works without providing a key (should generate one)
+	cfgNoKey := Config{
+		BaseURL: "http://localhost:8080",
+	}
+	hNoKey, err := NewHandler(cfgNoKey, p)
+	if err != nil {
+		t.Fatalf("NewHandler (no key): %v", err)
+	}
+	if hNoKey.privateKey == nil {
+		t.Error("expected Handler to generate a random key when OIDCPrivateKey is nil")
+	}
+}
+

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2,6 +2,10 @@ package auth
 
 import (
 	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -737,6 +741,10 @@ func TestTokenDeviceGrantSuccess(t *testing.T) {
 	// Mock GitHub's token endpoint returning a successful access token.
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/user") {
+			_, _ = fmt.Fprint(w, `{"login":"octocat","name":"The Octocat"}`)
+			return
+		}
 		_, _ = fmt.Fprint(w, `{"access_token":"gha_success_token","scope":"repo,user","token_type":"bearer"}`)
 	}))
 	defer ghServer.Close()
@@ -745,7 +753,23 @@ func TestTokenDeviceGrantSuccess(t *testing.T) {
 	defer func() { githubClient.Transport = originalTransport }()
 	githubClient.Transport = rewriteHostTransport{target: ghServer.URL, inner: ghServer.Client().Transport}
 
-	h := newTestHandler(t)
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+		UserAPI:      ghServer.URL + "/user",
+		TokenURL:     ghServer.URL + "/login/oauth/access_token",
+	})
+	h, err := NewHandler(Config{
+		BaseURL:    "http://localhost:8080",
+		SessionTTL: 10 * time.Minute,
+		CacheTTL:   5 * time.Minute,
+		ExpiresIn:  90 * 24 * time.Hour,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
 
 	expiresAt := time.Now().Add(15 * time.Minute)
 	internalCode, err := h.store.CreateDevice("gh-dev-code", "WDJB-MJHT", "https://github.com/login/device", expiresAt, 5, "http://localhost:8080")
@@ -2021,5 +2045,142 @@ func TestTokenStoreSaveProviderRefreshNoEntry(t *testing.T) {
 	}
 	if _, ok := store.Lookup("unknown"); ok {
 		t.Fatal("SaveProviderRefresh must not create a new entry for unknown token")
+	}
+}
+
+func TestOIDCProviderEndpoints(t *testing.T) {
+	h := newTestHandler(t)
+
+	// 1. Test OIDC Discovery
+	rDisc := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	wDisc := httptest.NewRecorder()
+	h.OIDCDiscovery(wDisc, rDisc)
+
+	if wDisc.Code != http.StatusOK {
+		t.Errorf("OIDCDiscovery status: got %d, want 200", wDisc.Code)
+	}
+	var discDoc map[string]any
+	if err := json.NewDecoder(wDisc.Body).Decode(&discDoc); err != nil {
+		t.Fatalf("decoding discovery: %v", err)
+	}
+	if discDoc["issuer"] != "http://localhost:8080" {
+		t.Errorf("issuer: got %v", discDoc["issuer"])
+	}
+	if discDoc["userinfo_endpoint"] != "http://localhost:8080/userinfo" {
+		t.Errorf("userinfo_endpoint: got %v", discDoc["userinfo_endpoint"])
+	}
+	if discDoc["jwks_uri"] != "http://localhost:8080/jwks" {
+		t.Errorf("jwks_uri: got %v", discDoc["jwks_uri"])
+	}
+
+	// 2. Test JWKS
+	rJWKS := httptest.NewRequest(http.MethodGet, "/jwks", nil)
+	wJWKS := httptest.NewRecorder()
+	h.JWKS(wJWKS, rJWKS)
+
+	if wJWKS.Code != http.StatusOK {
+		t.Errorf("JWKS status: got %d, want 200", wJWKS.Code)
+	}
+	var jwksDoc map[string]any
+	if err := json.NewDecoder(wJWKS.Body).Decode(&jwksDoc); err != nil {
+		t.Fatalf("decoding JWKS: %v", err)
+	}
+	keys, ok := jwksDoc["keys"].([]any)
+	if !ok || len(keys) == 0 {
+		t.Fatalf("expected keys in JWKS: %v", jwksDoc)
+	}
+	key := keys[0].(map[string]any)
+	if key["kty"] != "RSA" || key["alg"] != "RS256" || key["kid"] != "gateway-key-1" {
+		t.Errorf("unexpected JWK fields: %v", key)
+	}
+	if key["n"] == "" || key["e"] == "" {
+		t.Errorf("missing modulus/exponent: %v", key)
+	}
+
+	// 3. Test UserInfo - Unauthorized
+	rUIUnauth := httptest.NewRequest(http.MethodGet, "/userinfo", nil)
+	wUIUnauth := httptest.NewRecorder()
+	h.UserInfo(wUIUnauth, rUIUnauth)
+	if wUIUnauth.Code != http.StatusUnauthorized {
+		t.Errorf("unauthorized userinfo status: got %d, want 401", wUIUnauth.Code)
+	}
+
+	// 4. Test UserInfo - Success
+	h.store.CacheToken("my-gateway-token", "alice", "")
+	rUISuccess := httptest.NewRequest(http.MethodGet, "/userinfo", nil)
+	rUISuccess.Header.Set("Authorization", "Bearer my-gateway-token")
+	wUISuccess := httptest.NewRecorder()
+	h.UserInfo(wUISuccess, rUISuccess)
+
+	if wUISuccess.Code != http.StatusOK {
+		t.Errorf("success userinfo status: got %d, want 200; body: %s", wUISuccess.Code, wUISuccess.Body.String())
+	}
+	var uiDoc map[string]any
+	if err := json.NewDecoder(wUISuccess.Body).Decode(&uiDoc); err != nil {
+		t.Fatalf("decoding userinfo: %v", err)
+	}
+	if uiDoc["sub"] != "alice" {
+		t.Errorf("sub: got %v, want alice", uiDoc["sub"])
+	}
+
+	// 5. Test ID Token generation during code exchange
+	h.store.SaveSession("state-oidc", "http://localhost/cb", "", "http://localhost:8080")
+	code, err := h.store.CompleteCallback("state-oidc", "provider-tok", "openid", "", time.Time{}, "alice")
+	if err != nil {
+		t.Fatalf("CompleteCallback: %v", err)
+	}
+
+	body := fmt.Sprintf("grant_type=authorization_code&code=%s&redirect_uri=http://localhost/cb", code)
+	rToken := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	rToken.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	wToken := httptest.NewRecorder()
+
+	h.Token(wToken, rToken)
+	if wToken.Code != http.StatusOK {
+		t.Fatalf("token exchange: got status %d; body: %s", wToken.Code, wToken.Body.String())
+	}
+
+	var tokenResp map[string]any
+	if err := json.NewDecoder(wToken.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("decoding token response: %v", err)
+	}
+
+	idToken, ok := tokenResp["id_token"].(string)
+	if !ok || idToken == "" {
+		t.Fatal("expected id_token in response when openid scope requested")
+	}
+
+	// Verify id_token JWT structure
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid JWT format: got %d parts, want 3", len(parts))
+	}
+
+	// Verify claims
+	payloadDecoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payloadDecoded, &claims); err != nil {
+		t.Fatalf("unmarshaling payload: %v", err)
+	}
+	if claims["sub"] != "alice" || claims["iss"] != "http://localhost:8080" || claims["aud"] != "test-client-id" {
+		t.Errorf("unexpected payload claims: %v", claims)
+	}
+
+	// Verify signature
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decoding signature: %v", err)
+	}
+	signingInput := parts[0] + "." + parts[1]
+	hasher := sha256.New()
+	hasher.Write([]byte(signingInput))
+	hashed := hasher.Sum(nil)
+
+	pubKey := h.privateKey.Public().(*rsa.PublicKey)
+	if err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed, sig); err != nil {
+		t.Errorf("signature verification failed: %v", err)
 	}
 }

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -8,13 +8,17 @@ import (
 // Config carries the provider-agnostic configuration consumed by New.
 // Provider-specific fields are added as additional providers are introduced.
 type Config struct {
-	// Kind selects the provider implementation: "github".
+	// Kind selects the provider implementation: "github" or "oidc".
 	Kind string
 
 	ClientID     string
 	ClientSecret string
 	RedirectURI  string
 	Scopes       string
+
+	// OIDC-specific configurations
+	OIDCIssuerURL string
+	OIDCAudience  string
 }
 
 // New instantiates the Provider implementation selected by cfg.Kind.
@@ -37,6 +41,28 @@ func New(cfg Config) (Provider, error) {
 			RedirectURI:  cfg.RedirectURI,
 			Scopes:       cfg.Scopes,
 		}), nil
+	case "oidc":
+		if cfg.ClientID == "" || cfg.ClientSecret == "" {
+			return nil, fmt.Errorf("oidc provider requires ClientID and ClientSecret")
+		}
+		if cfg.RedirectURI == "" {
+			return nil, fmt.Errorf("oidc provider requires RedirectURI")
+		}
+		if cfg.OIDCIssuerURL == "" {
+			return nil, fmt.Errorf("oidc provider requires OIDCIssuerURL")
+		}
+		u, err := url.Parse(cfg.RedirectURI)
+		if err != nil || !u.IsAbs() || u.Host == "" || u.Fragment != "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return nil, fmt.Errorf("oidc provider requires an absolute http/https RedirectURI with a host and no fragment, got %q", cfg.RedirectURI)
+		}
+		return NewOIDC(OIDCConfig{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURI:  cfg.RedirectURI,
+			Scopes:       cfg.Scopes,
+			IssuerURL:    cfg.OIDCIssuerURL,
+			Audience:     cfg.OIDCAudience,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported OAuth provider %q", cfg.Kind)
 	}

--- a/internal/auth/provider/oidc.go
+++ b/internal/auth/provider/oidc.go
@@ -18,7 +18,7 @@ type OIDCConfig struct {
 	RedirectURI  string
 	Scopes       string
 	IssuerURL    string
-	Audience     string // Optional: used if additional audience verification is needed
+	Audience     string // Optional: Reserved for future JWT local verification. Currently unused/no-op in UserInfo-based validation.
 
 	// HTTPClient overrides the default 15s-timeout client. For tests.
 	HTTPClient *http.Client

--- a/internal/auth/provider/oidc.go
+++ b/internal/auth/provider/oidc.go
@@ -68,7 +68,7 @@ func NewOIDC(cfg OIDCConfig) (Provider, error) {
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
@@ -165,7 +165,7 @@ func (p *oidcProvider) postToken(ctx context.Context, form url.Values, op string
 	if err != nil {
 		return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("OIDC token endpoint unreachable: %w", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
@@ -221,7 +221,7 @@ func (p *oidcProvider) ValidateToken(ctx context.Context, token string) (Identit
 	if err != nil {
 		return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo endpoint unreachable: %w", err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {

--- a/internal/auth/provider/oidc.go
+++ b/internal/auth/provider/oidc.go
@@ -1,0 +1,275 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// OIDCConfig configures the OIDC OAuth provider.
+type OIDCConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	Scopes       string
+	IssuerURL    string
+	Audience     string // Optional: used if additional audience verification is needed
+
+	// HTTPClient overrides the default 15s-timeout client. For tests.
+	HTTPClient *http.Client
+}
+
+type oidcDiscovery struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserInfoEndpoint      string `json:"userinfo_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+	Issuer                string `json:"issuer"`
+}
+
+type oidcProvider struct {
+	cfg       OIDCConfig
+	client    *http.Client
+	discovery oidcDiscovery
+}
+
+// NewOIDC returns a Provider backed by generic OIDC (OpenID Connect).
+// It queries the provider's .well-known/openid-configuration endpoint at creation time.
+func NewOIDC(cfg OIDCConfig) (Provider, error) {
+	if cfg.IssuerURL == "" {
+		return nil, fmt.Errorf("provider.NewOIDC: IssuerURL is required")
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+
+	// Fetch OIDC discovery document
+	issuer := strings.TrimRight(cfg.IssuerURL, "/")
+	discURL := issuer + "/.well-known/openid-configuration"
+
+	var disc oidcDiscovery
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		req, err := http.NewRequest(http.MethodGet, discURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("provider.NewOIDC: building discovery request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("discovery endpoint unreachable: %w", err)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+			lastErr = fmt.Errorf("discovery returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&disc); err != nil {
+			return nil, fmt.Errorf("provider.NewOIDC: decoding discovery doc: %w", err)
+		}
+		lastErr = nil
+		break
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("provider.NewOIDC: failed to fetch discovery doc after 3 attempts: %w", lastErr)
+	}
+
+	if disc.AuthorizationEndpoint == "" || disc.TokenEndpoint == "" {
+		return nil, fmt.Errorf("provider.NewOIDC: missing required endpoints (authorization_endpoint or token_endpoint) in discovery doc")
+	}
+
+	return &oidcProvider{
+		cfg:       cfg,
+		client:    client,
+		discovery: disc,
+	}, nil
+}
+
+func (p *oidcProvider) Name() string     { return "oidc" }
+func (p *oidcProvider) ClientID() string { return p.cfg.ClientID }
+func (p *oidcProvider) Scopes() string   { return p.cfg.Scopes }
+
+func (p *oidcProvider) AuthorizeURL(state, codeChallenge string) string {
+	u, err := url.Parse(p.discovery.AuthorizationEndpoint)
+	if err != nil {
+		// Should not happen as we parsed/validated at construction, but fallback to string concatenation if it does.
+		return p.discovery.AuthorizationEndpoint
+	}
+	q := u.Query()
+	q.Set("client_id", p.cfg.ClientID)
+	q.Set("redirect_uri", p.cfg.RedirectURI)
+	q.Set("response_type", "code")
+	q.Set("state", state)
+	if p.cfg.Scopes != "" {
+		q.Set("scope", p.cfg.Scopes)
+	} else {
+		q.Set("scope", "openid profile email")
+	}
+	// OIDC spec supports PKCE. Pass code_challenge if provided.
+	if codeChallenge != "" {
+		q.Set("code_challenge", codeChallenge)
+		q.Set("code_challenge_method", "S256")
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (p *oidcProvider) ExchangeCode(ctx context.Context, code string) (TokenResponse, error) {
+	form := url.Values{
+		"grant_type":   {"authorization_code"},
+		"client_id":    {p.cfg.ClientID},
+		"client_secret": {p.cfg.ClientSecret},
+		"code":         {code},
+		"redirect_uri": {p.cfg.RedirectURI},
+	}
+	return p.postToken(ctx, form, "exchange")
+}
+
+func (p *oidcProvider) RefreshToken(ctx context.Context, refreshToken string) (TokenResponse, error) {
+	if strings.TrimSpace(refreshToken) == "" {
+		return TokenResponse{}, fmt.Errorf("RefreshToken: refresh token must not be empty")
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {p.cfg.ClientID},
+		"client_secret": {p.cfg.ClientSecret},
+		"refresh_token": {refreshToken},
+	}
+	return p.postToken(ctx, form, "refresh")
+}
+
+func (p *oidcProvider) postToken(ctx context.Context, form url.Values, op string) (TokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		p.discovery.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("building OIDC token %s request: %w", op, err)}
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("OIDC token endpoint unreachable: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		if resp.StatusCode >= 500 {
+			return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("OIDC token %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		}
+		return TokenResponse{}, fmt.Errorf("OIDC token %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var result struct {
+		AccessToken  string `json:"access_token"`
+		Scope        string `json:"scope"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+		Error        string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return TokenResponse{}, fmt.Errorf("decoding OIDC token %s response: %w", op, err)
+	}
+	if result.Error != "" {
+		return TokenResponse{}, fmt.Errorf("OIDC token %s error: %s", op, result.Error)
+	}
+	if result.AccessToken == "" {
+		return TokenResponse{}, fmt.Errorf("empty access_token from OIDC on %s", op)
+	}
+
+	var scopes []string
+	if result.Scope != "" {
+		scopes = strings.Split(result.Scope, " ")
+	}
+
+	return TokenResponse{
+		AccessToken:          result.AccessToken,
+		Scopes:               scopes,
+		RefreshToken:         result.RefreshToken,
+		AccessTokenExpiresIn: time.Duration(result.ExpiresIn) * time.Second,
+	}, nil
+}
+
+func (p *oidcProvider) ValidateToken(ctx context.Context, token string) (Identity, error) {
+	if p.discovery.UserInfoEndpoint == "" {
+		return Identity{}, fmt.Errorf("OIDC provider does not support userinfo endpoint (required for token validation)")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.discovery.UserInfoEndpoint, nil)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("building OIDC userinfo request: %w", err)}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo endpoint unreachable: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			return Identity{}, fmt.Errorf("invalid token: OIDC userinfo returned %d", resp.StatusCode)
+		case http.StatusForbidden, http.StatusTooManyRequests:
+			return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo returned %d", resp.StatusCode)}
+		default:
+			if resp.StatusCode >= 500 {
+				return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo returned %d", resp.StatusCode)}
+			}
+			return Identity{}, fmt.Errorf("invalid token: OIDC userinfo returned %d", resp.StatusCode)
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Identity{}, &UpstreamError{Err: fmt.Errorf("reading OIDC userinfo response: %w", err)}
+	}
+
+	var user struct {
+		Sub               string `json:"sub"`
+		Name              string `json:"name"`
+		PreferredUsername string `json:"preferred_username"`
+		Email             string `json:"email"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil {
+		return Identity{}, fmt.Errorf("decoding OIDC userinfo response: %w", err)
+	}
+
+	if user.Sub == "" {
+		return Identity{}, fmt.Errorf("OIDC userinfo response missing sub claim")
+	}
+
+	displayName := user.PreferredUsername
+	if displayName == "" {
+		displayName = user.Name
+	}
+	if displayName == "" {
+		displayName = user.Email
+	}
+	if displayName == "" {
+		displayName = user.Sub
+	}
+
+	return Identity{
+		Provider:    "oidc",
+		Subject:     user.Sub,
+		DisplayName: displayName,
+	}, nil
+}

--- a/internal/auth/provider/oidc_test.go
+++ b/internal/auth/provider/oidc_test.go
@@ -1,0 +1,234 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOIDCProvider_Success(t *testing.T) {
+	// 1. Setup mock OIDC server
+	mux := http.NewServeMux()
+
+	// Mock discovery doc
+	var mockServerURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization_endpoint": mockServerURL + "/auth",
+			"token_endpoint":         mockServerURL + "/token",
+			"userinfo_endpoint":      mockServerURL + "/userinfo",
+			"jwks_uri":               mockServerURL + "/jwks",
+			"issuer":                 mockServerURL,
+		})
+	})
+
+	// Mock Token Endpoint
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST to token endpoint, got %s", r.Method)
+		}
+		_ = r.ParseForm()
+
+		grantType := r.FormValue("grant_type")
+		if grantType == "authorization_code" {
+			if r.FormValue("code") != "valid-code" || r.FormValue("client_id") != "test-client" || r.FormValue("client_secret") != "test-secret" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"token-abc","refresh_token":"refresh-123","expires_in":3600,"scope":"openid profile"}`))
+		} else if grantType == "refresh_token" {
+			if r.FormValue("refresh_token") != "refresh-123" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"token-def","refresh_token":"refresh-456","expires_in":3600}`))
+		} else {
+			t.Errorf("unexpected grant_type: %s", grantType)
+		}
+	})
+
+	// Mock UserInfo Endpoint
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "Bearer token-abc" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sub":"user-123","name":"Jane Doe","preferred_username":"janedoe","email":"jane@example.com"}`))
+		} else if auth == "Bearer token-def" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sub":"user-123","preferred_username":"janedoe"}`))
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mockServerURL = server.URL
+
+	// 2. Initialize OIDC Provider
+	prov, err := NewOIDC(OIDCConfig{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURI:  "http://localhost/cb",
+		Scopes:       "openid email",
+		IssuerURL:    mockServerURL,
+	})
+	if err != nil {
+		t.Fatalf("NewOIDC failed: %v", err)
+	}
+
+	// 3. Test Provider info
+	if prov.Name() != "oidc" {
+		t.Errorf("expected name 'oidc', got %q", prov.Name())
+	}
+	if prov.ClientID() != "test-client" {
+		t.Errorf("expected client_id 'test-client', got %q", prov.ClientID())
+	}
+	if prov.Scopes() != "openid email" {
+		t.Errorf("expected scopes 'openid email', got %q", prov.Scopes())
+	}
+
+	// 4. Test AuthorizeURL
+	authURLStr := prov.AuthorizeURL("state-123", "challenge-xyz")
+	authURL, err := url.Parse(authURLStr)
+	if err != nil {
+		t.Fatalf("failed to parse auth URL: %v", err)
+	}
+	if authURL.Path != "/auth" {
+		t.Errorf("expected path '/auth', got %q", authURL.Path)
+	}
+	q := authURL.Query()
+	if q.Get("client_id") != "test-client" {
+		t.Errorf("expected client_id 'test-client', got %q", q.Get("client_id"))
+	}
+	if q.Get("redirect_uri") != "http://localhost/cb" {
+		t.Errorf("expected redirect_uri 'http://localhost/cb', got %q", q.Get("redirect_uri"))
+	}
+	if q.Get("state") != "state-123" {
+		t.Errorf("expected state 'state-123', got %q", q.Get("state"))
+	}
+	if q.Get("scope") != "openid email" {
+		t.Errorf("expected scope 'openid email', got %q", q.Get("scope"))
+	}
+	if q.Get("code_challenge") != "challenge-xyz" {
+		t.Errorf("expected code_challenge 'challenge-xyz', got %q", q.Get("code_challenge"))
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("expected code_challenge_method 'S256', got %q", q.Get("code_challenge_method"))
+	}
+
+	// 5. Test ExchangeCode
+	ctx := context.Background()
+	tokens, err := prov.ExchangeCode(ctx, "valid-code")
+	if err != nil {
+		t.Fatalf("ExchangeCode failed: %v", err)
+	}
+	if tokens.AccessToken != "token-abc" {
+		t.Errorf("expected access_token 'token-abc', got %q", tokens.AccessToken)
+	}
+	if tokens.RefreshToken != "refresh-123" {
+		t.Errorf("expected refresh_token 'refresh-123', got %q", tokens.RefreshToken)
+	}
+	if len(tokens.Scopes) != 2 || tokens.Scopes[0] != "openid" || tokens.Scopes[1] != "profile" {
+		t.Errorf("unexpected scopes: %v", tokens.Scopes)
+	}
+	if tokens.AccessTokenExpiresIn != 3600*time.Second {
+		t.Errorf("expected expires_in 3600s, got %v", tokens.AccessTokenExpiresIn)
+	}
+
+	// 6. Test ValidateToken
+	identity, err := prov.ValidateToken(ctx, "token-abc")
+	if err != nil {
+		t.Fatalf("ValidateToken failed: %v", err)
+	}
+	if identity.Provider != "oidc" {
+		t.Errorf("expected provider 'oidc', got %q", identity.Provider)
+	}
+	if identity.Subject != "user-123" {
+		t.Errorf("expected subject 'user-123', got %q", identity.Subject)
+	}
+	if identity.DisplayName != "janedoe" {
+		t.Errorf("expected display_name 'janedoe', got %q", identity.DisplayName)
+	}
+
+	// 7. Test RefreshToken
+	rotated, err := prov.RefreshToken(ctx, "refresh-123")
+	if err != nil {
+		t.Fatalf("RefreshToken failed: %v", err)
+	}
+	if rotated.AccessToken != "token-def" {
+		t.Errorf("expected rotated access_token 'token-def', got %q", rotated.AccessToken)
+	}
+	if rotated.RefreshToken != "refresh-456" {
+		t.Errorf("expected rotated refresh_token 'refresh-456', got %q", rotated.RefreshToken)
+	}
+
+	// 8. Test ValidateToken with rotated token
+	identityRotated, err := prov.ValidateToken(ctx, rotated.AccessToken)
+	if err != nil {
+		t.Fatalf("ValidateToken for rotated token failed: %v", err)
+	}
+	if identityRotated.Subject != "user-123" {
+		t.Errorf("expected subject 'user-123', got %q", identityRotated.Subject)
+	}
+}
+
+func TestOIDCProvider_DiscoveryFailure(t *testing.T) {
+	_, err := NewOIDC(OIDCConfig{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURI:  "http://localhost/cb",
+		IssuerURL:    "http://127.0.0.1:54321", // Non-existent port
+	})
+	if err == nil {
+		t.Error("expected NewOIDC to fail due to unreachable discovery endpoint")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch discovery doc") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestOIDCProvider_InvalidUserInfo(t *testing.T) {
+	mux := http.NewServeMux()
+	var mockServerURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization_endpoint": mockServerURL + "/auth",
+			"token_endpoint":         mockServerURL + "/token",
+			"userinfo_endpoint":      mockServerURL + "/userinfo",
+		})
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mockServerURL = server.URL
+
+	prov, err := NewOIDC(OIDCConfig{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURI:  "http://localhost/cb",
+		IssuerURL:    mockServerURL,
+	})
+	if err != nil {
+		t.Fatalf("NewOIDC failed: %v", err)
+	}
+
+	_, err = prov.ValidateToken(context.Background(), "invalid-token")
+	if err == nil {
+		t.Error("expected ValidateToken to fail for unauthorized status")
+	}
+}

--- a/internal/auth/provider/oidc_test.go
+++ b/internal/auth/provider/oidc_test.go
@@ -36,7 +36,8 @@ func TestOIDCProvider_Success(t *testing.T) {
 		_ = r.ParseForm()
 
 		grantType := r.FormValue("grant_type")
-		if grantType == "authorization_code" {
+		switch grantType {
+		case "authorization_code":
 			if r.FormValue("code") != "valid-code" || r.FormValue("client_id") != "test-client" || r.FormValue("client_secret") != "test-secret" {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
@@ -44,7 +45,7 @@ func TestOIDCProvider_Success(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token":"token-abc","refresh_token":"refresh-123","expires_in":3600,"scope":"openid profile"}`))
-		} else if grantType == "refresh_token" {
+		case "refresh_token":
 			if r.FormValue("refresh_token") != "refresh-123" {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
@@ -52,7 +53,7 @@ func TestOIDCProvider_Success(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token":"token-def","refresh_token":"refresh-456","expires_in":3600}`))
-		} else {
+		default:
 			t.Errorf("unexpected grant_type: %s", grantType)
 		}
 	})
@@ -60,13 +61,14 @@ func TestOIDCProvider_Success(t *testing.T) {
 	// Mock UserInfo Endpoint
 	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
-		if auth == "Bearer token-abc" {
+		switch auth {
+		case "Bearer token-abc":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"sub":"user-123","name":"Jane Doe","preferred_username":"janedoe","email":"jane@example.com"}`))
-		} else if auth == "Bearer token-def" {
+		case "Bearer token-def":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"sub":"user-123","preferred_username":"janedoe"}`))
-		} else {
+		default:
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -30,6 +30,7 @@ type Session struct {
 	ExpiresAt             time.Time
 	ProviderRefreshToken  string    // optional GitHub refresh token (expiring tokens)
 	ProviderAccessExpiry  time.Time // optional GitHub access-token expiry (zero = no expiry hint)
+	Subject               string    // resolved subject
 }
 
 type deviceStatus int
@@ -173,7 +174,7 @@ func (s *Store) HasSession(state string) bool {
 // providerRefreshToken and providerAccessExpiry are zero-valued when the
 // upstream provider did not advertise them (e.g. classic non-expiring GitHub
 // OAuth tokens).
-func (s *Store) CompleteCallback(state, accessToken, scope, providerRefreshToken string, providerAccessExpiry time.Time) (string, error) {
+func (s *Store) CompleteCallback(state, accessToken, scope, providerRefreshToken string, providerAccessExpiry time.Time, subject string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -192,6 +193,7 @@ func (s *Store) CompleteCallback(state, accessToken, scope, providerRefreshToken
 	sess.Scope = scope
 	sess.ProviderRefreshToken = providerRefreshToken
 	sess.ProviderAccessExpiry = providerAccessExpiry
+	sess.Subject = subject
 	s.codes[code] = sess
 	return code, nil
 }
@@ -205,6 +207,7 @@ type ExchangeCodeResult struct {
 	Audience             string
 	ProviderRefreshToken string
 	ProviderAccessExpiry time.Time
+	Subject              string    // resolved subject
 }
 
 // ExchangeCode validates PKCE and returns the access token, granted scope, and
@@ -234,6 +237,7 @@ func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (ExchangeCo
 		Audience:             sess.Audience,
 		ProviderRefreshToken: sess.ProviderRefreshToken,
 		ProviderAccessExpiry: sess.ProviderAccessExpiry,
+		Subject:              sess.Subject,
 	}
 	delete(s.codes, code)
 	delete(s.sessions, sess.State)

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -23,7 +23,7 @@ func TestStoreCompleteCallback(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state2", "http://localhost/cb", "", "https://gw.example/mcp")
 
-	code, err := s.CompleteCallback("state2", "token123", "repo,user", "", time.Time{})
+	code, err := s.CompleteCallback("state2", "token123", "repo,user", "", time.Time{}, "user123")
 	if err != nil {
 		t.Fatalf("CompleteCallback: %v", err)
 	}
@@ -45,11 +45,14 @@ func TestStoreCompleteCallback(t *testing.T) {
 	if sess.Audience != "https://gw.example/mcp" {
 		t.Errorf("audience: got %q", sess.Audience)
 	}
+	if sess.Subject != "user123" {
+		t.Errorf("subject: got %q, want %q", sess.Subject, "user123")
+	}
 }
 
 func TestStoreCompleteCallbackUnknownState(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	_, err := s.CompleteCallback("nosuchstate", "tok", "", "", time.Time{})
+	_, err := s.CompleteCallback("nosuchstate", "tok", "", "", time.Time{}, "user123")
 	if err == nil {
 		t.Fatal("expected error for unknown state")
 	}
@@ -59,7 +62,7 @@ func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state3", "http://localhost/cb", "", "https://gw.example/mcp")
 
-	code, _ := s.CompleteCallback("state3", "tok", "", "", time.Time{})
+	code, _ := s.CompleteCallback("state3", "tok", "", "", time.Time{}, "user123")
 	result, err := s.ExchangeCode(code, "http://localhost/cb", "")
 	if err != nil {
 		t.Fatalf("ExchangeCode: %v", err)
@@ -69,6 +72,9 @@ func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 	}
 	if result.Audience != "https://gw.example/mcp" {
 		t.Errorf("audience: got %q", result.Audience)
+	}
+	if result.Subject != "user123" {
+		t.Errorf("subject: got %q, want %q", result.Subject, "user123")
 	}
 
 	if _, err := s.ExchangeCode(code, "http://localhost/cb", ""); err == nil {
@@ -80,7 +86,7 @@ func TestStoreExchangeCodeRedirectURIMismatch(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state4", "http://localhost/cb", "", "https://gw.example/mcp")
 
-	code, _ := s.CompleteCallback("state4", "tok", "", "", time.Time{})
+	code, _ := s.CompleteCallback("state4", "tok", "", "", time.Time{}, "user123")
 	if _, err := s.ExchangeCode(code, "http://localhost/other", ""); err == nil {
 		t.Fatal("expected error for redirect_uri mismatch")
 	}
@@ -93,7 +99,7 @@ func TestStorePKCE(t *testing.T) {
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state5", "http://localhost/cb", challenge, "https://gw.example/mcp")
-	code, _ := s.CompleteCallback("state5", "tok", "", "", time.Time{})
+	code, _ := s.CompleteCallback("state5", "tok", "", "", time.Time{}, "user123")
 
 	// Wrong verifier: code is NOT consumed on PKCE failure so we can retry.
 	wrongVerifier := "wrongverifier_wrongverifier_wrongverifier_wrong"
@@ -112,7 +118,7 @@ func TestStorePKCEInvalidVerifierLength(t *testing.T) {
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 	s.SaveSession("state6", "http://localhost/cb", challenge, "https://gw.example/mcp")
-	code, _ := s.CompleteCallback("state6", "tok", "", "", time.Time{})
+	code, _ := s.CompleteCallback("state6", "tok", "", "", time.Time{}, "user123")
 
 	if _, err := s.ExchangeCode(code, "http://localhost/cb", "tooshort"); err == nil {
 		t.Fatal("expected error for verifier that is too short")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,12 @@ type AppConfig struct {
 type AuthConfig struct {
 	GitHubClientID     string `yaml:"github_client_id,omitempty"`
 	GitHubClientSecret string `yaml:"github_client_secret,omitempty"`
+
+	Provider      string `yaml:"provider,omitempty"`
+	ClientID      string `yaml:"client_id,omitempty"`
+	ClientSecret  string `yaml:"client_secret,omitempty"`
+	OIDCIssuerURL string `yaml:"oidc_issuer_url,omitempty"`
+	OIDCAudience  string `yaml:"oidc_audience,omitempty"`
 }
 
 // GatewayConfig holds gateway-level settings that can be persisted in config.yaml.
@@ -116,28 +122,45 @@ func SaveConfig(path string, cfg *AppConfig) error {
 //
 // When both OAUTH_CLIENT_SECRET and the legacy GITHUB_MCP_CLIENT_SECRET are set,
 // the new variable wins and a deprecation warning is logged for the legacy one.
-func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, error) {
-	secret := cfg.Auth.GitHubClientSecret
+func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial, providerKind string) (string, error) {
+	// Determine which secret to migrate based on providerKind and presence of fields
+	useGeneric := providerKind == "oidc"
+	if useGeneric && strings.TrimSpace(cfg.Auth.ClientSecret) == "" && strings.TrimSpace(cfg.Auth.GitHubClientSecret) != "" {
+		useGeneric = false
+	} else if !useGeneric && strings.TrimSpace(cfg.Auth.GitHubClientSecret) == "" && strings.TrimSpace(cfg.Auth.ClientSecret) != "" {
+		useGeneric = true
+	}
+
+	var secret *string
+	var fieldName string
+	if useGeneric {
+		secret = &cfg.Auth.ClientSecret
+		fieldName = "client_secret"
+	} else {
+		secret = &cfg.Auth.GitHubClientSecret
+		fieldName = "github_client_secret"
+	}
 
 	switch {
-	case IsEncrypted(secret):
-		plaintext, err := DecryptField(km, secret)
+	case IsEncrypted(*secret):
+		plaintext, err := DecryptField(km, *secret)
 		if err != nil {
-			return "", fmt.Errorf("decrypting github_client_secret: %w", err)
+			return "", fmt.Errorf("decrypting %s: %w", fieldName, err)
 		}
 		return plaintext, nil
 
-	case strings.TrimSpace(secret) != "":
-		slog.Info("plaintext github_client_secret found in config; encrypting and rewriting")
-		encrypted, err := EncryptField(km, secret)
+	case strings.TrimSpace(*secret) != "":
+		plain := *secret
+		slog.Info(fmt.Sprintf("plaintext %s found in config; encrypting and rewriting", fieldName))
+		encrypted, err := EncryptField(km, plain)
 		if err != nil {
-			return "", fmt.Errorf("encrypting github_client_secret from config: %w", err)
+			return "", fmt.Errorf("encrypting %s from config: %w", fieldName, err)
 		}
-		cfg.Auth.GitHubClientSecret = encrypted
+		*secret = encrypted
 		if err := SaveConfig(configPath, cfg); err != nil {
-			return "", fmt.Errorf("saving config after encrypting github_client_secret: %w", err)
+			return "", fmt.Errorf("saving config after encrypting %s: %w", fieldName, err)
 		}
-		return secret, nil
+		return plain, nil
 
 	default:
 		envSecret, envSource, ok := resolveOAuthEnvSourced("OAUTH_CLIENT_SECRET", "GITHUB_MCP_CLIENT_SECRET")
@@ -148,12 +171,12 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial) (string, 
 			if err != nil {
 				return "", fmt.Errorf("encrypting %s from env: %w", envSource, err)
 			}
-			cfg.Auth.GitHubClientSecret = encrypted
+			*secret = encrypted
 			if err := SaveConfig(configPath, cfg); err != nil {
 				return "", fmt.Errorf("saving config after encrypting %s: %w", envSource, err)
 			}
 			return envSecret, nil
 		}
-		return "", fmt.Errorf("github_client_secret is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml")
+		return "", fmt.Errorf("%s is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml", fieldName)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"os"
@@ -39,11 +43,12 @@ type AuthConfig struct {
 	GitHubClientID     string `yaml:"github_client_id,omitempty"`
 	GitHubClientSecret string `yaml:"github_client_secret,omitempty"`
 
-	Provider      string `yaml:"provider,omitempty"`
-	ClientID      string `yaml:"client_id,omitempty"`
-	ClientSecret  string `yaml:"client_secret,omitempty"`
-	OIDCIssuerURL string `yaml:"oidc_issuer_url,omitempty"`
-	OIDCAudience  string `yaml:"oidc_audience,omitempty"`
+	Provider       string `yaml:"provider,omitempty"`
+	ClientID       string `yaml:"client_id,omitempty"`
+	ClientSecret   string `yaml:"client_secret,omitempty"`
+	OIDCIssuerURL  string `yaml:"oidc_issuer_url,omitempty"`
+	OIDCAudience   string `yaml:"oidc_audience,omitempty"`
+	OIDCPrivateKey string `yaml:"oidc_private_key,omitempty"`
 }
 
 // GatewayConfig holds gateway-level settings that can be persisted in config.yaml.
@@ -180,3 +185,55 @@ func MigrateSecret(configPath string, cfg *AppConfig, km *KeyMaterial, providerK
 		return "", fmt.Errorf("%s is required: set OAUTH_CLIENT_SECRET env var or provide an encrypted value in config.yaml", fieldName)
 	}
 }
+
+// MigrateOIDCPrivateKey resolves the OIDC RSA private key, following this priority:
+//
+//  1. cfg.Auth.OIDCPrivateKey is "ENC[age:]..." → decrypt, parse PEM, and return *rsa.PrivateKey
+//  2. field empty/absent → generate a new RSA 2048-bit key, PEM encode, encrypt, save to config, and return
+func MigrateOIDCPrivateKey(configPath string, cfg *AppConfig, km *KeyMaterial) (*rsa.PrivateKey, error) {
+	keyField := &cfg.Auth.OIDCPrivateKey
+	if IsEncrypted(*keyField) {
+		plaintext, err := DecryptField(km, *keyField)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting oidc_private_key: %w", err)
+		}
+		block, _ := pem.Decode([]byte(plaintext))
+		if block == nil || block.Type != "RSA PRIVATE KEY" {
+			return nil, fmt.Errorf("invalid PEM block type for RSA private key")
+		}
+		privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing RSA private key: %w", err)
+		}
+		return privKey, nil
+	}
+
+	// Generate a new RSA 2048-bit key
+	slog.Info("no OIDC private key found; generating a new RSA key")
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generating RSA private key: %w", err)
+	}
+
+	privBytes := x509.MarshalPKCS1PrivateKey(privKey)
+	pemBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privBytes,
+	}
+	pemBytes := pem.EncodeToMemory(pemBlock)
+
+	encrypted, err := EncryptField(km, string(pemBytes))
+	if err != nil {
+		return nil, fmt.Errorf("encrypting generated RSA private key: %w", err)
+	}
+
+	*keyField = encrypted
+	if err := SaveConfig(configPath, cfg); err != nil {
+		slog.Warn("failed to save generated OIDC private key to config; using in-memory key (will not persist across restarts)", "err", err)
+	} else {
+		slog.Info("saved generated OIDC private key to config")
+	}
+
+	return privKey, nil
+}
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,7 +30,7 @@ func TestMigrateSecret_EncryptedValue(t *testing.T) {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	got, err := MigrateSecret(configPath, cfg2, km)
+	got, err := MigrateSecret(configPath, cfg2, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestMigrateSecret_PlaintextRewritten(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	got, err := MigrateSecret(configPath, cfg, km)
+	got, err := MigrateSecret(configPath, cfg, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestMigrateSecret_FromEnvVar(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	got, err := MigrateSecret(configPath, cfg, km)
+	got, err := MigrateSecret(configPath, cfg, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestMigrateSecret_FromLegacyEnvVar(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	got, err := MigrateSecret(configPath, cfg, km)
+	got, err := MigrateSecret(configPath, cfg, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestMigrateSecret_NewWinsOverLegacy(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	got, err := MigrateSecret(configPath, cfg, km)
+	got, err := MigrateSecret(configPath, cfg, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestMigrateSecret_NoSecretAnywhere(t *testing.T) {
 	t.Setenv("GITHUB_MCP_CLIENT_SECRET", "")
 
 	cfg := &AppConfig{}
-	_, err := MigrateSecret(configPath, cfg, km)
+	_, err := MigrateSecret(configPath, cfg, km, "github")
 	if err == nil {
 		t.Fatal("expected error when no secret is available")
 	}
@@ -208,7 +208,7 @@ func TestMigrateSecret_NoSecretInLogs(t *testing.T) {
 	resetLegacyEnvWarnedForTest()
 
 	cfg := &AppConfig{}
-	enc, err := MigrateSecret(configPath, cfg, km)
+	enc, err := MigrateSecret(configPath, cfg, km, "github")
 	if err != nil {
 		t.Fatalf("MigrateSecret: %v", err)
 	}
@@ -264,5 +264,37 @@ gateway:
 	}
 	if cfg.Gateway.TrustedProxies[0] != "127.0.0.1/32" || cfg.Gateway.TrustedProxies[1] != "10.0.0.0/8" {
 		t.Errorf("trusted_proxies: got %#v", cfg.Gateway.TrustedProxies)
+	}
+}
+
+// TestMigrateSecret_GenericOIDC verifies that when provider is "oidc",
+// client_secret is used and migrated instead of github_client_secret.
+func TestMigrateSecret_GenericOIDC(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	km := testKeyMaterial(t)
+	plaintext := "my-generic-oidc-client-secret"
+
+	cfg := &AppConfig{Auth: AuthConfig{ClientSecret: plaintext}}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := MigrateSecret(configPath, cfg, km, "oidc")
+	if err != nil {
+		t.Fatalf("MigrateSecret (oidc): %v", err)
+	}
+	if got != plaintext {
+		t.Errorf("got %q, want %q", got, plaintext)
+	}
+
+	// Config file should now hold an encrypted value for client_secret.
+	reloaded, _ := LoadConfig(configPath)
+	if !IsEncrypted(reloaded.Auth.ClientSecret) {
+		t.Error("config file should have been rewritten with encrypted value")
+	}
+	if strings.Contains(reloaded.Auth.ClientSecret, plaintext) {
+		t.Error("plaintext must not remain in config file after migration")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,3 +298,46 @@ func TestMigrateSecret_GenericOIDC(t *testing.T) {
 		t.Error("plaintext must not remain in config file after migration")
 	}
 }
+
+// TestMigrateOIDCPrivateKey verifies that OIDCPrivateKey is generated, encrypted,
+// saved to config, and decrypted correctly on subsequent loads.
+func TestMigrateOIDCPrivateKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	km := testKeyMaterial(t)
+
+	cfg := &AppConfig{}
+	if err := SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	// 1. Initial generation
+	privKey1, err := MigrateOIDCPrivateKey(configPath, cfg, km)
+	if err != nil {
+		t.Fatalf("MigrateOIDCPrivateKey (generate): %v", err)
+	}
+	if privKey1 == nil {
+		t.Fatal("expected non-nil private key")
+	}
+
+	// Config should now hold the encrypted value
+	reloaded, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !IsEncrypted(reloaded.Auth.OIDCPrivateKey) {
+		t.Error("config should hold encrypted OIDC private key")
+	}
+
+	// 2. Load existing key from config
+	privKey2, err := MigrateOIDCPrivateKey(configPath, reloaded, km)
+	if err != nil {
+		t.Fatalf("MigrateOIDCPrivateKey (load): %v", err)
+	}
+
+	// Keys should be identical (same N and D for RSA key)
+	if privKey1.N.Cmp(privKey2.N) != 0 || privKey1.D.Cmp(privKey2.D) != 0 {
+		t.Error("expected loaded private key to match generated private key")
+	}
+}
+

--- a/internal/setup/required.go
+++ b/internal/setup/required.go
@@ -15,8 +15,8 @@ import (
 // flag is true, missing effective config still triggers the wizard to
 // guard against inconsistent state.
 func IsSetupRequired(appCfg *appconfig.AppConfig, envClientID, envSecret string, envRoutes []router.Route) bool {
-	hasClientID := strings.TrimSpace(envClientID) != "" || strings.TrimSpace(appCfg.Auth.GitHubClientID) != ""
-	hasSecret := strings.TrimSpace(appCfg.Auth.GitHubClientSecret) != "" || strings.TrimSpace(envSecret) != ""
+	hasClientID := strings.TrimSpace(envClientID) != "" || strings.TrimSpace(appCfg.Auth.GitHubClientID) != "" || strings.TrimSpace(appCfg.Auth.ClientID) != ""
+	hasSecret := strings.TrimSpace(appCfg.Auth.GitHubClientSecret) != "" || strings.TrimSpace(appCfg.Auth.ClientSecret) != "" || strings.TrimSpace(envSecret) != ""
 	hasRoutes := len(envRoutes) > 0 || len(appCfg.Routes) > 0
 	return !hasClientID || !hasSecret || !hasRoutes
 }


### PR DESCRIPTION
This PR implements OpenID Connect (OIDC) provider support for mcp-gateway, addressing issue #6. It adds an OIDC provider using UserInfo endpoint for token validation, extends configuration parameters, and updates server initialization to support dynamic discovery. All tests are passing.