### PR TITLE
[codex] feat(auth): add persistent OAuth audit diagnostics

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,10 @@
 
 ### 追加
 
+- OAuth 監査ログと診断機能を追加（[#102](https://github.com/scottlz0310/mcp-gateway/issues/102)）
+  - authorize、callback、token exchange、identity resolution、refresh、provider rotation の成否を構造化イベントとして記録
+  - OS のユーザー state 領域を既定とし、Git worktree 外へ機密情報を除外した JSON Lines をサイズ・日数・世代数でローテーション保存
+  - 既存の loopback + shared secret internal API に `GET /internal/v1/auth/failures` を追加
 - OIDC プロバイダーのサポートを追加（[#98](https://github.com/scottlz0310/mcp-gateway/pull/98)）
   - agy CLI をサポートするため、mcp-gateway を OIDC Identity Provider として動作可能に
   - OIDC 用の RSA 秘密鍵の永続化をサポート

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add persistent OAuth audit diagnostics ([#102](https://github.com/scottlz0310/mcp-gateway/issues/102))
+  - Record authorize, callback, token exchange, identity resolution, refresh, and provider rotation outcomes as structured events
+  - Persist redacted JSON Lines outside Git worktrees with OS-specific user-state defaults and size/age/count rotation
+  - Add `GET /internal/v1/auth/failures` on the existing loopback and shared-secret internal API boundary
 - Add OIDC provider support ([#98](https://github.com/scottlz0310/mcp-gateway/pull/98))
   - Support mcp-gateway as an OIDC Identity Provider to support agy CLI
   - Support OIDC RSA private key persistence

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /out/mcp-gateway /mcp-gateway
 COPY --chown=nonroot:nonroot --from=builder /out/data /data
 EXPOSE 8080
+# Linux 標準の user state root を /data に置き、volume mount 時は監査ログを
+# /data/mcp-gateway/logs 配下へそのまま永続化する。
+ENV XDG_STATE_HOME=/data
 # Trivy DS-0002: explicitly declare non-root user (distroless:nonroot UID=65532)
 USER nonroot:nonroot
 ENTRYPOINT ["/mcp-gateway"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -199,6 +199,7 @@ environment:
 | `MCP_CONFIG_FILE` | `./config.yaml` | setup 結果と暗号化 secret。 |
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity。安全にバックアップしてください。 |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker 向け token 永続化 path。Docker 以外では書き込み可能な path を指定してください。 |
+| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS のユーザー state 領域。公式 image では `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines。相対 path と Git worktree 配下は拒否されます。 |
 
 詳細は [docs/configuration.md](docs/configuration.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Important paths:
 | `MCP_CONFIG_FILE` | `./config.yaml` | Persisted setup and encrypted secrets. |
 | `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity. Back it up securely. |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker-friendly token persistence path. Use a writable local path outside Docker. |
+| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS user state directory; `/data/mcp-gateway/logs/auth-audit.jsonl` in the official image | Rotating OAuth audit JSON Lines file. Relative paths and Git worktree paths are rejected. |
 
 The full reference is in [docs/configuration.md](docs/configuration.md).
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth"
 	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
+	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 	"github.com/scottlz0310/mcp-gateway/internal/internalapi"
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
@@ -223,6 +224,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	auditConfig, err := authaudit.FromEnvironment()
+	if err != nil {
+		slog.Error("auth audit configuration invalid", "err", err)
+		os.Exit(1)
+	}
+	auditRecorder, err := authaudit.New(auditConfig)
+	if err != nil {
+		slog.Error("auth audit initialization failed", "path", auditConfig.Path, "err", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := auditRecorder.Close(); err != nil {
+			slog.Error("auth audit shutdown failed", "err", err)
+		}
+	}()
+
 	oauthHandler, err := auth.NewHandler(auth.Config{
 		BaseURL:              cfg.publicURL,
 		SessionTTL:           time.Duration(cfg.sessionTTLMin) * time.Minute,
@@ -234,7 +251,7 @@ func main() {
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
 		OIDCPrivateKey:       oidcPrivateKey,
 		AllowedRedirectHosts: cfg.allowedRedirectHosts,
-	}, prov)
+	}, prov, auth.WithAuditRecorder(auditRecorder))
 	if err != nil {
 		slog.Error("auth handler init failed", "err", err)
 		os.Exit(1)
@@ -316,6 +333,7 @@ func main() {
 		"trusted_proxies", len(trustedProxies),
 		"token_audience_strict", cfg.tokenAudienceStrict,
 		"github_refresh_enabled", cfg.githubRefreshEnabled,
+		"auth_audit_log_path", auditRecorder.Path(),
 	)
 
 	server := &http.Server{
@@ -330,7 +348,7 @@ func main() {
 	// Phase B (#72) delegated-access PoC: optional loopback-only internal API.
 	// Activated only when both env vars are set; missing either → disabled
 	// (fail-closed) with an explicit log so misconfiguration is obvious.
-	startInternalAPI(oauthHandler)
+	startInternalAPI(oauthHandler, oauthHandler)
 
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		slog.Error("server error", "err", err)
@@ -545,7 +563,7 @@ func parseLogLevel(level string) slog.Level {
 // Missing or invalid configuration fails closed: the API is simply not served
 // and a log line announces the disabled state. We never bind to a non-loopback
 // address.
-func startInternalAPI(resolver internalapi.TokenResolver) {
+func startInternalAPI(resolver internalapi.TokenResolver, failures internalapi.FailureReader) {
 	secret := strings.TrimSpace(os.Getenv("MCP_GATEWAY_INTERNAL_SECRET"))
 	portRaw := strings.TrimSpace(os.Getenv("MCP_GATEWAY_INTERNAL_PORT"))
 	if secret == "" || portRaw == "" {
@@ -557,7 +575,7 @@ func startInternalAPI(resolver internalapi.TokenResolver) {
 		slog.Error("internal delegated access API disabled: invalid port", "port", portRaw)
 		return
 	}
-	handler, err := internalapi.NewHandler(resolver, secret)
+	handler, err := internalapi.NewHandler(resolver, secret, internalapi.WithFailureReader(failures))
 	if err != nil {
 		slog.Error("internal delegated access API disabled: invalid configuration", "err", err)
 		return

--- a/docs/auth-error-contract.md
+++ b/docs/auth-error-contract.md
@@ -112,6 +112,25 @@ returns `auth.ErrSubjectNotFound` and `auth.ErrRotationFailed` as distinct typed
 
 ---
 
+### 2.4 OAuth 失敗診断 endpoint
+
+`GET /internal/v1/auth/failures` は、既存の loopback + shared secret 境界で
+直近100件の OAuth 失敗を最新順に返す。`limit=1..100` で件数を縮小できる。
+
+| Error code | HTTP status | Trigger |
+|---|---|---|
+| `method_not_allowed` | 405 | `GET` 以外 |
+| `loopback_required` | 403 | loopback 以外からの接続 |
+| `invalid_authorization` | 401 | shared secret 不一致 |
+| `invalid_limit` | 400 | `limit` が1から100の整数ではない |
+| `diagnostics_unavailable` | 503 | failure reader が設定されていない |
+
+応答イベントには token、authorization code、OAuth `state`、secret、provider
+response body を含めない。永続的な解析の正本は OAuth 監査 JSON Lines
+ファイルであり、この endpoint のメモリ履歴は process 再起動時に消失する。
+
+---
+
 ## 3. copilot-review-mcp Mapping Contract
 
 This section documents how gateway error codes propagate through copilot-review-mcp's internal

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,10 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_BASE_URL` | none | Deprecated alias for `MCP_GATEWAY_PUBLIC_URL`. Emits a startup warning when set. |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | none | Comma-separated CIDR list for immediate reverse proxies whose `X-Forwarded-*` headers are trusted. |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. |
+| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS-specific user state path; official image: `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
+| `MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB` | `10` | 監査ログ1ファイルの最大サイズ（MiB）。 |
+| `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` | `5` | 保持するローテーション済み監査ログの最大数。 |
+| `MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS` | `30` | ローテーション済み監査ログの最大保持日数。 |
 | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
 | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub OAuth user access tokens. Safe to leave on with non-expiring OAuth Apps; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
 | `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
@@ -283,6 +287,54 @@ and proxying run.
 | `/setup` | GET/POST | First-run setup wizard endpoint, available only in setup mode. |
 | `/health` | GET | Health check in normal mode. |
 | `/<prefix>` | ANY | Reverse proxy to the matched upstream. Bearer-validated unless `auth=none` is set. |
+
+## OAuth 監査ログ
+
+認証開始、callback、token exchange、identity resolution、refresh、provider
+token rotation の成功・失敗を、標準出力と専用 JSON Lines ファイルの両方へ
+記録する。ファイルは1行1イベントで、`jq`、PowerShell、AI エージェントから
+そのまま解析できる。
+
+### 既定 path
+
+| 実行環境 | 既定 path |
+|----------|-----------|
+| Windows | `%LOCALAPPDATA%\mcp-gateway\logs\auth-audit.jsonl` |
+| Linux | `$XDG_STATE_HOME/mcp-gateway/logs/auth-audit.jsonl`。`XDG_STATE_HOME` 未設定時は `$HOME/.local/state/mcp-gateway/logs/auth-audit.jsonl` |
+| macOS | `$HOME/Library/Logs/mcp-gateway/auth-audit.jsonl` |
+| 公式 container image | `/data/mcp-gateway/logs/auth-audit.jsonl` |
+
+公式 image は Linux 標準の `XDG_STATE_HOME=/data` を設定済みである。
+compose を使わない `docker run` でも起動でき、`/data` に volume を mount
+すると container 再作成後も保持できる。
+
+```bash
+docker run --rm -p 8080:8080 \
+  --volume mcp-gateway-data:/data \
+  --env OAUTH_CLIENT_ID=<client-id> \
+  --env OAUTH_CLIENT_SECRET=<client-secret> \
+  --env MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080 \
+  --env 'ROUTE_EXAMPLE=/mcp/example|http://example-mcp:8081' \
+  ghcr.io/scottlz0310/mcp-gateway:latest
+```
+
+ネイティブ実行ではリポジトリを汚さないよう、相対 path、current working
+directory への fallback、Git worktree 配下の明示 path を拒否する。OS の
+ユーザー領域を解決できない場合や、保存先を作成・追記できない場合は起動失敗と
+なる。
+
+### ローテーション
+
+- 現行ファイルが `MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB` に達すると UTC timestamp
+  付きファイルへローテーションする。
+- `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` を超えた世代と、
+  `MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS` を超えたファイルを削除する。
+- ローテーション済みファイルは AI 解析時に直接読めるよう圧縮しない。
+- ファイルは owner のみ読み書き可能な permission で作成する。
+
+監査イベントには token、authorization code、device code、OAuth `state`、
+client secret、Authorization header、provider response body を保存しない。
+相関が必要な token は短い SHA-256 fingerprint のみを記録する。
 
 ## GitHub OAuth Refresh Token Rotation
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -180,6 +180,46 @@ If `jq` is not available, follow the raw logs:
 docker compose logs -f mcp-gateway
 ```
 
+### OAuth 監査ログファイル
+
+OAuth 監査イベントは stdout に加え、ローテーション付き JSON Lines ファイルへ
+保存される。既定 path は Windows では
+`%LOCALAPPDATA%\mcp-gateway\logs\auth-audit.jsonl`、Linux では
+`$XDG_STATE_HOME/mcp-gateway/logs/auth-audit.jsonl` または
+`$HOME/.local/state/mcp-gateway/logs/auth-audit.jsonl`、macOS では
+`$HOME/Library/Logs/mcp-gateway/auth-audit.jsonl` である。公式 container
+image は `/data/mcp-gateway/logs/auth-audit.jsonl` を使用する。
+
+PowerShell:
+
+```powershell
+$path = Join-Path $env:LOCALAPPDATA 'mcp-gateway\logs\auth-audit.jsonl'
+Get-Content -LiteralPath $path |
+  ForEach-Object { $_ | ConvertFrom-Json } |
+  Where-Object result -eq 'failure' |
+  Select-Object timestamp, phase, provider, error_class, oauth_error, http_status
+```
+
+Linux / macOS / container:
+
+```bash
+jq 'select(.result == "failure") |
+  {timestamp, phase, provider, error_class, oauth_error, http_status}' \
+  /data/mcp-gateway/logs/auth-audit.jsonl
+```
+
+直近の失敗は internal API が有効な場合に取得できる。endpoint は既存の
+loopback + shared secret 境界を共有する。
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer ${MCP_GATEWAY_INTERNAL_SECRET}" \
+  "http://127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}/internal/v1/auth/failures?limit=20"
+```
+
+応答は最新順で最大100件である。永続的な事後解析の正本は JSON Lines
+ファイルであり、internal API の履歴は process 再起動時に消失する。
+
 ## Common Problems
 
 ### `setup_required`

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
+	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 )
 
 // refreshTokenGracePeriod is the extra lifetime added to refresh tokens beyond
@@ -98,12 +99,24 @@ type Handler struct {
 	store            *Store
 	allowedAudiences map[string]struct{}
 	privateKey       *rsa.PrivateKey
+	audit            authaudit.Recorder
 	// rotationGroup serializes concurrent GitHub refresh-token rotations
 	// targeting the same access token. Without this, a burst of requests
 	// arriving inside the leeway window would race to call the provider's
 	// refresh endpoint, wasting upstream quota and risking bad_refresh_token
 	// from GitHub's sequential rotation contract.
 	rotationGroup singleflight.Group
+}
+
+// HandlerOption は任意の auth handler integration を設定する。
+type HandlerOption func(*Handler)
+
+// WithAuditRecorder は OAuth 監査ログ永続化と直近失敗診断を有効化する。
+// recorder は事前に初期化済みでなければならない。
+func WithAuditRecorder(recorder authaudit.Recorder) HandlerOption {
+	return func(h *Handler) {
+		h.audit = recorder
+	}
 }
 
 // NewHandler creates a new OAuth Handler with the given configuration and provider.
@@ -114,7 +127,7 @@ type Handler struct {
 // JSON file so that MCP clients do not need to re-authenticate after gateway
 // restarts. Tokens are stored with TTL equal to cfg.ExpiresIn (default 90 days).
 // When cfg.TokenStorePath is empty, an in-memory store is used (TTL = cfg.CacheTTL).
-func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
+func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handler, error) {
 	if p == nil {
 		return nil, fmt.Errorf("auth.NewHandler: provider must not be nil")
 	}
@@ -163,13 +176,70 @@ func NewHandler(cfg Config, p provider.Provider) (*Handler, error) {
 		}
 	}
 
-	return &Handler{
+	handler := &Handler{
 		cfg:              cfg,
 		provider:         p,
 		store:            NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
 		allowedAudiences: audienceSet(cfg.AllowedAudiences),
 		privateKey:       privateKey,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(handler)
+	}
+	return handler, nil
+}
+
+func (h *Handler) auditSuccess(phase, message string, httpStatus int) {
+	h.recordAudit(authaudit.Event{
+		Phase:      phase,
+		Provider:   h.provider.Name(),
+		Result:     "success",
+		HTTPStatus: httpStatus,
+		Message:    message,
+	})
+}
+
+func (h *Handler) auditFailure(phase, errorClass, message string, err error, httpStatus int, tokenHash string) {
+	oauthCode, providerStatus, transient := provider.ErrorDetails(err)
+	if providerStatus != 0 {
+		httpStatus = providerStatus
+	}
+	if transient {
+		errorClass = "provider_unavailable"
+	} else if oauthCode != "" && errorClass == "provider_error" {
+		errorClass = "provider_rejected"
+	}
+	h.recordAudit(authaudit.Event{
+		Phase:      phase,
+		Provider:   h.provider.Name(),
+		Result:     "failure",
+		ErrorClass: errorClass,
+		OAuthError: oauthCode,
+		HTTPStatus: httpStatus,
+		Message:    message,
+		TokenHash:  tokenHash,
+	})
+}
+
+func (h *Handler) recordAudit(event authaudit.Event) {
+	if h.audit == nil {
+		return
+	}
+	if err := h.audit.Record(event); err != nil {
+		slog.Error("auth audit persistence failed",
+			"phase", event.Phase,
+			"result", event.Result,
+			"err", err,
+		)
+	}
+}
+
+// RecentAuthFailures は internal 診断 endpoint 向けに最新順の snapshot を返す。
+func (h *Handler) RecentAuthFailures() []authaudit.Event {
+	if h.audit == nil {
+		return nil
+	}
+	return h.audit.RecentFailures()
 }
 
 // refreshTokenTTL returns the lifetime for gateway-issued refresh tokens.
@@ -300,19 +370,23 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	codeChallengeMethod := q.Get("code_challenge_method")
 	audience, audErr := h.resolveRequestedAudience(q["resource"])
 	if audErr != nil {
+		h.auditFailure("authorize", "invalid_target", "authorization target rejected", audErr, http.StatusBadRequest, "")
 		oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if responseType != "code" {
+		h.auditFailure("authorize", "unsupported_response_type", "authorization response type rejected", nil, http.StatusBadRequest, "")
 		oauthError(w, "unsupported_response_type", "response_type must be 'code'", http.StatusBadRequest)
 		return
 	}
 	if state == "" || redirectURI == "" {
+		h.auditFailure("authorize", "invalid_request", "authorization request missing required parameters", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "missing state or redirect_uri", http.StatusBadRequest)
 		return
 	}
 	if codeChallenge != "" && codeChallengeMethod != "S256" {
+		h.auditFailure("authorize", "invalid_request", "authorization PKCE method rejected", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "code_challenge_method must be S256", http.StatusBadRequest)
 		return
 	}
@@ -322,15 +396,18 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 		(parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") ||
 		parsedRedirect.Host == "" ||
 		parsedRedirect.Fragment != "" {
+		h.auditFailure("authorize", "invalid_request", "authorization redirect URI rejected", err, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "invalid redirect_uri: must be absolute http/https URL without fragment", http.StatusBadRequest)
 		return
 	}
 	if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
+		h.auditFailure("authorize", "invalid_request", "authorization redirect host rejected", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
 		return
 	}
 
 	h.store.SaveSession(state, redirectURI, codeChallenge, audience)
+	h.auditSuccess("authorize", "authorization redirect created", http.StatusFound)
 
 	http.Redirect(w, r, h.provider.AuthorizeURL(state, codeChallenge), http.StatusFound)
 }
@@ -341,33 +418,53 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	code := q.Get("code")
 	state := q.Get("state")
+	if oauthCode := provider.NormalizeOAuthErrorCode(q.Get("error")); oauthCode != "" {
+		h.recordAudit(authaudit.Event{
+			Phase:      "callback",
+			Provider:   h.provider.Name(),
+			Result:     "failure",
+			ErrorClass: "provider_rejected",
+			OAuthError: oauthCode,
+			HTTPStatus: http.StatusBadRequest,
+			Message:    "provider authorization callback rejected",
+		})
+		http.Error(w, "authorization failed", http.StatusBadRequest)
+		return
+	}
 
 	if code == "" || state == "" {
+		h.auditFailure("callback", "invalid_request", "authorization callback missing required parameters", nil, http.StatusBadRequest, "")
 		http.Error(w, "missing code or state", http.StatusBadRequest)
 		return
 	}
 	if !h.store.HasSession(state) {
+		h.auditFailure("callback", "invalid_state", "authorization callback state rejected", nil, http.StatusBadRequest, "")
 		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
 
 	tokens, err := h.provider.ExchangeCode(r.Context(), code)
 	if err != nil {
+		h.auditFailure("token_exchange", "provider_error", "provider token exchange failed", err, http.StatusBadGateway, "")
 		slog.Error("OAuth token exchange failed", "provider", h.provider.Name(), "err", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
+	h.auditSuccess("token_exchange", "provider token exchange succeeded", http.StatusOK)
 
 	// Resolve provider identity early to get the Subject claim
 	id, err := h.provider.ValidateToken(r.Context(), tokens.AccessToken)
 	if err != nil {
+		h.auditFailure("identity_resolution", "provider_error", "provider identity resolution failed", err, http.StatusBadGateway, tokenFingerprint(tokens.AccessToken))
 		slog.Error("OAuth identity resolution failed during callback", "provider", h.provider.Name(), "err", err)
 		http.Error(w, "identity resolution failed", http.StatusBadGateway)
 		return
 	}
+	h.auditSuccess("identity_resolution", "provider identity resolved", http.StatusOK)
 
 	internalCode, err := h.store.CompleteCallback(state, tokens.AccessToken, joinScopes(tokens.Scopes), tokens.RefreshToken, providerAccessExpiry(tokens.AccessTokenExpiresIn), id.Subject)
 	if err != nil {
+		h.auditFailure("callback", "store_error", "authorization callback session completion failed", err, http.StatusBadRequest, "")
 		slog.Error("session completion failed", "err", err)
 		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
@@ -375,6 +472,7 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	sess := h.store.lookupByCode(internalCode)
 	if sess == nil {
+		h.auditFailure("callback", "internal_error", "authorization callback session was unavailable", nil, http.StatusInternalServerError, "")
 		http.Error(w, "session lost", http.StatusInternalServerError)
 		return
 	}
@@ -385,6 +483,7 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 	rq.Set("state", state)
 	redirect.RawQuery = rq.Encode()
 
+	h.auditSuccess("callback", "authorization callback completed", http.StatusFound)
 	http.Redirect(w, r, redirect.String(), http.StatusFound)
 }
 
@@ -392,6 +491,7 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 	if err := r.ParseForm(); err != nil {
+		h.auditFailure("token_exchange", "invalid_request", "token request body rejected", err, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
 		return
 	}
@@ -403,6 +503,7 @@ func (h *Handler) Token(w http.ResponseWriter, r *http.Request) {
 	case "refresh_token":
 		h.tokenRefresh(w, r)
 	default:
+		h.auditFailure("token_exchange", "unsupported_grant_type", "token grant type rejected", nil, http.StatusBadRequest, "")
 		oauthError(w, "unsupported_grant_type", "unsupported grant_type", http.StatusBadRequest)
 	}
 }
@@ -414,6 +515,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		r.FormValue("code_verifier"),
 	)
 	if err != nil {
+		h.auditFailure("token_exchange", "invalid_grant", "authorization code exchange rejected", err, http.StatusBadRequest, "")
 		slog.Warn("token exchange rejected", "err", err)
 		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
 		return
@@ -425,6 +527,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("failed to create refresh token", "err", rtErr)
 	}
 	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject)
+	h.auditSuccess("token_exchange", "authorization code exchange completed", http.StatusOK)
 }
 
 // persistProviderRefresh writes upstream provider refresh metadata to the
@@ -442,22 +545,26 @@ func (h *Handler) persistProviderRefresh(accessToken, refreshToken string, acces
 func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 	deviceCode := r.FormValue("device_code")
 	if deviceCode == "" {
+		h.auditFailure("token_exchange", "invalid_request", "device token request missing device code", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "missing device_code", http.StatusBadRequest)
 		return
 	}
 
 	pending, ok := h.store.GetDevice(deviceCode)
 	if !ok {
+		h.auditFailure("token_exchange", "invalid_grant", "device token grant was not found", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_grant", "device code not found", http.StatusBadRequest)
 		return
 	}
 	if time.Now().After(pending.ExpiresAt) {
+		h.auditFailure("token_exchange", "token_expired", "device token grant expired", nil, http.StatusBadRequest, "")
 		oauthError(w, "expired_token", "device code expired", http.StatusBadRequest)
 		return
 	}
 
 	switch pending.Status {
 	case deviceDenied:
+		h.auditFailure("token_exchange", "access_denied", "device token grant denied", nil, http.StatusBadRequest, "")
 		oauthError(w, "access_denied", "user denied authorization", http.StatusBadRequest)
 		return
 	}
@@ -490,6 +597,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 	// Status is pending: poll GitHub on behalf of the client.
 	result, err := h.pollGitHubDeviceToken(r.Context(), pending.GitHubDevCode)
 	if err != nil {
+		h.auditFailure("token_exchange", "provider_error", "provider device token exchange failed", err, http.StatusBadGateway, "")
 		slog.Error("GitHub device token poll failed", "err", err)
 		oauthError(w, "server_error", "upstream error polling GitHub", http.StatusBadGateway)
 		return
@@ -500,12 +608,15 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		// Resolve provider identity early to get the Subject claim
 		id, valErr := h.provider.ValidateToken(r.Context(), result.AccessToken)
 		if valErr != nil {
+			h.auditFailure("identity_resolution", "provider_error", "device grant identity resolution failed", valErr, http.StatusBadGateway, tokenFingerprint(result.AccessToken))
 			slog.Error("Identity resolution failed during device grant callback", "err", valErr)
 			oauthError(w, "server_error", "failed to resolve identity", http.StatusBadGateway)
 			return
 		}
+		h.auditSuccess("identity_resolution", "device grant identity resolved", http.StatusOK)
 		completed, ok := h.store.AuthorizeAndConsumeDevice(deviceCode, result.AccessToken, result.Scope)
 		if !ok {
+			h.auditFailure("token_exchange", "invalid_grant", "device token grant was already consumed", nil, http.StatusBadRequest, "")
 			oauthError(w, "invalid_grant", "device code already consumed", http.StatusBadRequest)
 			return
 		}
@@ -516,17 +627,37 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
 		h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, id.Subject)
+		h.auditSuccess("token_exchange", "device token exchange completed", http.StatusOK)
 	case "authorization_pending":
 		oauthError(w, "authorization_pending", "user has not yet authorized the device", http.StatusBadRequest)
 	case "slow_down":
 		// RFC 8628 §3.5: client must increase polling interval by 5 seconds
 		oauthError(w, "slow_down", "polling too frequently, increase interval by 5 seconds", http.StatusBadRequest)
 	case "expired_token":
+		h.auditFailure("token_exchange", "token_expired", "provider device token expired", nil, http.StatusBadRequest, "")
 		oauthError(w, "expired_token", "device code expired on GitHub", http.StatusBadRequest)
 	case "access_denied":
 		h.store.DenyDevice(deviceCode)
+		h.recordAudit(authaudit.Event{
+			Phase:      "token_exchange",
+			Provider:   h.provider.Name(),
+			Result:     "failure",
+			ErrorClass: "access_denied",
+			OAuthError: "access_denied",
+			HTTPStatus: http.StatusBadRequest,
+			Message:    "provider device authorization denied",
+		})
 		oauthError(w, "access_denied", "user denied authorization", http.StatusBadRequest)
 	default:
+		h.recordAudit(authaudit.Event{
+			Phase:      "token_exchange",
+			Provider:   h.provider.Name(),
+			Result:     "failure",
+			ErrorClass: "provider_rejected",
+			OAuthError: provider.NormalizeOAuthErrorCode(result.Error),
+			HTTPStatus: http.StatusBadGateway,
+			Message:    "provider device token exchange rejected",
+		})
 		slog.Warn("unexpected GitHub device poll error", "err", result.Error)
 		oauthError(w, "server_error", "unexpected upstream error: "+result.Error, http.StatusBadGateway)
 	}
@@ -569,6 +700,7 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refres
 func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	rt := r.FormValue("refresh_token")
 	if rt == "" {
+		h.auditFailure("refresh", "invalid_request", "refresh request missing refresh token", nil, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "missing refresh_token", http.StatusBadRequest)
 		return
 	}
@@ -578,9 +710,11 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	accessToken, audience, rtExpiresAt, err := h.store.ReserveRefreshToken(rt)
 	if err != nil {
 		if errors.Is(err, ErrRefreshTokenDeleteFailed) {
+			h.auditFailure("refresh", "store_error", "refresh token store unavailable", err, http.StatusServiceUnavailable, "")
 			slog.Warn("refresh token store failure", "err", err)
 			oauthError(w, "temporarily_unavailable", "transient store error, please retry", http.StatusServiceUnavailable)
 		} else {
+			h.auditFailure("refresh", "invalid_grant", "refresh token rejected", err, http.StatusBadRequest, "")
 			slog.Warn("refresh token rejected", "err", err)
 			oauthError(w, "invalid_grant", "refresh token not found or expired", http.StatusBadRequest)
 		}
@@ -599,11 +733,13 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		resolved, audErr := h.resolveRequestedAudience(resources)
 		if audErr != nil {
 			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.auditFailure("refresh", "invalid_target", "refresh token target rejected", audErr, http.StatusBadRequest, tokenFingerprint(accessToken))
 			oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
 			return
 		}
 		if !isSubAudience(resolved, originalAudience) {
 			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.auditFailure("refresh", "invalid_target", "refresh token target widening rejected", nil, http.StatusBadRequest, tokenFingerprint(accessToken))
 			oauthError(w, "invalid_target", "resource is not a valid narrowing of the original audience", http.StatusBadRequest)
 			return
 		}
@@ -617,12 +753,14 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	if valErr != nil {
 		var upstreamErr *provider.UpstreamError
 		if errors.As(valErr, &upstreamErr) {
+			h.auditFailure("refresh", "provider_error", "refresh identity validation unavailable", valErr, http.StatusServiceUnavailable, tokenFingerprint(accessToken))
 			slog.Warn("refresh rejected: transient upstream error", "err", valErr)
 			// Restore the token with its original audience so the client can retry,
 			// potentially with a different resource value.
 			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
 			oauthError(w, "temporarily_unavailable", "upstream provider unreachable, retry later", http.StatusServiceUnavailable)
 		} else {
+			h.auditFailure("refresh", "invalid_grant", "refresh token underlying access token invalid", valErr, http.StatusBadRequest, tokenFingerprint(accessToken))
 			slog.Warn("refresh rejected: underlying token invalid", "err", valErr)
 			// Token genuinely invalid; do not restore.
 			oauthError(w, "invalid_grant", "underlying token no longer valid", http.StatusBadRequest)
@@ -635,6 +773,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	// Issue the rotated refresh token. The original is already consumed (reserved).
 	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, h.refreshTokenTTL())
 	if rtErr != nil {
+		h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
 		slog.Error("failed to rotate refresh token", "err", rtErr)
 		// Restore the original token (with its original audience) so the client can retry.
 		h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
@@ -643,6 +782,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject)
+	h.auditSuccess("refresh", "refresh token exchange completed", http.StatusOK)
 }
 
 // DeviceAuthorize handles POST /device_authorization (RFC 8628).
@@ -656,6 +796,7 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 	audience, audErr := h.resolveRequestedAudience(r.Form["resource"])
 	if audErr != nil {
+		h.auditFailure("authorize", "invalid_target", "device authorization target rejected", audErr, http.StatusBadRequest, "")
 		oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
 		return
 	}
@@ -665,6 +806,7 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	ghResp, err := h.startGitHubDeviceFlow(r.Context(), scope)
 	if err != nil {
+		h.auditFailure("authorize", "provider_error", "provider device authorization start failed", err, http.StatusBadGateway, "")
 		slog.Error("GitHub device flow start failed", "err", err)
 		oauthError(w, "server_error", "failed to start device flow with GitHub", http.StatusBadGateway)
 		return
@@ -673,6 +815,7 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().Add(time.Duration(ghResp.ExpiresIn) * time.Second)
 	internalCode, err := h.store.CreateDevice(ghResp.DeviceCode, ghResp.UserCode, ghResp.VerificationURI, expiresAt, ghResp.Interval, audience)
 	if err != nil {
+		h.auditFailure("authorize", "store_error", "device authorization session creation failed", err, http.StatusInternalServerError, "")
 		slog.Error("device session creation failed", "err", err)
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 		return
@@ -691,6 +834,7 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	_ = json.NewEncoder(w).Encode(resp)
+	h.auditSuccess("authorize", "device authorization started", http.StatusOK)
 }
 
 type githubDeviceCodeResp struct {
@@ -793,7 +937,7 @@ func (h *Handler) pollGitHubDeviceToken(ctx context.Context, githubDevCode strin
 		Scope:           raw.Scope,
 		RefreshToken:    raw.RefreshToken,
 		AccessExpiresIn: time.Duration(raw.ExpiresIn) * time.Second,
-		Error:           raw.Error,
+		Error:           provider.NormalizeOAuthErrorCode(raw.Error),
 	}, nil
 }
 
@@ -837,6 +981,7 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 	}
 	id, valErr := h.provider.ValidateToken(ctx, token)
 	if valErr != nil {
+		h.auditFailure("identity_resolution", "provider_error", "bearer identity resolution failed", valErr, http.StatusUnauthorized, tokenFingerprint(token))
 		return "", "", valErr
 	}
 	cacheAudience := ""
@@ -844,6 +989,7 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 		cacheAudience = audience
 	}
 	h.store.CacheToken(token, id.Subject, cacheAudience)
+	h.auditSuccess("identity_resolution", "bearer identity resolved", http.StatusOK)
 	return id.Subject, "", nil
 }
 
@@ -975,6 +1121,7 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 	tokens, err := h.provider.RefreshToken(ctx, record.ProviderRefreshToken)
 	if err != nil {
 		if errors.Is(err, provider.ErrRefreshNotSupported) {
+			h.auditFailure("rotation", "not_supported", "provider token rotation is not supported", err, 0, tokenFingerprint(token))
 			// Permanent: provider does not implement rotation. Clear so
 			// subsequent ValidateToken calls do not retry this branch.
 			h.store.ClearProviderRefresh(token)
@@ -982,6 +1129,7 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 		}
 		var upstreamErr *provider.UpstreamError
 		if errors.As(err, &upstreamErr) {
+			h.auditFailure("rotation", "provider_error", "provider token rotation unavailable", err, 0, tokenFingerprint(token))
 			// Transient (network failure / 5xx). Leave metadata intact so
 			// the next request retries — provider will likely recover.
 			slog.Warn("rotation_failed",
@@ -998,6 +1146,7 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 		// permanently failed additionally causes EnsureFreshAccessToken-
 		// ForSubject's lenient branch to return ErrRotationFailed instead
 		// of the (now-dead) cached bearer.
+		h.auditFailure("rotation", "provider_error", "provider token rotation rejected", err, 0, tokenFingerprint(token))
 		slog.Warn("rotation_failed",
 			"token_hash", tokenFingerprint(token),
 			"err", err,
@@ -1007,6 +1156,7 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 		return rotationResult{}
 	}
 	if tokens.AccessToken == "" {
+		h.auditFailure("rotation", "malformed_response", "provider token rotation returned no access token", nil, 0, tokenFingerprint(token))
 		slog.Warn("rotation_failed",
 			"token_hash", tokenFingerprint(token),
 			"err", "empty access_token from provider",
@@ -1040,6 +1190,14 @@ func (h *Handler) runGitHubRotation(ctx context.Context, token, audience string)
 		"old_token_hash", tokenFingerprint(token),
 		"new_token_hash", tokenFingerprint(tokens.AccessToken),
 	)
+	h.recordAudit(authaudit.Event{
+		Phase:      "rotation",
+		Provider:   h.provider.Name(),
+		Result:     "success",
+		HTTPStatus: http.StatusOK,
+		Message:    "provider access token rotated",
+		TokenHash:  tokenFingerprint(tokens.AccessToken),
+	})
 	return rotationResult{
 		newToken: tokens.AccessToken,
 		subject:  record.Subject,
@@ -1371,10 +1529,10 @@ func (h *Handler) JWKS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	pub := h.privateKey.Public().(*rsa.PublicKey)
-	
+
 	// Encode N and E
 	nStr := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
-	
+
 	eBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(eBytes, uint32(pub.E))
 	start := 0

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -875,8 +875,7 @@ func (h *Handler) startGitHubDeviceFlow(ctx context.Context, scope string) (*git
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return nil, &provider.UpstreamError{Err: fmt.Errorf("GitHub device code returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		return nil, githubDeviceHTTPError(resp, "device_authorization")
 	}
 
 	var result githubDeviceCodeResp
@@ -914,8 +913,7 @@ func (h *Handler) pollGitHubDeviceToken(ctx context.Context, githubDevCode strin
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return nil, &provider.UpstreamError{Err: fmt.Errorf("GitHub device token returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		return nil, githubDeviceHTTPError(resp, "device_token")
 	}
 
 	var raw struct {
@@ -939,6 +937,33 @@ func (h *Handler) pollGitHubDeviceToken(ctx context.Context, githubDevCode strin
 		AccessExpiresIn: time.Duration(raw.ExpiresIn) * time.Second,
 		Error:           provider.NormalizeOAuthErrorCode(raw.Error),
 	}, nil
+}
+
+func githubDeviceHTTPError(resp *http.Response, operation string) error {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(io.LimitReader(resp.Body, 4<<10)).Decode(&payload)
+	oauthErr := &provider.OAuthError{
+		Provider:   "github",
+		Operation:  operation,
+		Code:       provider.NormalizeOAuthErrorCode(payload.Error),
+		HTTPStatus: resp.StatusCode,
+		Transient:  resp.StatusCode >= 500 || githubRateLimited(resp),
+	}
+	if oauthErr.Transient {
+		return &provider.UpstreamError{Err: oauthErr}
+	}
+	return oauthErr
+}
+
+func githubRateLimited(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return resp.StatusCode == http.StatusForbidden &&
+		(strings.TrimSpace(resp.Header.Get("Retry-After")) != "" ||
+			strings.TrimSpace(resp.Header.Get("X-RateLimit-Remaining")) == "0")
 }
 
 // ValidateToken checks the bearer token via the provider (with cache) and

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -791,6 +791,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 	if err := r.ParseForm(); err != nil {
+		h.auditFailure("authorize", "invalid_request", "device authorization request body rejected", err, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -845,6 +845,70 @@ func TestDeviceAuthorizeSuccess(t *testing.T) {
 	}
 }
 
+func TestGitHubDeviceHTTPErrorRedactsResponseBody(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		wantTransient bool
+	}{
+		{name: "provider rejection", status: http.StatusBadRequest},
+		{name: "provider unavailable", status: http.StatusServiceUnavailable, wantTransient: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, `{"error":"invalid_grant","error_description":"secret-provider-response"}`)
+			}))
+			defer ghServer.Close()
+
+			originalClient := githubClient
+			githubClient = &http.Client{
+				Transport: rewriteHostTransport{target: ghServer.URL, inner: ghServer.Client().Transport},
+			}
+			defer func() { githubClient = originalClient }()
+
+			h := newTestHandler(t)
+			operations := []struct {
+				name string
+				call func() error
+			}{
+				{
+					name: "device authorization",
+					call: func() error {
+						_, err := h.startGitHubDeviceFlow(context.Background(), "repo")
+						return err
+					},
+				},
+				{
+					name: "device token",
+					call: func() error {
+						_, err := h.pollGitHubDeviceToken(context.Background(), "device-code")
+						return err
+					},
+				},
+			}
+			for _, operation := range operations {
+				t.Run(operation.name, func(t *testing.T) {
+					err := operation.call()
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					if strings.Contains(err.Error(), "secret-provider-response") {
+						t.Fatalf("error leaked provider response body: %v", err)
+					}
+					code, status, transient := provider.ErrorDetails(err)
+					if code != "invalid_grant" || status != tc.status || transient != tc.wantTransient {
+						t.Errorf("ErrorDetails: got (%q, %d, %v), want (%q, %d, %v)",
+							code, status, transient, "invalid_grant", tc.status, tc.wantTransient)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestTokenDeviceGrantPending(t *testing.T) {
 	// Mock GitHub's token endpoint returning authorization_pending.
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth/provider"
+	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 )
 
 func newTestHandler(t *testing.T) *Handler {
@@ -42,6 +43,22 @@ func newTestHandler(t *testing.T) *Handler {
 		t.Fatalf("NewHandler: %v", err)
 	}
 	return h
+}
+
+func newAuditRecorder(t *testing.T) (*authaudit.FileRecorder, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := authaudit.New(authaudit.Config{
+		Path:            path,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: authaudit.DefaultFailureLimit,
+	})
+	if err != nil {
+		t.Fatalf("authaudit.New: %v", err)
+	}
+	return recorder, path
 }
 
 func TestDiscovery(t *testing.T) {
@@ -292,6 +309,154 @@ func TestAuthorizeRedirectsToGitHub(t *testing.T) {
 	}
 	if !strings.Contains(loc, "client_id=test-client-id") {
 		t.Errorf("location missing client_id: %q", loc)
+	}
+}
+
+func TestOAuthAuditEventsAndSecretRedaction(t *testing.T) {
+	recorder, auditPath := newAuditRecorder(t)
+	p := &provider.Mock{
+		NameValue:     "github",
+		ClientIDValue: "test-client-id",
+		ScopesValue:   "repo,user",
+		ExchangeCodeFunc: func(_ context.Context, code string) (provider.TokenResponse, error) {
+			if code != "provider-secret-code" {
+				return provider.TokenResponse{}, fmt.Errorf("unexpected authorization code")
+			}
+			return provider.TokenResponse{
+				AccessToken:          "secret-access-token",
+				RefreshToken:         "secret-provider-refresh-token",
+				AccessTokenExpiresIn: 30 * time.Second,
+				Scopes:               []string{"repo", "user"},
+			}, nil
+		},
+		ValidateFunc: func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Provider: "github", Subject: "alice"}, nil
+		},
+		RefreshTokenFunc: func(_ context.Context, refreshToken string) (provider.TokenResponse, error) {
+			if refreshToken != "secret-provider-refresh-token" {
+				return provider.TokenResponse{}, fmt.Errorf("unexpected provider refresh token")
+			}
+			return provider.TokenResponse{
+				AccessToken:          "rotated-secret-access-token",
+				RefreshToken:         "rotated-secret-provider-refresh-token",
+				AccessTokenExpiresIn: time.Hour,
+			}, nil
+		},
+	}
+	h, err := NewHandler(Config{
+		BaseURL:              "http://localhost:8080",
+		SessionTTL:           10 * time.Minute,
+		CacheTTL:             5 * time.Minute,
+		ExpiresIn:            90 * 24 * time.Hour,
+		GitHubRefreshEnabled: true,
+	}, p, WithAuditRecorder(recorder))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=secret-state&redirect_uri=http://localhost/cb", nil)
+	authRec := httptest.NewRecorder()
+	h.Authorize(authRec, authReq)
+	if authRec.Code != http.StatusFound {
+		t.Fatalf("authorize status: got %d", authRec.Code)
+	}
+
+	callbackReq := httptest.NewRequest(http.MethodGet,
+		"/callback?code=provider-secret-code&state=secret-state", nil)
+	callbackRec := httptest.NewRecorder()
+	h.Callback(callbackRec, callbackReq)
+	if callbackRec.Code != http.StatusFound {
+		t.Fatalf("callback status: got %d; body=%s", callbackRec.Code, callbackRec.Body.String())
+	}
+	redirectURL, err := url.Parse(callbackRec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	internalCode := redirectURL.Query().Get("code")
+	if internalCode == "" {
+		t.Fatal("callback redirect missing internal code")
+	}
+
+	tokenBody := "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code=" + url.QueryEscape(internalCode)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token status: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+	}
+	var tokenResponse map[string]any
+	if err := json.NewDecoder(tokenRec.Body).Decode(&tokenResponse); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	gatewayRefreshToken, _ := tokenResponse["refresh_token"].(string)
+	if gatewayRefreshToken == "" {
+		t.Fatal("token response missing gateway refresh token")
+	}
+
+	if _, rotated, err := h.ValidateToken(context.Background(), "secret-access-token", "http://localhost:8080"); err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	} else if rotated != "rotated-secret-access-token" {
+		t.Fatalf("rotated token: got %q", rotated)
+	}
+
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(gatewayRefreshToken)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("refresh status: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+
+	deniedReq := httptest.NewRequest(http.MethodGet,
+		"/callback?error=access_denied&error_description=contains-secret&state=another-secret-state", nil)
+	deniedRec := httptest.NewRecorder()
+	h.Callback(deniedRec, deniedReq)
+	if deniedRec.Code != http.StatusBadRequest {
+		t.Fatalf("denied callback status: got %d", deniedRec.Code)
+	}
+
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var phases = map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var event authaudit.Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("invalid audit JSON line: %v", err)
+		}
+		if event.Result == "success" {
+			phases[event.Phase] = true
+		}
+	}
+	for _, phase := range []string{"authorize", "callback", "token_exchange", "identity_resolution", "refresh", "rotation"} {
+		if !phases[phase] {
+			t.Errorf("missing successful audit phase %q", phase)
+		}
+	}
+	failures := recorder.RecentFailures()
+	if len(failures) != 1 || failures[0].OAuthError != "access_denied" {
+		t.Fatalf("recent failures: got %#v", failures)
+	}
+	for _, secret := range []string{
+		"secret-state",
+		"another-secret-state",
+		"provider-secret-code",
+		"secret-access-token",
+		"secret-provider-refresh-token",
+		"rotated-secret-access-token",
+		"contains-secret",
+		gatewayRefreshToken,
+	} {
+		if strings.Contains(string(data), secret) {
+			t.Errorf("audit log contains secret value %q", secret)
+		}
 	}
 }
 
@@ -1830,9 +1995,9 @@ func TestValidateTokenGitHubRotationSingleflight(t *testing.T) {
 func TestValidateTokenGitHubRotationFailureClearsMetadata(t *testing.T) {
 	const audience = "http://localhost:8080/mcp"
 	cases := []struct {
-		name              string
-		refreshFunc       func(ctx context.Context, rt string) (provider.TokenResponse, error)
-		wantMetadataKept  bool // true means metadata must remain intact for next retry
+		name             string
+		refreshFunc      func(ctx context.Context, rt string) (provider.TokenResponse, error)
+		wantMetadataKept bool // true means metadata must remain intact for next retry
 	}{
 		{
 			name: "bad_refresh_token (permanent) clears metadata",
@@ -2273,4 +2438,3 @@ func TestNewHandler_OIDCPrivateKey(t *testing.T) {
 		t.Error("expected Handler to generate a random key when OIDCPrivateKey is nil")
 	}
 }
-

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 )
 
-func newTestHandler(t *testing.T) *Handler {
+func newTestHandler(t *testing.T, opts ...HandlerOption) *Handler {
 	t.Helper()
 	p := provider.NewGitHub(provider.GitHubConfig{
 		ClientID:     "test-client-id",
@@ -38,7 +38,7 @@ func newTestHandler(t *testing.T) *Handler {
 		SessionTTL: 10 * time.Minute,
 		CacheTTL:   5 * time.Minute,
 		ExpiresIn:  90 * 24 * time.Hour,
-	}, p)
+	}, p, opts...)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -842,6 +842,31 @@ func TestDeviceAuthorizeSuccess(t *testing.T) {
 	}
 	if resp["device_code"] == nil || resp["device_code"] == "" {
 		t.Error("device_code must be non-empty")
+	}
+}
+
+func TestDeviceAuthorizeMalformedBodyAudited(t *testing.T) {
+	recorder, _ := newAuditRecorder(t)
+	defer func() { _ = recorder.Close() }()
+	h := newTestHandler(t, WithAuditRecorder(recorder))
+	r := httptest.NewRequest(http.MethodPost, "/device_authorization",
+		strings.NewReader(strings.Repeat("x", (64<<10)+1)))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.DeviceAuthorize(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	failures := recorder.RecentFailures()
+	if len(failures) != 1 {
+		t.Fatalf("failure count: got %d, want 1", len(failures))
+	}
+	if got := failures[0]; got.Phase != "authorize" ||
+		got.ErrorClass != "invalid_request" ||
+		got.Message != "device authorization request body rejected" {
+		t.Fatalf("audit failure: got %#v", got)
 	}
 }
 

--- a/internal/auth/provider/errors.go
+++ b/internal/auth/provider/errors.go
@@ -1,5 +1,13 @@
 package provider
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
 // UpstreamError represents a transient failure contacting an OAuth provider's
 // API (network error, 5xx response). Callers (e.g. middleware) use this to
 // return 503 Service Unavailable instead of 401 Unauthorized so that clients
@@ -11,3 +19,75 @@ type UpstreamError struct {
 func (e *UpstreamError) Error() string         { return e.Err.Error() }
 func (e *UpstreamError) Unwrap() error         { return e.Err }
 func (e *UpstreamError) IsUpstreamError() bool { return true }
+
+// OAuthError は provider response body や error description の生値を保持せず、
+// 機械判定に必要な provider failure metadata だけを表す。
+type OAuthError struct {
+	Provider   string
+	Operation  string
+	Code       string
+	HTTPStatus int
+	Transient  bool
+	Err        error
+}
+
+func (e *OAuthError) Error() string {
+	message := fmt.Sprintf("%s OAuth %s failed", e.Provider, e.Operation)
+	if e.Code != "" {
+		message += ": " + e.Code
+	}
+	if e.HTTPStatus != 0 {
+		message += fmt.Sprintf(" (status %d)", e.HTTPStatus)
+	}
+	return message
+}
+
+func (e *OAuthError) Unwrap() error {
+	return e.Err
+}
+
+// ErrorDetails は認証監査イベントで使用する安定 field を抽出する。
+func ErrorDetails(err error) (oauthCode string, httpStatus int, transient bool) {
+	var oauthErr *OAuthError
+	if errors.As(err, &oauthErr) {
+		oauthCode = NormalizeOAuthErrorCode(oauthErr.Code)
+		httpStatus = oauthErr.HTTPStatus
+		transient = oauthErr.Transient
+	}
+	var upstreamErr *UpstreamError
+	if errors.As(err, &upstreamErr) {
+		transient = true
+	}
+	return oauthCode, httpStatus, transient
+}
+
+func decodeOAuthErrorCode(body io.Reader) string {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(io.LimitReader(body, 4<<10)).Decode(&payload); err != nil {
+		return ""
+	}
+	return NormalizeOAuthErrorCode(payload.Error)
+}
+
+// NormalizeOAuthErrorCode は外部入力の error code を監査ログ向け識別子へ制限する。
+func NormalizeOAuthErrorCode(code string) string {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return ""
+	}
+	if len(code) > 64 {
+		return "invalid_error_code"
+	}
+	for _, char := range code {
+		if char >= 'a' && char <= 'z' ||
+			char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' ||
+			char == '_' || char == '-' || char == '.' {
+			continue
+		}
+		return "invalid_error_code"
+	}
+	return code
+}

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -128,11 +128,18 @@ func (p *githubProvider) postToken(ctx context.Context, form url.Values, op stri
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		if resp.StatusCode >= 500 {
-			return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("GitHub OAuth %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		oauthCode := decodeOAuthErrorCode(resp.Body)
+		oauthErr := &OAuthError{
+			Provider:   "github",
+			Operation:  op,
+			Code:       oauthCode,
+			HTTPStatus: resp.StatusCode,
+			Transient:  resp.StatusCode >= 500,
 		}
-		return TokenResponse{}, fmt.Errorf("GitHub OAuth %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))
+		if resp.StatusCode >= 500 {
+			return TokenResponse{}, &UpstreamError{Err: oauthErr}
+		}
+		return TokenResponse{}, oauthErr
 	}
 
 	var result struct {
@@ -142,7 +149,6 @@ func (p *githubProvider) postToken(ctx context.Context, form url.Values, op stri
 		ExpiresIn             int64  `json:"expires_in"`
 		RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in"`
 		Error                 string `json:"error"`
-		ErrorDescription      string `json:"error_description"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return TokenResponse{}, fmt.Errorf("decoding GitHub OAuth %s response: %w", op, err)
@@ -150,10 +156,11 @@ func (p *githubProvider) postToken(ctx context.Context, form url.Values, op stri
 	if result.Error != "" {
 		// GitHub returns 200 OK with a JSON `error` field for normal OAuth
 		// failure modes (bad_verification_code, bad_refresh_token, ...).
-		if op == "refresh" && result.Error == "bad_refresh_token" {
-			return TokenResponse{}, fmt.Errorf("GitHub OAuth refresh error: %s", result.Error)
+		return TokenResponse{}, &OAuthError{
+			Provider:  "github",
+			Operation: op,
+			Code:      NormalizeOAuthErrorCode(result.Error),
 		}
-		return TokenResponse{}, fmt.Errorf("GitHub OAuth %s error: %s", op, result.Error)
 	}
 	if result.AccessToken == "" {
 		return TokenResponse{}, fmt.Errorf("empty access_token from GitHub on %s", op)
@@ -184,14 +191,35 @@ func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Ident
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+			return Identity{}, &OAuthError{
+				Provider:   "github",
+				Operation:  "userinfo",
+				Code:       "invalid_token",
+				HTTPStatus: resp.StatusCode,
+			}
 		case http.StatusForbidden, http.StatusTooManyRequests:
-			return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+			return Identity{}, &UpstreamError{Err: &OAuthError{
+				Provider:   "github",
+				Operation:  "userinfo",
+				Code:       map[int]string{http.StatusForbidden: "access_denied", http.StatusTooManyRequests: "rate_limited"}[resp.StatusCode],
+				HTTPStatus: resp.StatusCode,
+				Transient:  true,
+			}}
 		default:
 			if resp.StatusCode >= 500 {
-				return Identity{}, &UpstreamError{Err: fmt.Errorf("GitHub API returned %d", resp.StatusCode)}
+				return Identity{}, &UpstreamError{Err: &OAuthError{
+					Provider:   "github",
+					Operation:  "userinfo",
+					HTTPStatus: resp.StatusCode,
+					Transient:  true,
+				}}
 			}
-			return Identity{}, fmt.Errorf("invalid token: GitHub returned %d", resp.StatusCode)
+			return Identity{}, &OAuthError{
+				Provider:   "github",
+				Operation:  "userinfo",
+				Code:       "invalid_token",
+				HTTPStatus: resp.StatusCode,
+			}
 		}
 	}
 

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -197,11 +197,27 @@ func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Ident
 				Code:       "invalid_token",
 				HTTPStatus: resp.StatusCode,
 			}
-		case http.StatusForbidden, http.StatusTooManyRequests:
+		case http.StatusForbidden:
+			if githubRateLimited(resp) {
+				return Identity{}, &UpstreamError{Err: &OAuthError{
+					Provider:   "github",
+					Operation:  "userinfo",
+					Code:       "rate_limited",
+					HTTPStatus: resp.StatusCode,
+					Transient:  true,
+				}}
+			}
+			return Identity{}, &OAuthError{
+				Provider:   "github",
+				Operation:  "userinfo",
+				Code:       "access_denied",
+				HTTPStatus: resp.StatusCode,
+			}
+		case http.StatusTooManyRequests:
 			return Identity{}, &UpstreamError{Err: &OAuthError{
 				Provider:   "github",
 				Operation:  "userinfo",
-				Code:       map[int]string{http.StatusForbidden: "access_denied", http.StatusTooManyRequests: "rate_limited"}[resp.StatusCode],
+				Code:       "rate_limited",
 				HTTPStatus: resp.StatusCode,
 				Transient:  true,
 			}}
@@ -243,6 +259,11 @@ func (p *githubProvider) ValidateToken(ctx context.Context, token string) (Ident
 		Subject:     user.Login,
 		DisplayName: user.Name,
 	}, nil
+}
+
+func githubRateLimited(resp *http.Response) bool {
+	return strings.TrimSpace(resp.Header.Get("Retry-After")) != "" ||
+		strings.TrimSpace(resp.Header.Get("X-RateLimit-Remaining")) == "0"
 }
 
 // splitScopes normalizes GitHub's comma-delimited scope string into a slice.

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -337,9 +337,11 @@ func TestGitHubValidateToken(t *testing.T) {
 		name       string
 		status     int
 		body       string
+		headers    map[string]string
 		wantSub    string
 		wantErr    bool
 		wantUpstrm bool
+		wantCode   string
 	}{
 		{
 			name:    "success",
@@ -348,10 +350,11 @@ func TestGitHubValidateToken(t *testing.T) {
 			wantSub: "alice",
 		},
 		{
-			name:    "401 invalid token",
-			status:  http.StatusUnauthorized,
-			body:    "",
-			wantErr: true,
+			name:     "401 invalid token",
+			status:   http.StatusUnauthorized,
+			body:     "",
+			wantErr:  true,
+			wantCode: "invalid_token",
 		},
 		{
 			name:       "5xx upstream",
@@ -361,11 +364,20 @@ func TestGitHubValidateToken(t *testing.T) {
 			wantUpstrm: true,
 		},
 		{
-			name:       "403 is upstream error",
+			name:     "403 access denied is permanent",
+			status:   http.StatusForbidden,
+			body:     "",
+			wantErr:  true,
+			wantCode: "access_denied",
+		},
+		{
+			name:       "403 primary rate limit is transient",
 			status:     http.StatusForbidden,
 			body:       "",
+			headers:    map[string]string{"X-RateLimit-Remaining": "0"},
 			wantErr:    true,
 			wantUpstrm: true,
+			wantCode:   "rate_limited",
 		},
 		{
 			name:       "429 is upstream error",
@@ -373,6 +385,7 @@ func TestGitHubValidateToken(t *testing.T) {
 			body:       "",
 			wantErr:    true,
 			wantUpstrm: true,
+			wantCode:   "rate_limited",
 		},
 		{
 			name:    "empty login",
@@ -389,6 +402,9 @@ func TestGitHubValidateToken(t *testing.T) {
 				}
 				if got := r.Header.Get("Authorization"); got != "Bearer my-token" {
 					t.Errorf("Authorization: got %q", got)
+				}
+				for key, value := range tc.headers {
+					w.Header().Set(key, value)
 				}
 				w.WriteHeader(tc.status)
 				_, _ = w.Write([]byte(tc.body))
@@ -407,6 +423,13 @@ func TestGitHubValidateToken(t *testing.T) {
 				}
 				if !tc.wantUpstrm && errors.As(err, &ue) {
 					t.Errorf("did not expect UpstreamError, got %v", err)
+				}
+				if tc.status != http.StatusOK {
+					code, status, transient := ErrorDetails(err)
+					if code != tc.wantCode || status != tc.status || transient != tc.wantUpstrm {
+						t.Errorf("ErrorDetails: got (%q, %d, %v), want (%q, %d, %v)",
+							code, status, transient, tc.wantCode, tc.status, tc.wantUpstrm)
+					}
 				}
 				return
 			}

--- a/internal/auth/provider/github_test.go
+++ b/internal/auth/provider/github_test.go
@@ -80,16 +80,16 @@ func TestGitHubAuthorizeURL(t *testing.T) {
 
 func TestGitHubExchangeCode(t *testing.T) {
 	cases := []struct {
-		name             string
-		status           int
-		body             string
-		wantToken        string
-		wantScopes       []string
-		wantRefresh      string
-		wantAccessExpiry time.Duration
+		name              string
+		status            int
+		body              string
+		wantToken         string
+		wantScopes        []string
+		wantRefresh       string
+		wantAccessExpiry  time.Duration
 		wantRefreshExpiry time.Duration
-		wantErr          bool
-		wantUpstrm       bool
+		wantErr           bool
+		wantUpstrm        bool
 	}{
 		{
 			name:       "success non-expiring",
@@ -177,6 +177,57 @@ func TestGitHubExchangeCode(t *testing.T) {
 			}
 			if resp.RefreshTokenExpiresIn != tc.wantRefreshExpiry {
 				t.Errorf("refresh expiry: got %v, want %v", resp.RefreshTokenExpiresIn, tc.wantRefreshExpiry)
+			}
+		})
+	}
+}
+
+func TestGitHubOAuthErrorIsTypedAndRedacted(t *testing.T) {
+	const providerDescription = "sensitive provider response details"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"` + providerDescription + `"}`))
+	}))
+	defer srv.Close()
+
+	p := newGitHubFromServer(t, srv)
+	_, err := p.ExchangeCode(context.Background(), "secret-authorization-code")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("error type: got %T, want *OAuthError", err)
+	}
+	if oauthErr.Code != "invalid_grant" || oauthErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("OAuthError: got %#v", oauthErr)
+	}
+	if strings.Contains(err.Error(), providerDescription) || strings.Contains(err.Error(), "secret-authorization-code") {
+		t.Errorf("error leaked provider or request secret: %v", err)
+	}
+	code, status, transient := ErrorDetails(err)
+	if code != "invalid_grant" || status != http.StatusBadRequest || transient {
+		t.Errorf("ErrorDetails: got code=%q status=%d transient=%v", code, status, transient)
+	}
+}
+
+func TestNormalizeOAuthErrorCode(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "invalid_grant", want: "invalid_grant"},
+		{input: " access-denied ", want: "access-denied"},
+		{input: "bad.value", want: "bad.value"},
+		{input: "bad value", want: "invalid_error_code"},
+		{input: strings.Repeat("x", 65), want: "invalid_error_code"},
+		{input: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := NormalizeOAuthErrorCode(tc.input); got != tc.want {
+				t.Errorf("NormalizeOAuthErrorCode(%q): got %q, want %q", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/internal/auth/provider/oidc.go
+++ b/internal/auth/provider/oidc.go
@@ -243,11 +243,18 @@ func (p *oidcProvider) ValidateToken(ctx context.Context, token string) (Identit
 				Code:       "invalid_token",
 				HTTPStatus: resp.StatusCode,
 			}
-		case http.StatusForbidden, http.StatusTooManyRequests:
+		case http.StatusForbidden:
+			return Identity{}, &OAuthError{
+				Provider:   "oidc",
+				Operation:  "userinfo",
+				Code:       "access_denied",
+				HTTPStatus: resp.StatusCode,
+			}
+		case http.StatusTooManyRequests:
 			return Identity{}, &UpstreamError{Err: &OAuthError{
 				Provider:   "oidc",
 				Operation:  "userinfo",
-				Code:       map[int]string{http.StatusForbidden: "access_denied", http.StatusTooManyRequests: "rate_limited"}[resp.StatusCode],
+				Code:       "rate_limited",
 				HTTPStatus: resp.StatusCode,
 				Transient:  true,
 			}}

--- a/internal/auth/provider/oidc.go
+++ b/internal/auth/provider/oidc.go
@@ -130,11 +130,11 @@ func (p *oidcProvider) AuthorizeURL(state, codeChallenge string) string {
 
 func (p *oidcProvider) ExchangeCode(ctx context.Context, code string) (TokenResponse, error) {
 	form := url.Values{
-		"grant_type":   {"authorization_code"},
-		"client_id":    {p.cfg.ClientID},
+		"grant_type":    {"authorization_code"},
+		"client_id":     {p.cfg.ClientID},
 		"client_secret": {p.cfg.ClientSecret},
-		"code":         {code},
-		"redirect_uri": {p.cfg.RedirectURI},
+		"code":          {code},
+		"redirect_uri":  {p.cfg.RedirectURI},
 	}
 	return p.postToken(ctx, form, "exchange")
 }
@@ -168,11 +168,18 @@ func (p *oidcProvider) postToken(ctx context.Context, form url.Values, op string
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		if resp.StatusCode >= 500 {
-			return TokenResponse{}, &UpstreamError{Err: fmt.Errorf("OIDC token %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))}
+		oauthCode := decodeOAuthErrorCode(resp.Body)
+		oauthErr := &OAuthError{
+			Provider:   "oidc",
+			Operation:  op,
+			Code:       oauthCode,
+			HTTPStatus: resp.StatusCode,
+			Transient:  resp.StatusCode >= 500,
 		}
-		return TokenResponse{}, fmt.Errorf("OIDC token %s returned %d: %s", op, resp.StatusCode, strings.TrimSpace(string(snippet)))
+		if resp.StatusCode >= 500 {
+			return TokenResponse{}, &UpstreamError{Err: oauthErr}
+		}
+		return TokenResponse{}, oauthErr
 	}
 
 	var result struct {
@@ -186,7 +193,11 @@ func (p *oidcProvider) postToken(ctx context.Context, form url.Values, op string
 		return TokenResponse{}, fmt.Errorf("decoding OIDC token %s response: %w", op, err)
 	}
 	if result.Error != "" {
-		return TokenResponse{}, fmt.Errorf("OIDC token %s error: %s", op, result.Error)
+		return TokenResponse{}, &OAuthError{
+			Provider:  "oidc",
+			Operation: op,
+			Code:      NormalizeOAuthErrorCode(result.Error),
+		}
 	}
 	if result.AccessToken == "" {
 		return TokenResponse{}, fmt.Errorf("empty access_token from OIDC on %s", op)
@@ -226,14 +237,35 @@ func (p *oidcProvider) ValidateToken(ctx context.Context, token string) (Identit
 	if resp.StatusCode != http.StatusOK {
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			return Identity{}, fmt.Errorf("invalid token: OIDC userinfo returned %d", resp.StatusCode)
+			return Identity{}, &OAuthError{
+				Provider:   "oidc",
+				Operation:  "userinfo",
+				Code:       "invalid_token",
+				HTTPStatus: resp.StatusCode,
+			}
 		case http.StatusForbidden, http.StatusTooManyRequests:
-			return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo returned %d", resp.StatusCode)}
+			return Identity{}, &UpstreamError{Err: &OAuthError{
+				Provider:   "oidc",
+				Operation:  "userinfo",
+				Code:       map[int]string{http.StatusForbidden: "access_denied", http.StatusTooManyRequests: "rate_limited"}[resp.StatusCode],
+				HTTPStatus: resp.StatusCode,
+				Transient:  true,
+			}}
 		default:
 			if resp.StatusCode >= 500 {
-				return Identity{}, &UpstreamError{Err: fmt.Errorf("OIDC userinfo returned %d", resp.StatusCode)}
+				return Identity{}, &UpstreamError{Err: &OAuthError{
+					Provider:   "oidc",
+					Operation:  "userinfo",
+					HTTPStatus: resp.StatusCode,
+					Transient:  true,
+				}}
 			}
-			return Identity{}, fmt.Errorf("invalid token: OIDC userinfo returned %d", resp.StatusCode)
+			return Identity{}, &OAuthError{
+				Provider:   "oidc",
+				Operation:  "userinfo",
+				Code:       "invalid_token",
+				HTTPStatus: resp.StatusCode,
+			}
 		}
 	}
 

--- a/internal/auth/provider/oidc_test.go
+++ b/internal/auth/provider/oidc_test.go
@@ -277,3 +277,199 @@ func TestOIDCProviderTokenErrorIsTypedAndRedacted(t *testing.T) {
 		t.Errorf("error leaked provider or request secret: %v", err)
 	}
 }
+
+func TestOIDCProviderTokenFailureClassification(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		body          string
+		wantCode      string
+		wantTransient bool
+	}{
+		{
+			name:     "provider rejection",
+			status:   http.StatusBadRequest,
+			body:     `{"error":"invalid_grant"}`,
+			wantCode: "invalid_grant",
+		},
+		{
+			name:          "provider unavailable",
+			status:        http.StatusServiceUnavailable,
+			body:          `{"error":"temporarily_unavailable"}`,
+			wantCode:      "temporarily_unavailable",
+			wantTransient: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := newOIDCTestProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}, nil)
+
+			_, err := prov.RefreshToken(context.Background(), "refresh-token")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			code, status, transient := ErrorDetails(err)
+			if code != tc.wantCode || status != tc.status || transient != tc.wantTransient {
+				t.Errorf("ErrorDetails: got (%q, %d, %v), want (%q, %d, %v)",
+					code, status, transient, tc.wantCode, tc.status, tc.wantTransient)
+			}
+		})
+	}
+}
+
+func TestOIDCProviderRejectsInvalidTokenResponses(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid JSON", body: `{`},
+		{name: "embedded OAuth error", body: `{"error":"invalid_scope"}`},
+		{name: "missing access token", body: `{"scope":"openid"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := newOIDCTestProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}, nil)
+			if _, err := prov.ExchangeCode(context.Background(), "code"); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+
+	prov := newOIDCTestProvider(t, nil, nil)
+	if _, err := prov.RefreshToken(context.Background(), " "); err == nil {
+		t.Fatal("expected empty refresh token error")
+	}
+}
+
+func TestOIDCProviderUserInfoFailureClassification(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		wantCode      string
+		wantTransient bool
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, wantCode: "invalid_token"},
+		{name: "forbidden", status: http.StatusForbidden, wantCode: "access_denied", wantTransient: true},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantCode: "rate_limited", wantTransient: true},
+		{name: "server error", status: http.StatusBadGateway, wantTransient: true},
+		{name: "other rejection", status: http.StatusTeapot, wantCode: "invalid_token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := newOIDCTestProvider(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			})
+			_, err := prov.ValidateToken(context.Background(), "token")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			code, status, transient := ErrorDetails(err)
+			if code != tc.wantCode || status != tc.status || transient != tc.wantTransient {
+				t.Errorf("ErrorDetails: got (%q, %d, %v), want (%q, %d, %v)",
+					code, status, transient, tc.wantCode, tc.status, tc.wantTransient)
+			}
+		})
+	}
+}
+
+func TestOIDCProviderRejectsInvalidUserInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid JSON", body: `{`},
+		{name: "missing subject", body: `{"preferred_username":"alice"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := newOIDCTestProvider(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			})
+			if _, err := prov.ValidateToken(context.Background(), "token"); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestOIDCProviderDisplayNameFallbacks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "name", body: `{"sub":"subject","name":"Alice"}`, want: "Alice"},
+		{name: "email", body: `{"sub":"subject","email":"alice@example.com"}`, want: "alice@example.com"},
+		{name: "subject", body: `{"sub":"subject"}`, want: "subject"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := newOIDCTestProvider(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			})
+			identity, err := prov.ValidateToken(context.Background(), "token")
+			if err != nil {
+				t.Fatalf("ValidateToken: %v", err)
+			}
+			if identity.DisplayName != tc.want {
+				t.Errorf("DisplayName: got %q, want %q", identity.DisplayName, tc.want)
+			}
+		})
+	}
+}
+
+func newOIDCTestProvider(
+	t *testing.T,
+	tokenHandler http.HandlerFunc,
+	userInfoHandler http.HandlerFunc,
+) Provider {
+	t.Helper()
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization_endpoint": serverURL + "/auth",
+			"token_endpoint":         serverURL + "/token",
+			"userinfo_endpoint":      serverURL + "/userinfo",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if tokenHandler == nil {
+			_, _ = w.Write([]byte(`{"access_token":"token"}`))
+			return
+		}
+		tokenHandler(w, r)
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if userInfoHandler == nil {
+			_, _ = w.Write([]byte(`{"sub":"subject"}`))
+			return
+		}
+		userInfoHandler(w, r)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	serverURL = server.URL
+
+	prov, err := NewOIDC(OIDCConfig{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURI:  "http://localhost/cb",
+		IssuerURL:    serverURL,
+	})
+	if err != nil {
+		t.Fatalf("NewOIDC: %v", err)
+	}
+	return prov
+}

--- a/internal/auth/provider/oidc_test.go
+++ b/internal/auth/provider/oidc_test.go
@@ -357,7 +357,7 @@ func TestOIDCProviderUserInfoFailureClassification(t *testing.T) {
 		wantTransient bool
 	}{
 		{name: "unauthorized", status: http.StatusUnauthorized, wantCode: "invalid_token"},
-		{name: "forbidden", status: http.StatusForbidden, wantCode: "access_denied", wantTransient: true},
+		{name: "forbidden", status: http.StatusForbidden, wantCode: "access_denied"},
 		{name: "rate limited", status: http.StatusTooManyRequests, wantCode: "rate_limited", wantTransient: true},
 		{name: "server error", status: http.StatusBadGateway, wantTransient: true},
 		{name: "other rejection", status: http.StatusTeapot, wantCode: "invalid_token"},

--- a/internal/auth/provider/oidc_test.go
+++ b/internal/auth/provider/oidc_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -232,5 +233,47 @@ func TestOIDCProvider_InvalidUserInfo(t *testing.T) {
 	_, err = prov.ValidateToken(context.Background(), "invalid-token")
 	if err == nil {
 		t.Error("expected ValidateToken to fail for unauthorized status")
+	}
+}
+
+func TestOIDCProviderTokenErrorIsTypedAndRedacted(t *testing.T) {
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization_endpoint": serverURL + "/auth",
+			"token_endpoint":         serverURL + "/token",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"sensitive OIDC details"}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	serverURL = server.URL
+
+	prov, err := NewOIDC(OIDCConfig{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		RedirectURI:  "http://localhost/cb",
+		IssuerURL:    serverURL,
+	})
+	if err != nil {
+		t.Fatalf("NewOIDC: %v", err)
+	}
+	_, err = prov.ExchangeCode(context.Background(), "secret-code")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("error type: got %T, want *OAuthError", err)
+	}
+	if oauthErr.Code != "invalid_grant" || oauthErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("OAuthError: got %#v", oauthErr)
+	}
+	if strings.Contains(err.Error(), "sensitive OIDC details") || strings.Contains(err.Error(), "secret-code") {
+		t.Errorf("error leaked provider or request secret: %v", err)
 	}
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -181,7 +181,7 @@ func (s *Store) CompleteCallback(state, accessToken, scope, providerRefreshToken
 	sess, ok := s.sessions[state]
 	if !ok || time.Now().After(sess.ExpiresAt) {
 		delete(s.sessions, state)
-		return "", fmt.Errorf("session not found or expired for state %q", state)
+		return "", errors.New("session not found or expired")
 	}
 
 	code, err := generateCode()

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -52,9 +53,13 @@ func TestStoreCompleteCallback(t *testing.T) {
 
 func TestStoreCompleteCallbackUnknownState(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	_, err := s.CompleteCallback("nosuchstate", "tok", "", "", time.Time{}, "user123")
+	const state = "secret-state-value"
+	_, err := s.CompleteCallback(state, "tok", "", "", time.Time{}, "user123")
 	if err == nil {
 		t.Fatal("expected error for unknown state")
+	}
+	if strings.Contains(err.Error(), state) {
+		t.Fatalf("error leaked OAuth state: %v", err)
 	}
 }
 

--- a/internal/authaudit/recorder.go
+++ b/internal/authaudit/recorder.go
@@ -1,0 +1,473 @@
+package authaudit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultMaxSizeMB    = 10
+	DefaultMaxBackups   = 5
+	DefaultMaxAgeDays   = 30
+	DefaultFailureLimit = 100
+
+	auditEventName = "oauth_audit"
+)
+
+// Event は JSON Lines と internal 診断 API で共有する OAuth 監査イベントである。
+// token、authorization code、state、secret、provider body の生値を保持できる
+// field は意図的に定義しない。
+type Event struct {
+	Timestamp  time.Time `json:"timestamp"`
+	Event      string    `json:"event"`
+	Phase      string    `json:"phase"`
+	Provider   string    `json:"provider"`
+	Result     string    `json:"result"`
+	ErrorClass string    `json:"error_class"`
+	OAuthError string    `json:"oauth_error"`
+	HTTPStatus int       `json:"http_status"`
+	Message    string    `json:"message"`
+	TokenHash  string    `json:"token_hash,omitempty"`
+}
+
+// Recorder は auth package と internal API が利用する監査機能の境界である。
+type Recorder interface {
+	Record(Event) error
+	RecentFailures() []Event
+	Path() string
+	Close() error
+}
+
+// Config は監査ログの保存先と保持設定を表す。
+type Config struct {
+	Path            string
+	MaxSizeBytes    int64
+	MaxBackups      int
+	MaxAge          time.Duration
+	FailureCapacity int
+}
+
+// FromEnvironment は OS 別の既定 path と保持設定を解決する。
+// 不正な明示設定は既定値へ fallback せずエラーにする。
+func FromEnvironment() (Config, error) {
+	path, err := ResolvePath(strings.TrimSpace(os.Getenv("MCP_GATEWAY_AUTH_AUDIT_LOG_PATH")))
+	if err != nil {
+		return Config{}, err
+	}
+	maxSizeMB, err := positiveEnvInt("MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB", DefaultMaxSizeMB)
+	if err != nil {
+		return Config{}, err
+	}
+	maxBackups, err := positiveEnvInt("MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS", DefaultMaxBackups)
+	if err != nil {
+		return Config{}, err
+	}
+	maxAgeDays, err := positiveEnvInt("MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS", DefaultMaxAgeDays)
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{
+		Path:            path,
+		MaxSizeBytes:    int64(maxSizeMB) * 1024 * 1024,
+		MaxBackups:      maxBackups,
+		MaxAge:          time.Duration(maxAgeDays) * 24 * time.Hour,
+		FailureCapacity: DefaultFailureLimit,
+	}, nil
+}
+
+func positiveEnvInt(name string, fallback int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive integer, got %q", name, raw)
+	}
+	return value, nil
+}
+
+// ResolvePath は Git worktree 外の絶対監査ログ path を返す。
+func ResolvePath(configured string) (string, error) {
+	path := configured
+	if path == "" {
+		var err error
+		path, err = defaultPath(runtime.GOOS, os.Getenv, os.UserHomeDir)
+		if err != nil {
+			return "", err
+		}
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("auth audit log path must be absolute, got %q", path)
+	}
+	path = filepath.Clean(path)
+	if err := rejectGitWorktreePath(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func defaultPath(goos string, getenv func(string) string, userHomeDir func() (string, error)) (string, error) {
+	switch goos {
+	case "windows":
+		base := strings.TrimSpace(getenv("LOCALAPPDATA"))
+		if base == "" {
+			return "", errors.New("cannot resolve auth audit log path: LOCALAPPDATA is not set")
+		}
+		return windowsJoin(base, "mcp-gateway", "logs", "auth-audit.jsonl"), nil
+	case "darwin":
+		home, err := userHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", fmt.Errorf("cannot resolve auth audit log path: user home directory unavailable: %w", err)
+		}
+		return path.Join(home, "Library", "Logs", "mcp-gateway", "auth-audit.jsonl"), nil
+	default:
+		base := strings.TrimSpace(getenv("XDG_STATE_HOME"))
+		if base != "" {
+			if !strings.HasPrefix(base, "/") {
+				return "", fmt.Errorf("XDG_STATE_HOME must be absolute, got %q", base)
+			}
+			return path.Join(base, "mcp-gateway", "logs", "auth-audit.jsonl"), nil
+		}
+		home, err := userHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", fmt.Errorf("cannot resolve auth audit log path: XDG_STATE_HOME and user home directory are unavailable: %w", err)
+		}
+		return path.Join(home, ".local", "state", "mcp-gateway", "logs", "auth-audit.jsonl"), nil
+	}
+}
+
+func windowsJoin(base string, elements ...string) string {
+	result := strings.TrimRight(base, `\/`)
+	for _, element := range elements {
+		result += `\` + strings.Trim(element, `\/`)
+	}
+	return result
+}
+
+func rejectGitWorktreePath(path string) error {
+	dir := filepath.Dir(path)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return fmt.Errorf("auth audit log path must be outside a Git worktree, got %q", path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("checking auth audit log path %q: %w", path, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		dir = parent
+	}
+}
+
+// FileRecorder はイベントを1行1 JSON で保存し、診断 API 向けに直近の失敗を
+// 上限付きメモリ領域へ保持する。
+type FileRecorder struct {
+	mu sync.Mutex
+
+	cfg  Config
+	file *os.File
+	size int64
+	now  func() time.Time
+
+	failures    []Event
+	failureHead int
+	failureLen  int
+}
+
+// New は監査ログを作成し、保存できない場合は fail closed でエラーを返す。
+func New(cfg Config) (*FileRecorder, error) {
+	return newRecorder(cfg, time.Now)
+}
+
+func newRecorder(cfg Config, now func() time.Time) (*FileRecorder, error) {
+	if !filepath.IsAbs(cfg.Path) {
+		return nil, fmt.Errorf("auth audit log path must be absolute, got %q", cfg.Path)
+	}
+	if cfg.MaxSizeBytes <= 0 {
+		return nil, errors.New("auth audit max size must be positive")
+	}
+	if cfg.MaxBackups <= 0 {
+		return nil, errors.New("auth audit max backups must be positive")
+	}
+	if cfg.MaxAge <= 0 {
+		return nil, errors.New("auth audit max age must be positive")
+	}
+	if cfg.FailureCapacity <= 0 {
+		return nil, errors.New("auth audit failure capacity must be positive")
+	}
+	if err := rejectGitWorktreePath(cfg.Path); err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(cfg.Path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating auth audit log directory %q: %w", dir, err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving auth audit log directory %q: %w", dir, err)
+	}
+	resolvedPath := filepath.Join(resolvedDir, filepath.Base(cfg.Path))
+	if err := rejectGitWorktreePath(resolvedPath); err != nil {
+		return nil, err
+	}
+	if _, err := os.Lstat(resolvedPath); err == nil {
+		resolvedFile, err := filepath.EvalSymlinks(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolving auth audit log file %q: %w", resolvedPath, err)
+		}
+		if err := rejectGitWorktreePath(resolvedFile); err != nil {
+			return nil, err
+		}
+		resolvedPath = resolvedFile
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("checking auth audit log file %q: %w", resolvedPath, err)
+	}
+	cfg.Path = resolvedPath
+
+	file, err := os.OpenFile(cfg.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening auth audit log %q: %w", cfg.Path, err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("setting auth audit log permissions %q: %w", cfg.Path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("reading auth audit log metadata %q: %w", cfg.Path, err)
+	}
+
+	recorder := &FileRecorder{
+		cfg:      cfg,
+		file:     file,
+		size:     info.Size(),
+		now:      now,
+		failures: make([]Event, cfg.FailureCapacity),
+	}
+	if err := recorder.cleanupLocked(); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return recorder, nil
+}
+
+func (r *FileRecorder) Path() string {
+	return r.cfg.Path
+}
+
+func (r *FileRecorder) Record(event Event) error {
+	now := r.now().UTC()
+	if event.Timestamp.IsZero() {
+		event.Timestamp = now
+	} else {
+		event.Timestamp = event.Timestamp.UTC()
+	}
+	event.Event = auditEventName
+
+	line, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("encoding auth audit event: %w", err)
+	}
+	line = append(line, '\n')
+
+	r.mu.Lock()
+	if r.file == nil {
+		r.mu.Unlock()
+		return errors.New("auth audit recorder is closed")
+	}
+	if r.size > 0 && r.size+int64(len(line)) > r.cfg.MaxSizeBytes {
+		if err := r.rotateLocked(now); err != nil {
+			r.mu.Unlock()
+			return err
+		}
+	}
+	n, err := r.file.Write(line)
+	if err == nil && n != len(line) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		r.mu.Unlock()
+		return fmt.Errorf("writing auth audit log %q: %w", r.cfg.Path, err)
+	}
+	r.size += int64(n)
+	if event.Result == "failure" {
+		r.addFailureLocked(event)
+	}
+	r.mu.Unlock()
+
+	attrs := []any{
+		"timestamp", event.Timestamp.Format(time.RFC3339Nano),
+		"event", event.Event,
+		"phase", event.Phase,
+		"provider", event.Provider,
+		"result", event.Result,
+		"message", event.Message,
+	}
+	if event.ErrorClass != "" {
+		attrs = append(attrs, "error_class", event.ErrorClass)
+	}
+	if event.OAuthError != "" {
+		attrs = append(attrs, "oauth_error", event.OAuthError)
+	}
+	if event.HTTPStatus != 0 {
+		attrs = append(attrs, "http_status", event.HTTPStatus)
+	}
+	if event.TokenHash != "" {
+		attrs = append(attrs, "token_hash", event.TokenHash)
+	}
+	if event.Result == "failure" {
+		slog.Warn("oauth audit", attrs...)
+	} else {
+		slog.Info("oauth audit", attrs...)
+	}
+	return nil
+}
+
+func (r *FileRecorder) addFailureLocked(event Event) {
+	if r.failureLen < len(r.failures) {
+		index := (r.failureHead + r.failureLen) % len(r.failures)
+		r.failures[index] = event
+		r.failureLen++
+		return
+	}
+	r.failures[r.failureHead] = event
+	r.failureHead = (r.failureHead + 1) % len(r.failures)
+}
+
+// RecentFailures は診断表示向けに最新順の snapshot を返す。
+func (r *FileRecorder) RecentFailures() []Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]Event, 0, r.failureLen)
+	for offset := r.failureLen - 1; offset >= 0; offset-- {
+		index := (r.failureHead + offset) % len(r.failures)
+		out = append(out, r.failures[index])
+	}
+	return out
+}
+
+func (r *FileRecorder) rotateLocked(now time.Time) error {
+	if err := r.file.Close(); err != nil {
+		return fmt.Errorf("closing auth audit log before rotation: %w", err)
+	}
+	r.file = nil
+
+	rotated, err := r.nextRotatedPathLocked(now)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(r.cfg.Path, rotated); err != nil {
+		return fmt.Errorf("rotating auth audit log %q to %q: %w", r.cfg.Path, rotated, err)
+	}
+
+	file, err := os.OpenFile(r.cfg.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening new auth audit log %q after rotation: %w", r.cfg.Path, err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("setting new auth audit log permissions %q: %w", r.cfg.Path, err)
+	}
+	r.file = file
+	r.size = 0
+	return r.cleanupLocked()
+}
+
+func (r *FileRecorder) nextRotatedPathLocked(now time.Time) (string, error) {
+	ext := filepath.Ext(r.cfg.Path)
+	stem := strings.TrimSuffix(r.cfg.Path, ext)
+	timestamp := now.UTC().Format("20060102T150405.000000000Z")
+	for sequence := 0; sequence < 1000; sequence++ {
+		candidate := fmt.Sprintf("%s.%s.%03d%s", stem, timestamp, sequence, ext)
+		if _, err := os.Stat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate, nil
+		} else if err != nil {
+			return "", fmt.Errorf("checking rotated auth audit log %q: %w", candidate, err)
+		}
+	}
+	return "", errors.New("could not allocate a unique auth audit rotation filename")
+}
+
+func (r *FileRecorder) cleanupLocked() error {
+	files, err := r.rotatedFilesLocked()
+	if err != nil {
+		return err
+	}
+	cutoff := r.now().Add(-r.cfg.MaxAge)
+	kept := make([]rotatedFile, 0, len(files))
+	for _, file := range files {
+		if file.modTime.Before(cutoff) {
+			if err := os.Remove(file.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("removing expired auth audit log %q: %w", file.path, err)
+			}
+			continue
+		}
+		kept = append(kept, file)
+	}
+	for index := r.cfg.MaxBackups; index < len(kept); index++ {
+		if err := os.Remove(kept[index].path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing excess auth audit log %q: %w", kept[index].path, err)
+		}
+	}
+	return nil
+}
+
+type rotatedFile struct {
+	path    string
+	modTime time.Time
+}
+
+func (r *FileRecorder) rotatedFilesLocked() ([]rotatedFile, error) {
+	ext := filepath.Ext(r.cfg.Path)
+	stem := strings.TrimSuffix(r.cfg.Path, ext)
+	paths, err := filepath.Glob(stem + ".*" + ext)
+	if err != nil {
+		return nil, fmt.Errorf("listing rotated auth audit logs: %w", err)
+	}
+	files := make([]rotatedFile, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading rotated auth audit log metadata %q: %w", path, err)
+		}
+		files = append(files, rotatedFile{path: path, modTime: info.ModTime()})
+	}
+	slices.SortFunc(files, func(a, b rotatedFile) int {
+		return b.modTime.Compare(a.modTime)
+	})
+	return files, nil
+}
+
+func (r *FileRecorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.file == nil {
+		return nil
+	}
+	err := r.file.Close()
+	r.file = nil
+	if err != nil {
+		return fmt.Errorf("closing auth audit log %q: %w", r.cfg.Path, err)
+	}
+	return nil
+}

--- a/internal/authaudit/recorder.go
+++ b/internal/authaudit/recorder.go
@@ -178,10 +178,11 @@ func rejectGitWorktreePath(path string) error {
 type FileRecorder struct {
 	mu sync.Mutex
 
-	cfg  Config
-	file *os.File
-	size int64
-	now  func() time.Time
+	cfg        Config
+	file       *os.File
+	size       int64
+	now        func() time.Time
+	renameFile func(string, string) error
 
 	failures    []Event
 	failureHead int
@@ -254,11 +255,12 @@ func newRecorder(cfg Config, now func() time.Time) (*FileRecorder, error) {
 	}
 
 	recorder := &FileRecorder{
-		cfg:      cfg,
-		file:     file,
-		size:     info.Size(),
-		now:      now,
-		failures: make([]Event, cfg.FailureCapacity),
+		cfg:        cfg,
+		file:       file,
+		size:       info.Size(),
+		now:        now,
+		renameFile: os.Rename,
+		failures:   make([]Event, cfg.FailureCapacity),
 	}
 	if err := recorder.cleanupLocked(); err != nil {
 		_ = file.Close()
@@ -364,30 +366,63 @@ func (r *FileRecorder) RecentFailures() []Event {
 }
 
 func (r *FileRecorder) rotateLocked(now time.Time) error {
+	rotated, err := r.nextRotatedPathLocked(now)
+	if err != nil {
+		return err
+	}
 	if err := r.file.Close(); err != nil {
 		return fmt.Errorf("closing auth audit log before rotation: %w", err)
 	}
 	r.file = nil
 
-	rotated, err := r.nextRotatedPathLocked(now)
+	if err := r.renameFile(r.cfg.Path, rotated); err != nil {
+		rotationErr := fmt.Errorf("rotating auth audit log %q to %q: %w", r.cfg.Path, rotated, err)
+		if recoveryErr := r.reopenCurrentLocked(); recoveryErr != nil {
+			return errors.Join(rotationErr, fmt.Errorf("recovering auth audit log after failed rotation: %w", recoveryErr))
+		}
+		return rotationErr
+	}
+
+	if err := r.reopenCurrentLocked(); err != nil {
+		openErr := fmt.Errorf("opening new auth audit log %q after rotation: %w", r.cfg.Path, err)
+		if recoveryErr := r.restoreRotatedLocked(rotated); recoveryErr != nil {
+			return errors.Join(openErr, fmt.Errorf("rolling back auth audit rotation: %w", recoveryErr))
+		}
+		return openErr
+	}
+	return r.cleanupLocked()
+}
+
+func (r *FileRecorder) reopenCurrentLocked() error {
+	file, err := os.OpenFile(r.cfg.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	if err := os.Rename(r.cfg.Path, rotated); err != nil {
-		return fmt.Errorf("rotating auth audit log %q to %q: %w", r.cfg.Path, rotated, err)
-	}
-
-	file, err := os.OpenFile(r.cfg.Path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("opening new auth audit log %q after rotation: %w", r.cfg.Path, err)
-	}
 	if err := file.Chmod(0o600); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("setting new auth audit log permissions %q: %w", r.cfg.Path, err)
+		return err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return err
 	}
 	r.file = file
-	r.size = 0
-	return r.cleanupLocked()
+	r.size = info.Size()
+	return nil
+}
+
+func (r *FileRecorder) restoreRotatedLocked(rotated string) error {
+	if err := os.Remove(r.cfg.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing incomplete auth audit log %q: %w", r.cfg.Path, err)
+	}
+	if err := r.renameFile(rotated, r.cfg.Path); err != nil {
+		return fmt.Errorf("restoring rotated auth audit log %q to %q: %w", rotated, r.cfg.Path, err)
+	}
+	if err := r.reopenCurrentLocked(); err != nil {
+		return fmt.Errorf("reopening restored auth audit log %q: %w", r.cfg.Path, err)
+	}
+	return nil
 }
 
 func (r *FileRecorder) nextRotatedPathLocked(now time.Time) (string, error) {

--- a/internal/authaudit/recorder_test.go
+++ b/internal/authaudit/recorder_test.go
@@ -1,0 +1,357 @@
+package authaudit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDefaultPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		goos    string
+		env     map[string]string
+		home    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "windows local app data",
+			goos: "windows",
+			env:  map[string]string{"LOCALAPPDATA": `C:\Users\alice\AppData\Local`},
+			want: `C:\Users\alice\AppData\Local\mcp-gateway\logs\auth-audit.jsonl`,
+		},
+		{
+			name: "linux xdg state",
+			goos: "linux",
+			env:  map[string]string{"XDG_STATE_HOME": "/state"},
+			want: "/state/mcp-gateway/logs/auth-audit.jsonl",
+		},
+		{
+			name: "linux home fallback",
+			goos: "linux",
+			home: "/home/alice",
+			want: "/home/alice/.local/state/mcp-gateway/logs/auth-audit.jsonl",
+		},
+		{
+			name: "macOS logs",
+			goos: "darwin",
+			home: "/Users/alice",
+			want: "/Users/alice/Library/Logs/mcp-gateway/auth-audit.jsonl",
+		},
+		{
+			name:    "windows missing local app data",
+			goos:    "windows",
+			wantErr: true,
+		},
+		{
+			name:    "linux relative xdg state",
+			goos:    "linux",
+			env:     map[string]string{"XDG_STATE_HOME": "relative"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(key string) string {
+				return tc.env[key]
+			}
+			userHome := func() (string, error) {
+				return tc.home, nil
+			}
+			got, err := defaultPath(tc.goos, getenv, userHome)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultPath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("path: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvePathRejectsRelativeAndGitWorktree(t *testing.T) {
+	if _, err := ResolvePath("logs/auth-audit.jsonl"); err == nil {
+		t.Fatal("expected relative path rejection")
+	}
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	path := filepath.Join(root, "logs", "auth-audit.jsonl")
+	if _, err := ResolvePath(path); err == nil {
+		t.Fatal("expected Git worktree path rejection")
+	}
+}
+
+func TestRecorderRejectsSymlinkIntoGitWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires environment-specific privileges")
+	}
+	worktree := t.TempDir()
+	if err := os.Mkdir(filepath.Join(worktree, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	target := filepath.Join(worktree, "auth-audit.jsonl")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	_, err := New(Config{
+		Path:            link,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 10,
+	})
+	if err == nil {
+		t.Fatal("expected symlink into Git worktree rejection")
+	}
+}
+
+func TestFromEnvironment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	t.Setenv("MCP_GATEWAY_AUTH_AUDIT_LOG_PATH", path)
+	t.Setenv("MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB", "12")
+	t.Setenv("MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS", "7")
+	t.Setenv("MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS", "45")
+
+	cfg, err := FromEnvironment()
+	if err != nil {
+		t.Fatalf("FromEnvironment: %v", err)
+	}
+	if cfg.Path != path {
+		t.Errorf("path: got %q, want %q", cfg.Path, path)
+	}
+	if cfg.MaxSizeBytes != 12*1024*1024 || cfg.MaxBackups != 7 || cfg.MaxAge != 45*24*time.Hour {
+		t.Errorf("config: got %#v", cfg)
+	}
+
+	t.Setenv("MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB", "invalid")
+	if _, err := FromEnvironment(); err == nil {
+		t.Fatal("expected invalid size error")
+	}
+}
+
+func TestRecorderWritesJSONLinesAndRecentFailures(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := New(Config{
+		Path:            path,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 2,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = recorder.Close() }()
+
+	events := []Event{
+		{Phase: "authorize", Provider: "github", Result: "success", Message: "authorization started"},
+		{Phase: "callback", Provider: "github", Result: "failure", ErrorClass: "invalid_grant", OAuthError: "access_denied", HTTPStatus: 400, Message: "provider rejected authorization"},
+		{Phase: "refresh", Provider: "github", Result: "failure", ErrorClass: "token_expired", Message: "refresh token expired"},
+		{Phase: "rotation", Provider: "github", Result: "failure", ErrorClass: "provider_unavailable", TokenHash: "12345678", Message: "provider rotation unavailable"},
+	}
+	for _, event := range events {
+		if err := recorder.Record(event); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("permissions: got %o, want 600", got)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != len(events) {
+		t.Fatalf("line count: got %d, want %d", len(lines), len(events))
+	}
+	for _, line := range lines {
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("invalid JSON line %q: %v", line, err)
+		}
+		if event.Event != auditEventName {
+			t.Errorf("event: got %q, want %q", event.Event, auditEventName)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("timestamp is zero")
+		}
+	}
+
+	failures := recorder.RecentFailures()
+	if len(failures) != 2 {
+		t.Fatalf("failure count: got %d, want 2", len(failures))
+	}
+	if failures[0].Phase != "rotation" || failures[1].Phase != "refresh" {
+		t.Errorf("failures are not newest-first: %#v", failures)
+	}
+}
+
+func TestRecorderRotatesAndEnforcesBackupLimit(t *testing.T) {
+	baseTime := time.Date(2026, 6, 13, 1, 2, 3, 0, time.UTC)
+	now := baseTime
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := newRecorder(Config{
+		Path:            path,
+		MaxSizeBytes:    180,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 10,
+	}, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newRecorder: %v", err)
+	}
+	defer func() { _ = recorder.Close() }()
+
+	for index := 0; index < 8; index++ {
+		now = now.Add(time.Second)
+		if err := recorder.Record(Event{
+			Phase:    "callback",
+			Provider: "github",
+			Result:   "failure",
+			Message:  strings.Repeat("x", 80),
+		}); err != nil {
+			t.Fatalf("Record %d: %v", index, err)
+		}
+	}
+
+	ext := filepath.Ext(path)
+	stem := strings.TrimSuffix(path, ext)
+	backups, err := filepath.Glob(stem + ".*" + ext)
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(backups) != 2 {
+		t.Fatalf("backup count: got %d, want 2 (%v)", len(backups), backups)
+	}
+}
+
+func TestRecorderRemovesExpiredBackups(t *testing.T) {
+	now := time.Date(2026, 6, 13, 1, 2, 3, 0, time.UTC)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth-audit.jsonl")
+	oldBackup := filepath.Join(dir, "auth-audit.20250101T000000.000000000Z.000.jsonl")
+	if err := os.WriteFile(oldBackup, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	oldTime := now.Add(-48 * time.Hour)
+	if err := os.Chtimes(oldBackup, oldTime, oldTime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	recorder, err := newRecorder(Config{
+		Path:            path,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      5,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 10,
+	}, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newRecorder: %v", err)
+	}
+	defer func() { _ = recorder.Close() }()
+
+	if _, err := os.Stat(oldBackup); !os.IsNotExist(err) {
+		t.Fatalf("expired backup still exists: %v", err)
+	}
+}
+
+func TestRecorderConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := New(Config{
+		Path:            path,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 100,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = recorder.Close() }()
+
+	const writes = 50
+	var wg sync.WaitGroup
+	wg.Add(writes)
+	for index := 0; index < writes; index++ {
+		go func() {
+			defer wg.Done()
+			if err := recorder.Record(Event{
+				Phase:    "authorize",
+				Provider: "github",
+				Result:   "success",
+				Message:  "authorization started",
+			}); err != nil {
+				t.Errorf("Record: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != writes {
+		t.Fatalf("line count: got %d, want %d", len(lines), writes)
+	}
+	for _, line := range lines {
+		if !json.Valid([]byte(line)) {
+			t.Fatalf("invalid JSON line: %q", line)
+		}
+	}
+}
+
+func TestEventCannotSerializeSecretsByConstruction(t *testing.T) {
+	event := Event{
+		Phase:      "callback",
+		Provider:   "github",
+		Result:     "failure",
+		ErrorClass: "provider_rejected",
+		Message:    "provider rejected authorization",
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	for _, forbidden := range []string{"access_token", "refresh_token", "authorization_code", "client_secret", "state"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Errorf("serialized event contains forbidden field %q: %s", forbidden, data)
+		}
+	}
+}

--- a/internal/authaudit/recorder_test.go
+++ b/internal/authaudit/recorder_test.go
@@ -386,6 +386,60 @@ func TestRecorderRotatesAndEnforcesBackupLimit(t *testing.T) {
 	}
 }
 
+func TestRecorderRecoversAfterRotationRenameFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := New(Config{
+		Path:            path,
+		MaxSizeBytes:    1,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 10,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = recorder.Close() }()
+
+	if err := recorder.Record(Event{
+		Phase:    "authorize",
+		Provider: "github",
+		Result:   "success",
+		Message:  "first event",
+	}); err != nil {
+		t.Fatalf("first Record: %v", err)
+	}
+
+	renameCalls := 0
+	recorder.renameFile = func(oldPath, newPath string) error {
+		renameCalls++
+		if renameCalls == 1 {
+			return errors.New("forced rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	err = recorder.Record(Event{
+		Phase:    "callback",
+		Provider: "github",
+		Result:   "failure",
+		Message:  "rotation fails",
+	})
+	if err == nil || !strings.Contains(err.Error(), "forced rename failure") {
+		t.Fatalf("rotation error: got %v", err)
+	}
+	if strings.Contains(err.Error(), "recorder is closed") {
+		t.Fatalf("recorder incorrectly became closed: %v", err)
+	}
+
+	if err := recorder.Record(Event{
+		Phase:    "token_exchange",
+		Provider: "github",
+		Result:   "success",
+		Message:  "recording resumed",
+	}); err != nil {
+		t.Fatalf("Record after recovered rotation: %v", err)
+	}
+}
+
 func TestRecorderRemovesExpiredBackups(t *testing.T) {
 	now := time.Date(2026, 6, 13, 1, 2, 3, 0, time.UTC)
 	dir := t.TempDir()

--- a/internal/authaudit/recorder_test.go
+++ b/internal/authaudit/recorder_test.go
@@ -1,7 +1,9 @@
 package authaudit
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -82,6 +84,31 @@ func TestDefaultPath(t *testing.T) {
 	}
 }
 
+func TestDefaultPathRejectsUnavailableHome(t *testing.T) {
+	cases := []struct {
+		name string
+		goos string
+		home string
+		err  error
+	}{
+		{name: "macOS lookup error", goos: "darwin", err: errors.New("lookup failed")},
+		{name: "macOS empty home", goos: "darwin"},
+		{name: "linux lookup error", goos: "linux", err: errors.New("lookup failed")},
+		{name: "linux empty home", goos: "linux"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := defaultPath(tc.goos, func(string) string { return "" }, func() (string, error) {
+				return tc.home, tc.err
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestResolvePathRejectsRelativeAndGitWorktree(t *testing.T) {
 	if _, err := ResolvePath("logs/auth-audit.jsonl"); err == nil {
 		t.Fatal("expected relative path rejection")
@@ -150,6 +177,59 @@ func TestFromEnvironment(t *testing.T) {
 	}
 }
 
+func TestFromEnvironmentRejectsInvalidRetentionValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	cases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "zero size", key: "MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB", value: "0"},
+		{name: "invalid backups", key: "MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS", value: "many"},
+		{name: "negative age", key: "MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS", value: "-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCP_GATEWAY_AUTH_AUDIT_LOG_PATH", path)
+			t.Setenv(tc.key, tc.value)
+			if _, err := FromEnvironment(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestNewRecorderRejectsInvalidConfig(t *testing.T) {
+	valid := Config{
+		Path:            filepath.Join(t.TempDir(), "auth-audit.jsonl"),
+		MaxSizeBytes:    1,
+		MaxBackups:      1,
+		MaxAge:          time.Hour,
+		FailureCapacity: 1,
+	}
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{name: "relative path", mutate: func(cfg *Config) { cfg.Path = "auth-audit.jsonl" }},
+		{name: "zero max size", mutate: func(cfg *Config) { cfg.MaxSizeBytes = 0 }},
+		{name: "zero backups", mutate: func(cfg *Config) { cfg.MaxBackups = 0 }},
+		{name: "zero max age", mutate: func(cfg *Config) { cfg.MaxAge = 0 }},
+		{name: "zero failure capacity", mutate: func(cfg *Config) { cfg.FailureCapacity = 0 }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := valid
+			tc.mutate(&cfg)
+			if _, err := New(cfg); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
 func TestRecorderWritesJSONLinesAndRecentFailures(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
 	recorder, err := New(Config{
@@ -215,6 +295,55 @@ func TestRecorderWritesJSONLinesAndRecentFailures(t *testing.T) {
 	}
 	if failures[0].Phase != "rotation" || failures[1].Phase != "refresh" {
 		t.Errorf("failures are not newest-first: %#v", failures)
+	}
+}
+
+func TestRecorderPathTimestampAndClosedState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth-audit.jsonl")
+	recorder, err := New(Config{
+		Path:            path,
+		MaxSizeBytes:    1 << 20,
+		MaxBackups:      2,
+		MaxAge:          24 * time.Hour,
+		FailureCapacity: 2,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if recorder.Path() != path {
+		t.Fatalf("Path: got %q, want %q", recorder.Path(), path)
+	}
+
+	timestamp := time.Date(2026, 6, 13, 1, 2, 3, 456, time.FixedZone("test", 9*60*60))
+	if err := recorder.Record(Event{
+		Timestamp: timestamp,
+		Phase:     "authorize",
+		Provider:  "github",
+		Result:    "success",
+		Message:   "authorization started",
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if err := recorder.Record(Event{Result: "success"}); err == nil {
+		t.Fatal("expected closed recorder error")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var event Event
+	if err := json.Unmarshal(bytes.TrimSpace(data), &event); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !event.Timestamp.Equal(timestamp.UTC()) || event.Timestamp.Location() != time.UTC {
+		t.Errorf("timestamp: got %v, want %v", event.Timestamp, timestamp.UTC())
 	}
 }
 

--- a/internal/internalapi/handler.go
+++ b/internal/internalapi/handler.go
@@ -1,12 +1,7 @@
-// Package internalapi implements the Phase B delegated-access PoC endpoints
-// (#72). The handlers in this package serve a loopback-only HTTP listener
-// and let trusted upstream MCP processes fetch the latest valid access
-// token for a known subject without re-doing the OAuth user flow.
-//
-// Trust boundary: the listener MUST bind to a loopback address (127.0.0.1
-// or ::1) and requests MUST present the configured shared secret in the
-// Authorization header. Both controls are enforced; binding to a non-loopback
-// address is a startup error in cmd/server.
+// Package internalapi は delegated access (#72) と認証失敗診断 (#102) の
+// internal endpoint を提供する。loopback listener と shared secret の両方を
+// 必須とし、trusted upstream だけに access token 取得と監査診断を許可する。
+// non-loopback bind は cmd/server の起動時に拒否する。
 package internalapi
 
 import (
@@ -18,10 +13,12 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 )
 
 // MinSecretLength is the smallest acceptable shared secret length.
@@ -40,29 +37,47 @@ type TokenResolver interface {
 	EnsureFreshAccessTokenForSubject(ctx context.Context, subject string) (auth.DelegatedAccessResult, error)
 }
 
+// FailureReader は機密情報除外済みの直近 OAuth 失敗 snapshot を提供する。
+// 実 auth handler は authaudit.FileRecorder へ処理を委譲する。
+type FailureReader interface {
+	RecentAuthFailures() []authaudit.Event
+}
+
 // Handler serves the loopback-only internal API.
 type Handler struct {
 	resolver TokenResolver
+	failures FailureReader
 	secret   string
+}
+
+type HandlerOption func(*Handler)
+
+// WithFailureReader は OAuth 失敗診断 endpoint を有効化する。
+func WithFailureReader(reader FailureReader) HandlerOption {
+	return func(h *Handler) {
+		h.failures = reader
+	}
 }
 
 // NewHandler builds the internal API handler. The secret must be at least
 // MinSecretLength characters; shorter secrets are an error so the caller
 // (cmd/server) can fail closed at startup rather than serving a weak
 // boundary.
-func NewHandler(resolver TokenResolver, secret string) (*Handler, error) {
+func NewHandler(resolver TokenResolver, secret string, opts ...HandlerOption) (*Handler, error) {
 	if resolver == nil {
 		return nil, errors.New("internalapi: resolver must not be nil")
 	}
 	if len(secret) < MinSecretLength {
 		return nil, errors.New("internalapi: shared secret must be at least 32 characters")
 	}
-	return &Handler{resolver: resolver, secret: secret}, nil
+	handler := &Handler{resolver: resolver, secret: secret}
+	for _, opt := range opts {
+		opt(handler)
+	}
+	return handler, nil
 }
 
-// RegisterRoutes wires the internal API onto mux. Currently a single
-// endpoint, but kept as a method so future delegated-access routes can be
-// added without touching the listener wiring.
+// RegisterRoutes は delegated access と認証診断 route を mux へ登録する。
 //
 // We register the route without an HTTP method prefix and check r.Method
 // inside the handler. The Go 1.22+ ServeMux method-matching syntax
@@ -70,6 +85,57 @@ func NewHandler(resolver TokenResolver, secret string) (*Handler, error) {
 // 405, bypassing our JSON error envelope.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/internal/v1/whoami", h.Whoami)
+	mux.HandleFunc("/internal/v1/auth/failures", h.AuthFailures)
+}
+
+type authFailuresResponse struct {
+	Failures []authaudit.Event `json:"failures"`
+}
+
+// AuthFailures は直近の OAuth 失敗を最新順で返す。
+// delegated access と同じ loopback + pre-shared-secret 境界を使用する。
+func (h *Handler) AuthFailures(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+	if !isLoopback(r.RemoteAddr) {
+		writeError(w, http.StatusForbidden, "loopback_required")
+		return
+	}
+	if !h.checkAuth(r) {
+		writeError(w, http.StatusUnauthorized, "invalid_authorization")
+		return
+	}
+	if h.failures == nil {
+		writeError(w, http.StatusServiceUnavailable, "diagnostics_unavailable")
+		return
+	}
+
+	limit := authaudit.DefaultFailureLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > authaudit.DefaultFailureLimit {
+			writeError(w, http.StatusBadRequest, "invalid_limit")
+			return
+		}
+		limit = parsed
+	}
+	failures := h.failures.RecentAuthFailures()
+	if len(failures) > limit {
+		failures = failures[:limit]
+	}
+	if failures == nil {
+		failures = []authaudit.Event{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	if err := json.NewEncoder(w).Encode(authFailuresResponse{Failures: failures}); err != nil {
+		slog.Warn("internalapi: auth failures response encode failed", "err", err)
+	}
 }
 
 // whoamiRequest is the body shape for POST /internal/v1/whoami.

--- a/internal/internalapi/handler_test.go
+++ b/internal/internalapi/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/authaudit"
 )
 
 const testSecret = "test-secret-32-characters-long-aaa"
@@ -25,6 +26,14 @@ type fakeResolver struct {
 
 	gotSubject string
 	calls      int
+}
+
+type fakeFailureReader struct {
+	failures []authaudit.Event
+}
+
+func (f *fakeFailureReader) RecentAuthFailures() []authaudit.Event {
+	return append([]authaudit.Event(nil), f.failures...)
 }
 
 func (f *fakeResolver) EnsureFreshAccessTokenForSubject(_ context.Context, subject string) (auth.DelegatedAccessResult, error) {
@@ -337,6 +346,152 @@ func TestWhoamiNonLoopbackRejected(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status: got %d want 403", rr.Code)
 	}
+}
+
+func TestAuthFailures(t *testing.T) {
+	reader := &fakeFailureReader{failures: []authaudit.Event{
+		{
+			Timestamp:  time.Date(2026, 6, 13, 1, 2, 3, 0, time.UTC),
+			Event:      "oauth_audit",
+			Phase:      "rotation",
+			Provider:   "github",
+			Result:     "failure",
+			ErrorClass: "provider_rejected",
+			OAuthError: "bad_refresh_token",
+			Message:    "provider token rotation rejected",
+			TokenHash:  "12345678",
+		},
+		{
+			Timestamp:  time.Date(2026, 6, 13, 1, 1, 3, 0, time.UTC),
+			Event:      "oauth_audit",
+			Phase:      "callback",
+			Provider:   "oidc",
+			Result:     "failure",
+			ErrorClass: "access_denied",
+			OAuthError: "access_denied",
+			Message:    "provider authorization callback rejected",
+		},
+	}}
+	h, err := NewHandler(&fakeResolver{}, testSecret, WithFailureReader(reader))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/internal/v1/auth/failures?limit=1", nil)
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	var payload struct {
+		Failures []authaudit.Event `json:"failures"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(payload.Failures) != 1 {
+		t.Fatalf("failure count: got %d, want 1", len(payload.Failures))
+	}
+	if payload.Failures[0].OAuthError != "bad_refresh_token" {
+		t.Errorf("oauth_error: got %q", payload.Failures[0].OAuthError)
+	}
+	if strings.Contains(mustJSON(t, payload), `"refresh_token":`) {
+		t.Fatal("diagnostic response contains a raw refresh_token field")
+	}
+}
+
+func TestAuthFailuresErrors(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		auth       string
+		target     string
+		withReader bool
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "method rejected",
+			method:     http.MethodPost,
+			auth:       "Bearer " + testSecret,
+			target:     "/internal/v1/auth/failures",
+			withReader: true,
+			wantStatus: http.StatusMethodNotAllowed,
+			wantError:  "method_not_allowed",
+		},
+		{
+			name:       "authorization required",
+			method:     http.MethodGet,
+			target:     "/internal/v1/auth/failures",
+			withReader: true,
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "invalid_authorization",
+		},
+		{
+			name:       "reader unavailable",
+			method:     http.MethodGet,
+			auth:       "Bearer " + testSecret,
+			target:     "/internal/v1/auth/failures",
+			wantStatus: http.StatusServiceUnavailable,
+			wantError:  "diagnostics_unavailable",
+		},
+		{
+			name:       "limit rejected",
+			method:     http.MethodGet,
+			auth:       "Bearer " + testSecret,
+			target:     "/internal/v1/auth/failures?limit=101",
+			withReader: true,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "invalid_limit",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var opts []HandlerOption
+			if tc.withReader {
+				opts = append(opts, WithFailureReader(&fakeFailureReader{}))
+			}
+			h, err := NewHandler(&fakeResolver{}, testSecret, opts...)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+			req := httptest.NewRequest(tc.method, tc.target, nil)
+			req.RemoteAddr = "127.0.0.1:1234"
+			if tc.auth != "" {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			rec := httptest.NewRecorder()
+			h.AuthFailures(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", rec.Code, tc.wantStatus)
+			}
+			var envelope map[string]string
+			if err := json.NewDecoder(rec.Body).Decode(&envelope); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if envelope["error"] != tc.wantError {
+				t.Errorf("error: got %q, want %q", envelope["error"], tc.wantError)
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return string(data)
 }
 
 // doWhoami issues a properly authenticated POST request. It centralizes

--- a/internal/internalapi/handler_test.go
+++ b/internal/internalapi/handler_test.go
@@ -429,6 +429,15 @@ func TestAuthFailuresErrors(t *testing.T) {
 			wantError:  "method_not_allowed",
 		},
 		{
+			name:       "loopback required",
+			method:     http.MethodGet,
+			auth:       "Bearer " + testSecret,
+			target:     "/internal/v1/auth/failures",
+			withReader: true,
+			wantStatus: http.StatusForbidden,
+			wantError:  "loopback_required",
+		},
+		{
 			name:       "authorization required",
 			method:     http.MethodGet,
 			target:     "/internal/v1/auth/failures",
@@ -465,7 +474,11 @@ func TestAuthFailuresErrors(t *testing.T) {
 				t.Fatalf("NewHandler: %v", err)
 			}
 			req := httptest.NewRequest(tc.method, tc.target, nil)
-			req.RemoteAddr = "127.0.0.1:1234"
+			if tc.name == "loopback required" {
+				req.RemoteAddr = "10.20.30.40:1234"
+			} else {
+				req.RemoteAddr = "127.0.0.1:1234"
+			}
 			if tc.auth != "" {
 				req.Header.Set("Authorization", tc.auth)
 			}
@@ -482,6 +495,30 @@ func TestAuthFailuresErrors(t *testing.T) {
 				t.Errorf("error: got %q, want %q", envelope["error"], tc.wantError)
 			}
 		})
+	}
+}
+
+func TestAuthFailuresEmptyResponse(t *testing.T) {
+	h, err := NewHandler(&fakeResolver{}, testSecret, WithFailureReader(&fakeFailureReader{}))
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/auth/failures", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	rec := httptest.NewRecorder()
+
+	h.AuthFailures(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"failures":[]}` {
+		t.Fatalf("body: got %s", got)
+	}
+	if rec.Header().Get("Cache-Control") != "no-store" || rec.Header().Get("Pragma") != "no-cache" {
+		t.Errorf("cache headers: got Cache-Control=%q Pragma=%q",
+			rec.Header().Get("Cache-Control"), rec.Header().Get("Pragma"))
 	}
 }
 

--- a/tasks.md
+++ b/tasks.md
@@ -13,6 +13,24 @@
 
 ---
 
+## Issue #102 — OAuth 認証監査ログの永続化・ローテーション・診断機能
+
+**目的**: OAuth 認証フローの成否と失敗原因を、リポジトリ外の機械可読な監査ログと internal API から事後解析可能にする。
+
+### サブタスク
+
+- [x] `internal/authaudit` に OS 別の外部保存 path 解決と Git worktree 配下拒否を実装
+- [x] JSON Lines、10 MiB、5世代、30日保持のローテーションを実装
+- [x] provider の OAuth エラーを型付き化し、`oauth_error` と HTTP status を安全に抽出
+- [x] authorize / callback / token exchange / identity resolution / refresh / rotation の監査イベントを追加
+- [x] 直近100件の失敗を保持し、`GET /internal/v1/auth/failures` から参照可能にする
+- [x] 公式 container image の `XDG_STATE_HOME` を `/data` に設定し、既定 path を `/data/mcp-gateway/logs/auth-audit.jsonl` に解決
+- [x] 機密情報除外、ローテーション境界、保持数・日数、並行書き込み、診断 API のテストを追加
+- [x] `README.md` / `README.ja.md` / `docs/configuration.md` / `docs/operations.md` を更新
+- [x] `CHANGELOG.md` / `CHANGELOG.ja.md` の `Unreleased` を更新
+
+---
+
 ## Issue #100 — redirect_uri 許可ホストに設定経路がなく agy 認証が失敗する
 
 **目的**: agy（Antigravity）からの OAuth 認証が許可リスト制限で失敗する問題を解消するため、ホスト許可リストの設定手段（環境変数および config.yaml）を追加し、デフォルト許可ホストに `antigravity.google` を加える。


### PR DESCRIPTION
## 概要

ISSUE #102 の OAuth 認証監査・診断機能を実装します。

## 変更内容

- authorize / callback / token exchange / identity resolution / refresh / provider rotation を共通 schema の監査イベントとして記録
- OS のユーザー state 領域へ JSON Lines を永続化し、サイズ・世代数・保持日数でローテーション
- 相対 path、Git worktree 配下、symlink 経由の worktree 内保存を拒否
- provider OAuth error を型付き化し、`oauth_error` / HTTP status / transient 判定を安全に抽出
- loopback + shared secret internal API に `GET /internal/v1/auth/failures` を追加
- 公式 container image で `XDG_STATE_HOME=/data` を設定
- 機密情報除外、並行書き込み、ローテーション、診断 API の回帰テストを追加

## 影響

ネイティブ実行では Windows / Linux / macOS のユーザー領域へ保存します。公式 container image では `/data/mcp-gateway/logs/auth-audit.jsonl` を使用し、`/data` volume を mount すると再作成後も保持できます。

## 検証

- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build ./cmd/server`
- Docker image build
- compose なしの container で `/health` 200、`/authorize` 302、監査 JSONL 出力を確認

`go test -race` は Windows 環境に C compiler がないためローカル未実行です。Linux CI の race job で確認します。

Closes #102