### PR TITLE
docs(changelog): add entry for routing prefix stripping fix (#108)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -17,6 +17,9 @@
 
 ### 修正
 
+- upstream 転送時にルーティングプレフィックスをストリップする機能を追加（[#108](https://github.com/scottlz0310/mcp-gateway/issues/108)）
+  - `github-mcp-server` や `playwright-mcp` などパスを厳格に検証する MCP サーバーで発生していた `405 Method Not Allowed` を解消するため、プロキシ転送前にルーティングプレフィックス（例: `/mcp/github`）をリクエストパスから除去するよう修正
+  - upstream にベースパスがある場合（例: `https://mcp.cloudflare.com/mcp`）も正しくパスが結合されるよう、`SetURL` の呼び出し前にプレフィックスを除去する実装に変更
 - github-mcp-server プロキシ時の認証失敗を修正（[#104](https://github.com/scottlz0310/mcp-gateway/pull/104)）
   - docker-compose.yml で mcp-gateway の環境変数に `GITHUB_PERSONAL_ACCESS_TOKEN` を追加
   - `/mcp/github` ルートに `upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN` を指定し、クライアント側のトークン期限切れが github-mcp-server に伝播して認証エラーになる問題を解消

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Strip routing prefix before forwarding to upstream ([#108](https://github.com/scottlz0310/mcp-gateway/issues/108))
+  - Routing prefix (e.g. `/mcp/github`) is now stripped from the request path before proxying to prevent `405 Method Not Allowed` errors on path-strict MCP servers such as `github-mcp-server` and `playwright-mcp`
+  - Prefix is stripped before `SetURL` so that upstream base paths (e.g. `https://mcp.cloudflare.com/mcp`) are correctly joined with the stripped path
 - Fix proxy authentication failure for github-mcp-server ([#104](https://github.com/scottlz0310/mcp-gateway/pull/104))
   - Pass `GITHUB_PERSONAL_ACCESS_TOKEN` to mcp-gateway environment in docker-compose.yml
   - Configure `/mcp/github` route with `upstream_bearer_token_env=GITHUB_PERSONAL_ACCESS_TOKEN` to prevent client token expiration from leaking to the github-mcp-server upstream


### PR DESCRIPTION
## Summary

- CHANGELOG の `[Unreleased] > Fixed` に #108 のエントリを追加

本来 #109 の PR ブランチ内に含めるべきでしたが、マージ後に対応する手順の誤りがあったため、本 PR で補完します。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)