### PR TITLE
[codex] exact-prefix の upstream base path を保持する

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -17,6 +17,7 @@
 
 ### 修正
 
+- exact-prefix リクエストで upstream のベースパスに末尾スラッシュを付与せず、そのまま転送するよう修正（[#111](https://github.com/scottlz0310/mcp-gateway/issues/111)）
 - upstream 転送時にルーティングプレフィックスをストリップする機能を追加（[#108](https://github.com/scottlz0310/mcp-gateway/issues/108)）
   - `github-mcp-server` や `playwright-mcp` などパスを厳格に検証する MCP サーバーで発生していた `405 Method Not Allowed` を解消するため、プロキシ転送前にルーティングプレフィックス（例: `/mcp/github`）をリクエストパスから除去するよう修正
   - upstream にベースパスがある場合（例: `https://mcp.cloudflare.com/mcp`）も正しくパスが結合されるよう、`SetURL` の呼び出し前にプレフィックスを除去する実装に変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Preserve an upstream base path without adding a trailing slash for exact-prefix requests ([#111](https://github.com/scottlz0310/mcp-gateway/issues/111))
 - Strip routing prefix before forwarding to upstream ([#108](https://github.com/scottlz0310/mcp-gateway/issues/108))
   - Routing prefix (e.g. `/mcp/github`) is now stripped from the request path before proxying to prevent `405 Method Not Allowed` errors on path-strict MCP servers such as `github-mcp-server` and `playwright-mcp`
   - Prefix is stripped before `SetURL` so that upstream base paths (e.g. `https://mcp.cloudflare.com/mcp`) are correctly joined with the stripped path

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -35,9 +35,11 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			// Strip prefix before SetURL so that SetURL correctly joins
 			// upstream.Path + stripped_path (SetURL appends pr.Out.URL.Path).
+			exactPrefix := false
 			if prefix != "" && prefix != "/" {
 				stripped := strings.TrimPrefix(pr.Out.URL.Path, prefix)
 				if stripped == "" {
+					exactPrefix = true
 					stripped = "/"
 				}
 				pr.Out.URL.Path = stripped
@@ -51,6 +53,12 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 			}
 
 			pr.SetURL(upstream)
+			if exactPrefix && upstream.Path != "" {
+				// SetURL appends "/" when joining a non-empty base path with
+				// the exact route prefix. Preserve the configured base path.
+				pr.Out.URL.Path = upstream.Path
+				pr.Out.URL.RawPath = upstream.RawPath
+			}
 
 			pr.Out.Header.Del("X-Forwarded-For")
 			pr.Out.Header.Del("X-Real-Ip")

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -366,40 +366,59 @@ func TestProxyStripsRoutingPrefix(t *testing.T) {
 // own base, not the full gateway path.
 func TestProxyStripsRoutingPrefixWithUpstreamBasePath(t *testing.T) {
 	tests := []struct {
-		name         string
-		prefix       string
-		upstreamBase string // path suffix added to httptest server URL
-		requestPath  string
-		wantPath     string
+		name          string
+		prefix        string
+		upstreamBase  string // path suffix added to httptest server URL
+		requestTarget string
+		wantPath      string
+		wantRawPath   string
+		wantRawQuery  string
 	}{
 		{
-			name:         "upstream with base path: prefix stripped then base prepended",
-			prefix:       "/mcp/cloudflare",
-			upstreamBase: "/mcp",
-			requestPath:  "/mcp/cloudflare/sse",
-			wantPath:     "/mcp/sse",
+			name:          "upstream with base path: prefix stripped then base prepended",
+			prefix:        "/mcp/cloudflare",
+			upstreamBase:  "/mcp",
+			requestTarget: "/mcp/cloudflare/sse",
+			wantPath:      "/mcp/sse",
 		},
 		{
-			name:         "upstream with base path: prefix stripped to root",
-			prefix:       "/mcp/cloudflare",
-			upstreamBase: "/mcp",
-			requestPath:  "/mcp/cloudflare",
-			wantPath:     "/mcp/",
+			name:          "upstream with base path: exact prefix preserves base path",
+			prefix:        "/mcp/cloudflare",
+			upstreamBase:  "/mcp",
+			requestTarget: "/mcp/cloudflare",
+			wantPath:      "/mcp",
 		},
 		{
-			name:         "upstream with base path: no prefix leaves path intact",
-			prefix:       "",
-			upstreamBase: "/mcp",
-			requestPath:  "/mcp/cloudflare/sse",
-			wantPath:     "/mcp/mcp/cloudflare/sse",
+			name:          "upstream without base path: exact prefix becomes root",
+			prefix:        "/mcp/github",
+			requestTarget: "/mcp/github",
+			wantPath:      "/",
+		},
+		{
+			name:          "exact prefix preserves upstream raw path and request query",
+			prefix:        "/mcp/cloudflare",
+			upstreamBase:  "/mcp%2Fv1",
+			requestTarget: "/mcp/cloudflare?session=abc",
+			wantPath:      "/mcp/v1",
+			wantRawPath:   "/mcp%2Fv1",
+			wantRawQuery:  "session=abc",
+		},
+		{
+			name:          "upstream with base path: no prefix leaves path intact",
+			prefix:        "",
+			upstreamBase:  "/mcp",
+			requestTarget: "/mcp/cloudflare/sse",
+			wantPath:      "/mcp/mcp/cloudflare/sse",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotPath string
+			var gotPath, gotRawPath, gotRawQuery string
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotPath = r.URL.Path
+				gotRawPath = r.URL.RawPath
+				gotRawQuery = r.URL.RawQuery
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer upstream.Close()
@@ -407,7 +426,7 @@ func TestProxyStripsRoutingPrefixWithUpstreamBasePath(t *testing.T) {
 			u, _ := url.Parse(upstream.URL + tc.upstreamBase)
 			h := NewHandler(u, &mockInvalidator{}, "", tc.prefix)
 
-			r := httptest.NewRequest(http.MethodGet, tc.requestPath, nil)
+			r := httptest.NewRequest(http.MethodGet, tc.requestTarget, nil)
 			ctx := context.WithValue(r.Context(), middleware.ContextKeyIdentity, "alice")
 			ctx = context.WithValue(ctx, middleware.ContextKeyToken, "tok")
 			r = r.WithContext(ctx)
@@ -417,6 +436,12 @@ func TestProxyStripsRoutingPrefixWithUpstreamBasePath(t *testing.T) {
 
 			if gotPath != tc.wantPath {
 				t.Errorf("upstream path: got %q, want %q", gotPath, tc.wantPath)
+			}
+			if gotRawPath != tc.wantRawPath {
+				t.Errorf("upstream raw path: got %q, want %q", gotRawPath, tc.wantRawPath)
+			}
+			if gotRawQuery != tc.wantRawQuery {
+				t.Errorf("upstream raw query: got %q, want %q", gotRawQuery, tc.wantRawQuery)
 			}
 		})
 	}


### PR DESCRIPTION
## 概要

exact-prefix リクエストを upstream base path へ転送する際、意図しない末尾スラッシュを付与しないよう修正します。

Closes #111

## 原因

route prefix の除去後に空パスを `/` へ変換して `ProxyRequest.SetURL` に渡していたため、upstream base path `/mcp` と結合されて `/mcp/` になっていました。

## 変更内容

- exact-prefix かつ upstream base path がある場合、`SetURL` 後に明示された upstream `Path` / `RawPath` を保持
- upstream base path がない exact-prefix は従来どおり `/` へ転送
- subpath、query、encoded `RawPath` の回帰テストを追加
- `CHANGELOG.md` / `CHANGELOG.ja.md` を更新

## 影響

`/mcp/thread-owl` のような exact-prefix は upstream `/mcp` に転送されます。`/mcp/thread-owl/foo` は従来どおり `/mcp/foo` に転送され、root upstream の `github-mcp-server` / `playwright-mcp` 向け挙動も維持されます。

## 検証

- `golangci-lint run ./...`
- `go vet ./...`
- `go test ./...`
- `govulncheck ./...`
- `go build ./cmd/server`
- lefthook pre-commit / pre-push