### PR TITLE
fix(auth): redirect_uri 許可ホストの設定経路がなく agy の認証が失敗する問題を修正 (#100)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+### 追加
+
+- OIDC プロバイダーのサポートを追加（[#98](https://github.com/scottlz0310/mcp-gateway/pull/98)）
+  - agy CLI をサポートするため、mcp-gateway を OIDC Identity Provider として動作可能に
+  - OIDC 用の RSA 秘密鍵の永続化をサポート
+
+### 修正
+
+- redirect_uri 許可ホストの設定経路を追加（[#100](https://github.com/scottlz0310/mcp-gateway/issues/100)）
+  - `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` 環境変数（カンマ区切り）および `gateway.allowed_redirect_hosts` 設定（config.yaml）による許可ホストの設定を可能に
+  - デフォルトの許可リストに `antigravity.google` を追加
+
 ### ドキュメント
 
 - `docs/architecture.md` 新規作成: review platform における mcp-gateway の役割（MCP reverse proxy / routing gateway / auth boundary）を明文化し、thread-owl / mcp-resource-subscriber / review-raven / Mcp-Docker との責務境界を記載（[#92](https://github.com/scottlz0310/mcp-gateway/issues/92)）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add OIDC provider support ([#98](https://github.com/scottlz0310/mcp-gateway/pull/98))
+  - Support mcp-gateway as an OIDC Identity Provider to support agy CLI
+  - Support OIDC RSA private key persistence
+
+### Fixed
+
+- Fix redirect_uri host verification configuration ([#100](https://github.com/scottlz0310/mcp-gateway/issues/100))
+  - Add `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` environment variable (comma-separated) and `gateway.allowed_redirect_hosts` (config.yaml) configuration path to allow registering external redirect hostnames
+  - Add `antigravity.google` to the default allowed redirect hosts list
+
 ### Documentation
 
 - `docs/architecture.md`: define mcp-gateway's role as MCP reverse proxy / routing gateway / auth boundary within the review platform; document responsibility boundaries with thread-owl, mcp-resource-subscriber, review-raven, and Mcp-Docker ([#92](https://github.com/scottlz0310/mcp-gateway/issues/92))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -128,6 +128,9 @@ func main() {
 	if _, set := os.LookupEnv("MCP_GATEWAY_GITHUB_REFRESH_ENABLED"); !set {
 		cfg.githubRefreshEnabled = appCfg.Gateway.GitHubRefreshEnabled
 	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")) == "" && len(appCfg.Gateway.AllowedRedirectHosts) > 0 {
+		cfg.allowedRedirectHosts = appCfg.Gateway.AllowedRedirectHosts
+	}
 	// Apply config.yaml OAuth provider overrides
 	if strings.TrimSpace(os.Getenv("OAUTH_PROVIDER")) == "" && strings.TrimSpace(appCfg.Auth.Provider) != "" {
 		cfg.oauthProvider = appCfg.Auth.Provider
@@ -230,6 +233,7 @@ func main() {
 		TokenAudienceStrict:  cfg.tokenAudienceStrict,
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
 		OIDCPrivateKey:       oidcPrivateKey,
+		AllowedRedirectHosts: cfg.allowedRedirectHosts,
 	}, prov)
 	if err != nil {
 		slog.Error("auth handler init failed", "err", err)
@@ -403,6 +407,7 @@ type config struct {
 	tokenStorePath       string
 	keyPath              string
 	configPath           string
+	allowedRedirectHosts []string
 }
 
 func loadConfig() config {
@@ -445,6 +450,7 @@ func loadConfig() config {
 		tokenStorePath:       lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
 		keyPath:              getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
 		configPath:           getEnv("MCP_CONFIG_FILE", "./config.yaml"),
+		allowedRedirectHosts: splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ Configuration is resolved in this order:
 | Trusted proxies | `MCP_GATEWAY_TRUSTED_PROXIES` > `gateway.trusted_proxies` > none |
 | Token audience strict mode | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` > `gateway.token_audience_strict` > `false` |
 | GitHub refresh token rotation | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` > `gateway.github_refresh_enabled` > `false` |
+| Allowed redirect hosts | `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` > `gateway.allowed_redirect_hosts` > `localhost, 127.0.0.1, vscode.dev, antigravity.google` (default) |
 
 The OAuth client secret is intentionally special: once `config.yaml` contains a
 secret, `OAUTH_CLIENT_SECRET` / `GITHUB_MCP_CLIENT_SECRET` are ignored except
@@ -68,6 +69,7 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. |
 | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
 | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub OAuth user access tokens. Safe to leave on with non-expiring OAuth Apps; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
+| `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of external hostnames permitted in OAuth redirect_uris. |
 | `LOG_LEVEL` | `info` | JSON log level: `debug`, `info`, `warn`, or `error`. |
 | `SESSION_TTL_MIN` | `10` | OAuth authorization session lifetime in minutes. |
 | `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
@@ -95,6 +97,8 @@ gateway:
   trusted_proxies:
     - "127.0.0.1/32"
   token_audience_strict: false
+  allowed_redirect_hosts:
+    - "antigravity.google"
 
 routes:
   - name: github
@@ -128,6 +132,7 @@ setup:
 | `gateway.trusted_proxies` | CIDR list for trusted reverse proxy peers. |
 | `gateway.token_audience_strict` | Strict legacy-token audience enforcement. |
 | `gateway.github_refresh_enabled` | Enable transparent GitHub OAuth access token rotation; see [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
+| `gateway.allowed_redirect_hosts` | YAML list of external hostnames permitted in OAuth redirect_uris. |
 | `routes[].name` | Route name. Must be non-empty. |
 | `routes[].prefix` | URL path prefix. Must start with `/`; trailing slashes are trimmed except for `/`. |
 | `routes[].upstream` | Absolute `http` or `https` upstream URL. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. |
 | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
 | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub OAuth user access tokens. Safe to leave on with non-expiring OAuth Apps; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
-| `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of external hostnames permitted in OAuth redirect_uris. |
+| `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
 | `LOG_LEVEL` | `info` | JSON log level: `debug`, `info`, `warn`, or `error`. |
 | `SESSION_TTL_MIN` | `10` | OAuth authorization session lifetime in minutes. |
 | `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
@@ -132,7 +132,7 @@ setup:
 | `gateway.trusted_proxies` | CIDR list for trusted reverse proxy peers. |
 | `gateway.token_audience_strict` | Strict legacy-token audience enforcement. |
 | `gateway.github_refresh_enabled` | Enable transparent GitHub OAuth access token rotation; see [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
-| `gateway.allowed_redirect_hosts` | YAML list of external hostnames permitted in OAuth redirect_uris. |
+| `gateway.allowed_redirect_hosts` | YAML list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
 | `routes[].name` | Route name. Must be non-empty. |
 | `routes[].prefix` | URL path prefix. Must start with `/`; trailing slashes are trimmed except for `/`. |
 | `routes[].upstream` | Absolute `http` or `https` upstream URL. |

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -121,7 +121,7 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 	cfg.AllowedAudiences = normalizeAllowedAudiences(cfg.BaseURL, cfg.AllowedAudiences)
 	if len(cfg.AllowedRedirectHosts) == 0 {
-		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev"}
+		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev", "antigravity.google"}
 	}
 	if cfg.ExpiresIn <= 0 {
 		cfg.ExpiresIn = 90 * 24 * time.Hour

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -217,6 +217,57 @@ func TestAuthorizeDisallowedRedirectHost(t *testing.T) {
 	}
 }
 
+func TestAuthorizeDefaultAllowedRedirectHosts(t *testing.T) {
+	h := newTestHandler(t)
+	// antigravity.google should be allowed by default
+	r := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=s&redirect_uri=https://antigravity.google/cb", nil)
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, r)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("antigravity.google should be allowed by default: got %d, want %d", w.Code, http.StatusFound)
+	}
+}
+
+func TestAuthorizeCustomAllowedRedirectHosts(t *testing.T) {
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+	})
+	h, err := NewHandler(Config{
+		BaseURL:              "http://localhost:8080",
+		SessionTTL:           10 * time.Minute,
+		CacheTTL:             5 * time.Minute,
+		ExpiresIn:            90 * 24 * time.Hour,
+		AllowedRedirectHosts: []string{"custom-allowed.com"},
+	}, p)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	// custom-allowed.com should be allowed
+	r := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=s&redirect_uri=https://custom-allowed.com/cb", nil)
+	w := httptest.NewRecorder()
+	h.Authorize(w, r)
+	if w.Code != http.StatusFound {
+		t.Errorf("custom-allowed.com should be allowed: got %d, want %d", w.Code, http.StatusFound)
+	}
+
+	// localhost should be disallowed since it was overridden
+	r2 := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=s&redirect_uri=https://localhost/cb", nil)
+	w2 := httptest.NewRecorder()
+	h.Authorize(w2, r2)
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("localhost should be disallowed when overridden: got %d, want %d", w2.Code, http.StatusBadRequest)
+	}
+}
+
 func TestNewHandlerErrorsOnNilProvider(t *testing.T) {
 	_, err := NewHandler(Config{}, nil)
 	if err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,9 @@ type GatewayConfig struct {
 	// the OAuth App is configured for non-expiring tokens — the rotation path
 	// is dormant unless the upstream advertises refresh_token + expires_in.
 	GitHubRefreshEnabled bool `yaml:"github_refresh_enabled,omitempty"`
+	// AllowedRedirectHosts lists external hostnames permitted in OAuth redirect_uris.
+	// Defaults to ["localhost", "127.0.0.1", "vscode.dev", "antigravity.google"].
+	AllowedRedirectHosts []string `yaml:"allowed_redirect_hosts,omitempty"`
 }
 
 // LoadConfig reads AppConfig from path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,7 +76,8 @@ type GatewayConfig struct {
 	// the OAuth App is configured for non-expiring tokens — the rotation path
 	// is dormant unless the upstream advertises refresh_token + expires_in.
 	GitHubRefreshEnabled bool `yaml:"github_refresh_enabled,omitempty"`
-	// AllowedRedirectHosts lists external hostnames permitted in OAuth redirect_uris.
+	// AllowedRedirectHosts lists hostnames permitted in OAuth redirect_uris.
+	// When set, replaces the built-in default list entirely.
 	// Defaults to ["localhost", "127.0.0.1", "vscode.dev", "antigravity.google"].
 	AllowedRedirectHosts []string `yaml:"allowed_redirect_hosts,omitempty"`
 }

--- a/tasks.md
+++ b/tasks.md
@@ -13,6 +13,21 @@
 
 ---
 
+## Issue #100 — redirect_uri 許可ホストに設定経路がなく agy 認証が失敗する
+
+**目的**: agy（Antigravity）からの OAuth 認証が許可リスト制限で失敗する問題を解消するため、ホスト許可リストの設定手段（環境変数および config.yaml）を追加し、デフォルト許可ホストに `antigravity.google` を加える。
+
+### サブタスク
+
+- [x] `internal/config/config.go` の `GatewayConfig` に `AllowedRedirectHosts` フィールドを追加し、`config.yaml` から設定可能にする
+- [x] `cmd/server/main.go` にて環境変数 `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS`（カンマ区切り）の読み込み経路と、`config.yaml` からのフォールバックを設定
+- [x] `internal/auth/handler.go` のデフォルト `AllowedRedirectHosts` に `antigravity.google` を追加
+- [x] ユニットテストを追加し、デフォルト動作とカスタム設定時の挙動を検証
+- [x] `docs/configuration.md` に設定項目について追記
+- [x] `CHANGELOG.md` / `CHANGELOG.ja.md` の `Unreleased` セクションに変更内容を追記
+
+---
+
 ## アクティブフェーズ: Issue #70 — Auth Lifecycle Mismatch 対応
 
 ### 背景


### PR DESCRIPTION
# 概要
PR #98 (OIDC provider support) のマージ後、agy (Antigravity) からの OAuth 認証が以下のエラーで失敗する問題を修正します。
`{"error":"invalid_request","error_description":"redirect_uri host not permitted"}`

# 原因
`redirect_uri` のホスト制限検証ロジックが、ハードコードされたデフォルトリスト（`["localhost", "127.0.0.1", "vscode.dev"]`）に対してのみ行われており、外部からホストを追加設定するための環境変数や `config.yaml` の設定経路が存在しなかったためです。

# 修正内容
1. **設定経路の追加**
   - [config.go](file:///C:/Users/dev/src/mcp-gateway/internal/config/config.go) の `GatewayConfig` に `AllowedRedirectHosts` フィールドを追加。
   - [main.go](file:///C:/Users/dev/src/mcp-gateway/cmd/server/main.go) にて、環境変数 `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS`（カンマ区切り）または `config.yaml` の `gateway.allowed_redirect_hosts` から設定をパースし、認証ハンドラへ引き渡す処理を追加。
2. **既知クライアントのデフォルト許可**
   - [handler.go](file:///C:/Users/dev/src/mcp-gateway/internal/auth/handler.go) 内のデフォルトリストに `antigravity.google` を追加し、agy CLI がゼロコンフィグで認証完走できるように対応。
3. **テストの追加**
   - [handler_test.go](file:///C:/Users/dev/src/mcp-gateway/internal/auth/handler_test.go) にデフォルト許可リストの検証テスト、およびカスタム許可リスト指定時にデフォルト設定が正しく上書きされることを保証するテストを追加。
4. **ドキュメント・管理ファイルの更新**
   - [configuration.md](file:///C:/Users/dev/src/mcp-gateway/docs/configuration.md) に新たな設定項目について解説を追記。
   - [CHANGELOG.md](file:///C:/Users/dev/src/mcp-gateway/CHANGELOG.md) / [CHANGELOG.ja.md](file:///C:/Users/dev/src/mcp-gateway/CHANGELOG.ja.md) / [tasks.md](file:///C:/Users/dev/src/mcp-gateway/tasks.md) を更新。

# 受け入れ基準の確認
- [x] 環境変数または config.yaml で `redirect_uri` 許可ホストを追加できること
- [x] agy (redirect_uri: `https://antigravity.google/oauth-callback`) の認証が完走すること（デフォルトで許可されること）
- [x] 許可リスト外のホストは引き続き `redirect_uri host not permitted` で拒否されること
- [x] 既存クライアントに影響がないこと
