### PR TITLE
feat(auth): RFC 8252 custom URL scheme redirect_uri support

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -14,6 +14,10 @@
 - OIDC プロバイダーのサポートを追加（[#98](https://github.com/scottlz0310/mcp-gateway/pull/98)）
   - agy CLI をサポートするため、mcp-gateway を OIDC Identity Provider として動作可能に
   - OIDC 用の RSA 秘密鍵の永続化をサポート
+- RFC 8252 カスタム URL スキーム redirect_uri のサポートを追加（[#121](https://github.com/scottlz0310/mcp-gateway/issues/121)）
+  - agy CLI 等のネイティブアプリクライアントが `antigravity://oauth-callback` 等のカスタム URL スキームを redirect_uri として使用可能に
+  - デフォルト許可スキーム: `antigravity`、`antigravity-insiders`
+  - `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` 環境変数または `gateway.allowed_redirect_schemes`（config.yaml）で上書き可能
 
 ### 修正
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Add OIDC provider support ([#98](https://github.com/scottlz0310/mcp-gateway/pull/98))
   - Support mcp-gateway as an OIDC Identity Provider to support agy CLI
   - Support OIDC RSA private key persistence
+- Add RFC 8252 custom URL scheme redirect_uri support ([#121](https://github.com/scottlz0310/mcp-gateway/issues/121))
+  - Allow native app clients (e.g. agy CLI) to use custom URL scheme redirect_uris such as `antigravity://oauth-callback`
+  - Default permitted schemes: `antigravity`, `antigravity-insiders`
+  - Configurable via `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` env var or `gateway.allowed_redirect_schemes` in `config.yaml`
 
 ### Fixed
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -132,6 +132,9 @@ func main() {
 	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")) == "" && len(appCfg.Gateway.AllowedRedirectHosts) > 0 {
 		cfg.allowedRedirectHosts = appCfg.Gateway.AllowedRedirectHosts
 	}
+	if strings.TrimSpace(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES")) == "" && len(appCfg.Gateway.AllowedRedirectSchemes) > 0 {
+		cfg.allowedRedirectSchemes = appCfg.Gateway.AllowedRedirectSchemes
+	}
 	// Apply config.yaml OAuth provider overrides
 	if strings.TrimSpace(os.Getenv("OAUTH_PROVIDER")) == "" && strings.TrimSpace(appCfg.Auth.Provider) != "" {
 		cfg.oauthProvider = appCfg.Auth.Provider
@@ -250,7 +253,8 @@ func main() {
 		TokenAudienceStrict:  cfg.tokenAudienceStrict,
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
 		OIDCPrivateKey:       oidcPrivateKey,
-		AllowedRedirectHosts: cfg.allowedRedirectHosts,
+		AllowedRedirectHosts:   cfg.allowedRedirectHosts,
+		AllowedRedirectSchemes: cfg.allowedRedirectSchemes,
 	}, prov, auth.WithAuditRecorder(auditRecorder))
 	if err != nil {
 		slog.Error("auth handler init failed", "err", err)
@@ -425,7 +429,8 @@ type config struct {
 	tokenStorePath       string
 	keyPath              string
 	configPath           string
-	allowedRedirectHosts []string
+	allowedRedirectHosts   []string
+	allowedRedirectSchemes []string
 }
 
 func loadConfig() config {
@@ -468,7 +473,8 @@ func loadConfig() config {
 		tokenStorePath:       lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", "/data/tokens.json"),
 		keyPath:              getEnv("MCP_GATEWAY_KEY_PATH", "./gateway.key"),
 		configPath:           getEnv("MCP_CONFIG_FILE", "./config.yaml"),
-		allowedRedirectHosts: splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
+		allowedRedirectHosts:   splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
+		allowedRedirectSchemes: splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES")),
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ Configuration is resolved in this order:
 | Token audience strict mode | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` > `gateway.token_audience_strict` > `false` |
 | GitHub refresh token rotation | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` > `gateway.github_refresh_enabled` > `false` |
 | Allowed redirect hosts | `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` > `gateway.allowed_redirect_hosts` > `localhost, 127.0.0.1, vscode.dev, antigravity.google` (default) |
+| Allowed redirect schemes | `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` > `gateway.allowed_redirect_schemes` > `antigravity, antigravity-insiders` (default) |
 
 The OAuth client secret is intentionally special: once `config.yaml` contains a
 secret, `OAUTH_CLIENT_SECRET` / `GITHUB_MCP_CLIENT_SECRET` are ignored except
@@ -74,6 +75,7 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
 | `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub OAuth user access tokens. Safe to leave on with non-expiring OAuth Apps; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
 | `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
+| `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` | none | Comma-separated list of custom URL schemes (RFC 8252) permitted in OAuth redirect_uris in addition to `http` and `https`. When set, replaces the built-in default list entirely. Defaults to `antigravity,antigravity-insiders`. |
 | `LOG_LEVEL` | `info` | JSON log level: `debug`, `info`, `warn`, or `error`. |
 | `SESSION_TTL_MIN` | `10` | OAuth authorization session lifetime in minutes. |
 | `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
@@ -137,6 +139,7 @@ setup:
 | `gateway.token_audience_strict` | Strict legacy-token audience enforcement. |
 | `gateway.github_refresh_enabled` | Enable transparent GitHub OAuth access token rotation; see [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
 | `gateway.allowed_redirect_hosts` | YAML list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
+| `gateway.allowed_redirect_schemes` | YAML list of custom URL schemes (RFC 8252) permitted in OAuth redirect_uris in addition to `http` and `https`. When set, replaces the built-in default list entirely. Defaults to `["antigravity", "antigravity-insiders"]`. |
 | `routes[].name` | Route name. Must be non-empty. |
 | `routes[].prefix` | URL path prefix. Must start with `/`; trailing slashes are trimmed except for `/`. |
 | `routes[].upstream` | Absolute `http` or `https` upstream URL. |

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -68,6 +68,10 @@ type Config struct {
 	// AllowedAudiences is the set of RFC 8707 resource indicator values accepted
 	// by this gateway. BaseURL is always allowed.
 	AllowedAudiences []string
+	// AllowedRedirectSchemes is the set of custom URL schemes (RFC 8252) permitted
+	// as redirect_uri in addition to http and https. When empty, defaults to
+	// ["antigravity", "antigravity-insiders"]. Set explicitly to override.
+	AllowedRedirectSchemes []string
 	// TokenAudienceStrict rejects tokens without audience metadata. The default
 	// false value is a grace mode for tokens issued before this metadata existed.
 	TokenAudienceStrict bool
@@ -135,6 +139,9 @@ func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handle
 	cfg.AllowedAudiences = normalizeAllowedAudiences(cfg.BaseURL, cfg.AllowedAudiences)
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev", "antigravity.google"}
+	}
+	if len(cfg.AllowedRedirectSchemes) == 0 {
+		cfg.AllowedRedirectSchemes = []string{"antigravity", "antigravity-insiders"}
 	}
 	if cfg.ExpiresIn <= 0 {
 		cfg.ExpiresIn = 90 * 24 * time.Hour
@@ -392,18 +399,25 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsedRedirect, err := url.Parse(redirectURI)
-	if err != nil ||
-		(parsedRedirect.Scheme != "http" && parsedRedirect.Scheme != "https") ||
-		parsedRedirect.Host == "" ||
-		parsedRedirect.Fragment != "" {
+	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Host == "" || parsedRedirect.Fragment != "" {
 		h.auditFailure("authorize", "invalid_request", "authorization redirect URI rejected", err, http.StatusBadRequest, "")
-		oauthError(w, "invalid_request", "invalid redirect_uri: must be absolute http/https URL without fragment", http.StatusBadRequest)
+		oauthError(w, "invalid_request", "invalid redirect_uri: must be an absolute URI without fragment", http.StatusBadRequest)
 		return
 	}
-	if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
-		h.auditFailure("authorize", "invalid_request", "authorization redirect host rejected", nil, http.StatusBadRequest, "")
-		oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
-		return
+	switch parsedRedirect.Scheme {
+	case "http", "https":
+		if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
+			h.auditFailure("authorize", "invalid_request", "authorization redirect host rejected", nil, http.StatusBadRequest, "")
+			oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
+			return
+		}
+	default:
+		// RFC 8252: custom URL scheme for native apps (e.g. antigravity://oauth-callback)
+		if !isAllowedRedirectScheme(parsedRedirect.Scheme, h.cfg.AllowedRedirectSchemes) {
+			h.auditFailure("authorize", "invalid_request", "authorization redirect scheme rejected", nil, http.StatusBadRequest, "")
+			oauthError(w, "invalid_request", "redirect_uri scheme not permitted", http.StatusBadRequest)
+			return
+		}
 	}
 
 	h.store.SaveSession(state, redirectURI, codeChallenge, audience)
@@ -1497,6 +1511,10 @@ func tokenFingerprint(token string) string {
 
 func isAllowedRedirectHost(hostname string, allowed []string) bool {
 	return slices.Contains(allowed, hostname)
+}
+
+func isAllowedRedirectScheme(scheme string, allowed []string) bool {
+	return slices.Contains(allowed, scheme)
 }
 
 // joinScopes serializes the provider's scope slice for OAuth token responses.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2527,3 +2527,100 @@ func TestNewHandler_OIDCPrivateKey(t *testing.T) {
 		t.Error("expected Handler to generate a random key when OIDCPrivateKey is nil")
 	}
 }
+
+func TestAuthorizeCustomSchemeRedirectURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		redirectURI string
+		schemes     []string // nil = use default
+		wantStatus  int
+	}{
+		{
+			name:        "antigravity scheme accepted by default",
+			redirectURI: "antigravity://oauth-callback",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "antigravity-insiders scheme accepted by default",
+			redirectURI: "antigravity-insiders://oauth-callback",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "unknown custom scheme rejected",
+			redirectURI: "myapp://callback",
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "custom scheme allowed when explicitly configured",
+			redirectURI: "myapp://callback",
+			schemes:     []string{"myapp"},
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "http scheme still works",
+			redirectURI: "http://localhost/callback",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "https scheme still works",
+			redirectURI: "https://antigravity.google/oauth-callback",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "custom scheme with explicit empty list rejects antigravity",
+			redirectURI: "antigravity://oauth-callback",
+			schemes:     []string{"other"},
+			wantStatus:  http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := provider.NewGitHub(provider.GitHubConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURI:  "http://localhost:8080/callback",
+				Scopes:       "repo,user",
+			})
+			cfg := Config{
+				BaseURL:    "http://localhost:8080",
+				SessionTTL: 10 * time.Minute,
+				CacheTTL:   5 * time.Minute,
+				ExpiresIn:  90 * 24 * time.Hour,
+			}
+			if tc.schemes != nil {
+				cfg.AllowedRedirectSchemes = tc.schemes
+			}
+			h, err := NewHandler(cfg, p)
+			if err != nil {
+				t.Fatalf("NewHandler: %v", err)
+			}
+
+			r := httptest.NewRequest(http.MethodGet, "/authorize?response_type=code&state=teststate&redirect_uri="+url.QueryEscape(tc.redirectURI), nil)
+			w := httptest.NewRecorder()
+			h.Authorize(w, r)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d; body: %s", w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAuthorizeCustomSchemeDefaultSchemes(t *testing.T) {
+	h := newTestHandler(t)
+
+	// デフォルトの AllowedRedirectSchemes が正しく設定されているか検証
+	wantSchemes := []string{"antigravity", "antigravity-insiders"}
+	for _, scheme := range wantSchemes {
+		t.Run("default includes "+scheme, func(t *testing.T) {
+			redirectURI := scheme + "://oauth-callback"
+			r := httptest.NewRequest(http.MethodGet, "/authorize?response_type=code&state=s&redirect_uri="+url.QueryEscape(redirectURI), nil)
+			w := httptest.NewRecorder()
+			h.Authorize(w, r)
+			if w.Code != http.StatusFound {
+				t.Errorf("scheme %q should be accepted by default, got status %d", scheme, w.Code)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,11 @@ type GatewayConfig struct {
 	// When set, replaces the built-in default list entirely.
 	// Defaults to ["localhost", "127.0.0.1", "vscode.dev", "antigravity.google"].
 	AllowedRedirectHosts []string `yaml:"allowed_redirect_hosts,omitempty"`
+	// AllowedRedirectSchemes lists custom URL schemes (RFC 8252) permitted in
+	// OAuth redirect_uris in addition to http and https. When set, replaces the
+	// built-in default list entirely.
+	// Defaults to ["antigravity", "antigravity-insiders"].
+	AllowedRedirectSchemes []string `yaml:"allowed_redirect_schemes,omitempty"`
 }
 
 // LoadConfig reads AppConfig from path.


### PR DESCRIPTION
## Summary

- OAuth `/authorize` エンドポイントが `antigravity://oauth-callback` 等のカスタム URL スキームを redirect_uri として受け入れるようにした（RFC 8252 準拠）
- デフォルト許可スキーム: `antigravity`, `antigravity-insiders`
- `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` 環境変数または `gateway.allowed_redirect_schemes`（config.yaml）で上書き可能
- `docs/configuration.md` に新設定項目のドキュメントを追加

## Background

ISSUE #119 スパイクにより、agy CLI が `antigravity://oauth-callback` を redirect_uri に指定するが、gateway が `http`/`https` 以外のスキームを拒否するため OOB フォールバックに落ちて `state` パラメータが消失することが判明した。本PRでその根本原因を修正する。

## Test plan

- [x] `TestAuthorizeCustomSchemeRedirectURI` — 7ケースのテーブル駆動テスト（デフォルト許可・拒否・明示設定）
- [x] `TestAuthorizeCustomSchemeDefaultSchemes` — デフォルトスキームリストの検証
- [x] `go test ./internal/auth/...` — 全テスト通過
- [x] `go build ./...` — ビルド成功
- [x] pre-push フック（build / test / lint）— 全パス

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)