### PR TITLE
feat(auth): OAUTH_PROVIDER=builtin — GitHub social login with gateway-issued RS256 JWT (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add `OAUTH_PROVIDER=builtin` mode: GitHub OAuth 2.0 PKCE social login with gateway-issued RS256 JWT ([#127](https://github.com/scottlz0310/mcp-gateway/issues/127))
+  - gateway が自身の RS256 JWT（access_token + id_token + refresh_token）を発行する
+  - GitHub は identity 取得のみに使用し、GitHub access_token はクライアントに渡さず callback 後に破棄する
+  - `/token`（authorization_code grant）でゲートウェイ署名付き JWT を発行
+  - `/token`（refresh_token grant）でゲートウェイ JWT を再発行（GitHub API 不要）
+  - `ValidateToken` でゲートウェイ JWT をローカルで RS256 検証（GitHub API 呼び出し不要）
+  - 既存の `OAUTH_PROVIDER=github` モードとの並存を維持
 - Add persistent OAuth audit diagnostics ([#102](https://github.com/scottlz0310/mcp-gateway/issues/102))
   - Record authorize, callback, token exchange, identity resolution, refresh, and provider rotation outcomes as structured events
   - Persist redacted JSON Lines outside Git worktrees with OS-specific user-state defaults and size/age/count rotation

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -534,6 +534,28 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		oauthError(w, "invalid_grant", err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	if h.isBuiltinMode() {
+		// builtin mode: discard GitHub access token, issue gateway-signed JWT instead.
+		// GitHub token was used only for identity resolution in Callback(); it must not
+		// reach the client.
+		gatewayToken, genErr := h.generateGatewayAccessToken(result.Subject, result.Audience)
+		if genErr != nil {
+			h.auditFailure("token_exchange", "server_error", "gateway access token generation failed", genErr, http.StatusInternalServerError, "")
+			slog.Error("gateway access token generation failed", "err", genErr)
+			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
+			return
+		}
+		h.store.CacheToken(gatewayToken, result.Subject, result.Audience)
+		refreshToken, rtErr := h.store.CreateRefreshToken(gatewayToken, result.Audience, h.refreshTokenTTL())
+		if rtErr != nil {
+			slog.Warn("failed to create refresh token", "err", rtErr)
+		}
+		h.writeTokenResponse(w, gatewayToken, result.Scope, refreshToken, result.Subject)
+		h.auditSuccess("token_exchange", "authorization code exchange completed (builtin)", http.StatusOK)
+		return
+	}
+
 	h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
 	h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
 	refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
@@ -690,7 +712,7 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refres
 	if refreshToken != "" {
 		resp["refresh_token"] = refreshToken
 	}
-	if subject != "" && (strings.Contains(scope, "openid") || h.provider.Name() == "oidc") {
+	if subject != "" && (strings.Contains(scope, "openid") || h.provider.Name() == "oidc" || h.isBuiltinMode()) {
 		idToken, err := h.generateIDToken(h.cfg.BaseURL, subject, h.provider.ClientID())
 		if err == nil {
 			resp["id_token"] = idToken
@@ -758,6 +780,38 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		audience = resolved
+	}
+
+	if h.isBuiltinMode() {
+		// builtin mode: verify the existing gateway JWT locally to extract subject,
+		// then issue a new gateway JWT. GitHub API is not consulted.
+		sub, jwtErr := h.verifyGatewayJWT(accessToken)
+		if jwtErr != nil {
+			h.auditFailure("refresh", "invalid_grant", "refresh token gateway JWT invalid", jwtErr, http.StatusBadRequest, tokenFingerprint(accessToken))
+			slog.Warn("refresh rejected: gateway JWT invalid", "err", jwtErr)
+			oauthError(w, "invalid_grant", "underlying token no longer valid", http.StatusBadRequest)
+			return
+		}
+		newGatewayToken, genErr := h.generateGatewayAccessToken(sub, audience)
+		if genErr != nil {
+			h.auditFailure("refresh", "server_error", "gateway token generation failed during refresh", genErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
+			slog.Error("gateway access token generation failed during refresh", "err", genErr)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
+			return
+		}
+		h.store.CacheToken(newGatewayToken, sub, audience)
+		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, h.refreshTokenTTL())
+		if rtErr != nil {
+			h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(newGatewayToken))
+			slog.Error("failed to rotate refresh token (builtin)", "err", rtErr)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
+			return
+		}
+		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub)
+		h.auditSuccess("refresh", "refresh token exchange completed (builtin)", http.StatusOK)
+		return
 	}
 
 	// Re-validate the underlying token directly against the upstream provider,
@@ -1019,6 +1073,23 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 	} else if err := h.validateAudience(token, TokenRecord{}, audience); err != nil {
 		return "", "", err
 	}
+
+	// builtin mode: validate gateway-issued JWT locally without calling GitHub API.
+	if h.isBuiltinMode() {
+		sub, jwtErr := h.verifyGatewayJWT(token)
+		if jwtErr != nil {
+			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT verification failed", jwtErr, http.StatusUnauthorized, tokenFingerprint(token))
+			return "", "", jwtErr
+		}
+		cacheAudience := ""
+		if cached && record.HasAudience(audience) {
+			cacheAudience = audience
+		}
+		h.store.CacheToken(token, sub, cacheAudience)
+		h.auditSuccess("identity_resolution", "gateway JWT verified", http.StatusOK)
+		return sub, "", nil
+	}
+
 	id, valErr := h.provider.ValidateToken(ctx, token)
 	if valErr != nil {
 		h.auditFailure("identity_resolution", "provider_error", "bearer identity resolution failed", valErr, http.StatusUnauthorized, tokenFingerprint(token))
@@ -1631,6 +1702,106 @@ func (h *Handler) UserInfo(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// isBuiltinMode reports whether the handler operates in builtin mode, where
+// the gateway issues its own RS256 JWTs instead of forwarding provider tokens.
+func (h *Handler) isBuiltinMode() bool {
+	return h.provider.Name() == "builtin"
+}
+
+// generateGatewayAccessToken creates a signed RS256 JWT suitable for use as
+// the client-facing access_token in builtin mode. Unlike generateIDToken it
+// uses h.cfg.ExpiresIn for the expiry so the lifetime matches the token store TTL.
+func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, error) {
+	if h.privateKey == nil {
+		return "", fmt.Errorf("private key is nil")
+	}
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": "gateway-key-1",
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerBytes)
+
+	now := time.Now()
+	expiresIn := h.cfg.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 90 * 24 * time.Hour
+	}
+	jtiBytes := make([]byte, 16)
+	if _, err := rand.Read(jtiBytes); err != nil {
+		return "", fmt.Errorf("generating JWT ID: %w", err)
+	}
+	payload := map[string]any{
+		"iss": h.cfg.BaseURL,
+		"sub": subject,
+		"aud": audience,
+		"iat": now.Unix(),
+		"exp": now.Add(expiresIn).Unix(),
+		"jti": base64.RawURLEncoding.EncodeToString(jtiBytes),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	signingInput := headerB64 + "." + payloadB64
+	hasher := sha256.New()
+	hasher.Write([]byte(signingInput))
+	hashed := hasher.Sum(nil)
+
+	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, h.privateKey, crypto.SHA256, hashed)
+	if err != nil {
+		return "", fmt.Errorf("signing gateway access token: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), nil
+}
+
+// verifyGatewayJWT verifies a gateway-issued RS256 JWT and returns the subject claim.
+// It does not perform audience validation; callers must check audience separately.
+func (h *Handler) verifyGatewayJWT(token string) (subject string, err error) {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed JWT: expected 3 parts")
+	}
+	signingInput := parts[0] + "." + parts[1]
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("JWT signature decode: %w", err)
+	}
+
+	hasher := sha256.New()
+	hasher.Write([]byte(signingInput))
+	hashed := hasher.Sum(nil)
+	pub := &h.privateKey.PublicKey
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, hashed, sigBytes); err != nil {
+		return "", fmt.Errorf("JWT signature invalid: %w", err)
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("JWT payload decode: %w", err)
+	}
+	var claims struct {
+		Sub string `json:"sub"`
+		Exp int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return "", fmt.Errorf("JWT payload parse: %w", err)
+	}
+	if claims.Sub == "" {
+		return "", fmt.Errorf("JWT missing sub claim")
+	}
+	if claims.Exp > 0 && time.Now().Unix() > claims.Exp {
+		return "", fmt.Errorf("JWT expired")
+	}
+	return claims.Sub, nil
 }
 
 // generateIDToken creates a signed RS256 JWT for the given subject.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -785,7 +785,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	if h.isBuiltinMode() {
 		// builtin mode: verify the existing gateway JWT locally to extract subject,
 		// then issue a new gateway JWT. GitHub API is not consulted.
-		sub, jwtErr := h.verifyGatewayJWT(accessToken)
+		sub, _, jwtErr := h.verifyGatewayJWT(accessToken)
 		if jwtErr != nil {
 			h.auditFailure("refresh", "invalid_grant", "refresh token gateway JWT invalid", jwtErr, http.StatusBadRequest, tokenFingerprint(accessToken))
 			slog.Warn("refresh rejected: gateway JWT invalid", "err", jwtErr)
@@ -1070,24 +1070,37 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 			}
 			return record.Subject, "", nil
 		}
-	} else if err := h.validateAudience(token, TokenRecord{}, audience); err != nil {
-		return "", "", err
 	}
 
 	// builtin mode: validate gateway-issued JWT locally without calling GitHub API.
+	// Must be checked before validateAudience because the token store has no audience
+	// record on cache miss; validateAudience(token, TokenRecord{}, audience) would
+	// erroneously reject valid tokens when TokenAudienceStrict is enabled.
 	if h.isBuiltinMode() {
-		sub, jwtErr := h.verifyGatewayJWT(token)
+		sub, tokenAud, jwtErr := h.verifyGatewayJWT(token)
 		if jwtErr != nil {
 			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT verification failed", jwtErr, http.StatusUnauthorized, tokenFingerprint(token))
 			return "", "", jwtErr
 		}
-		cacheAudience := ""
-		if cached && record.HasAudience(audience) {
+		// Validate that the JWT audience matches the requested resource.
+		// normalizeAudience("") returns "" which means any audience is accepted.
+		if audience != "" && normalizeAudience(tokenAud) != audience {
+			err := audienceCheckError{ErrTokenAudienceMismatch}
+			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT audience mismatch", err, http.StatusUnauthorized, tokenFingerprint(token))
+			return "", "", err
+		}
+		// Cache with the audience from the JWT so subsequent hits can validate it.
+		cacheAudience := tokenAud
+		if audience != "" {
 			cacheAudience = audience
 		}
 		h.store.CacheToken(token, sub, cacheAudience)
 		h.auditSuccess("identity_resolution", "gateway JWT verified", http.StatusOK)
 		return sub, "", nil
+	}
+
+	if err := h.validateAudience(token, TokenRecord{}, audience); err != nil {
+		return "", "", err
 	}
 
 	id, valErr := h.provider.ValidateToken(ctx, token)
@@ -1763,45 +1776,62 @@ func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, 
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), nil
 }
 
-// verifyGatewayJWT verifies a gateway-issued RS256 JWT and returns the subject claim.
-// It does not perform audience validation; callers must check audience separately.
-func (h *Handler) verifyGatewayJWT(token string) (subject string, err error) {
+// verifyGatewayJWT verifies a gateway-issued RS256 JWT and returns the subject
+// and audience claims. It validates alg, signature, exp (required), and sub.
+// Audience matching against the request resource is the caller's responsibility.
+func (h *Handler) verifyGatewayJWT(token string) (subject, audience string, err error) {
 	parts := strings.SplitN(token, ".", 3)
 	if len(parts) != 3 {
-		return "", fmt.Errorf("malformed JWT: expected 3 parts")
+		return "", "", fmt.Errorf("malformed JWT: expected 3 parts")
 	}
+
+	// Validate header: alg must be RS256.
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", "", fmt.Errorf("JWT header decode: %w", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return "", "", fmt.Errorf("JWT header parse: %w", err)
+	}
+	if header.Alg != "RS256" {
+		return "", "", fmt.Errorf("JWT alg must be RS256, got %q", header.Alg)
+	}
+
 	signingInput := parts[0] + "." + parts[1]
 	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
 	if err != nil {
-		return "", fmt.Errorf("JWT signature decode: %w", err)
+		return "", "", fmt.Errorf("JWT signature decode: %w", err)
 	}
-
 	hasher := sha256.New()
 	hasher.Write([]byte(signingInput))
 	hashed := hasher.Sum(nil)
-	pub := &h.privateKey.PublicKey
-	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, hashed, sigBytes); err != nil {
-		return "", fmt.Errorf("JWT signature invalid: %w", err)
+	if err := rsa.VerifyPKCS1v15(&h.privateKey.PublicKey, crypto.SHA256, hashed, sigBytes); err != nil {
+		return "", "", fmt.Errorf("JWT signature invalid: %w", err)
 	}
 
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return "", fmt.Errorf("JWT payload decode: %w", err)
+		return "", "", fmt.Errorf("JWT payload decode: %w", err)
 	}
 	var claims struct {
 		Sub string `json:"sub"`
+		Aud string `json:"aud"`
 		Exp int64  `json:"exp"`
 	}
 	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
-		return "", fmt.Errorf("JWT payload parse: %w", err)
+		return "", "", fmt.Errorf("JWT payload parse: %w", err)
 	}
 	if claims.Sub == "" {
-		return "", fmt.Errorf("JWT missing sub claim")
+		return "", "", fmt.Errorf("JWT missing sub claim")
 	}
-	if claims.Exp > 0 && time.Now().Unix() > claims.Exp {
-		return "", fmt.Errorf("JWT expired")
+	// exp is required in gateway-issued JWTs; absence or zero is rejected.
+	if claims.Exp <= 0 || time.Now().Unix() > claims.Exp {
+		return "", "", fmt.Errorf("JWT expired or missing exp claim")
 	}
-	return claims.Sub, nil
+	return claims.Sub, claims.Aud, nil
 }
 
 // generateIDToken creates a signed RS256 JWT for the given subject.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2624,3 +2624,411 @@ func TestAuthorizeCustomSchemeDefaultSchemes(t *testing.T) {
 		})
 	}
 }
+
+// newBuiltinTestHandler creates a Handler in builtin mode (provider.Name() == "builtin")
+// with the given GitHub exchange and identity functions.
+func newBuiltinTestHandler(t *testing.T, ghExchange func(context.Context, string) (provider.TokenResponse, error), ghValidate func(context.Context, string) (provider.Identity, error)) *Handler {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	p := &provider.Mock{
+		NameValue:        "builtin",
+		ClientIDValue:    "builtin-client-id",
+		ScopesValue:      "read:user,user:email",
+		ExchangeCodeFunc: ghExchange,
+		ValidateFunc:     ghValidate,
+	}
+	h, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		CacheTTL:       5 * time.Minute,
+		ExpiresIn:      90 * 24 * time.Hour,
+		OIDCPrivateKey: key,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h
+}
+
+// pkceChallenge returns a PKCE S256 code_challenge for the given verifier.
+func pkceChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// parseJWTPayload base64url-decodes the JWT payload and unmarshals it.
+func parseJWTPayload(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		t.Fatalf("not a JWT: %q", token)
+	}
+	b, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("JWT payload decode: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(b, &claims); err != nil {
+		t.Fatalf("JWT payload parse: %v", err)
+	}
+	return claims
+}
+
+func TestBuiltinAuthorizeRedirectsToGitHub(t *testing.T) {
+	const ghAccessToken = "gh-access-token-must-not-leak"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, code string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "testuser"}, nil
+		},
+	)
+
+	// AuthorizeURL with PKCE challenge and state
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := pkceChallenge(verifier)
+	r := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=teststate&redirect_uri=http://localhost/cb"+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	w := httptest.NewRecorder()
+	h.Authorize(w, r)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want %d; body=%s", w.Code, http.StatusFound, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "state=teststate") {
+		t.Errorf("location missing state: %q", loc)
+	}
+	// GitHub classic OAuth ignores code_challenge, but the URL must not contain it
+	// or the gateway silently drops PKCE enforcement; we only verify redirect target.
+	if !strings.Contains(loc, "github.com") && !strings.Contains(loc, "mock.example.com") {
+		t.Errorf("unexpected redirect target: %q", loc)
+	}
+}
+
+func TestBuiltinTokenFlowIssuesGatewayJWT(t *testing.T) {
+	const ghAccessToken = "gh-access-token-must-not-leak"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := pkceChallenge(verifier)
+	const state = "builtin-state"
+	const redirectURI = "http://localhost/cb"
+
+	// 1. authorize
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	authRec := httptest.NewRecorder()
+	h.Authorize(authRec, authReq)
+	if authRec.Code != http.StatusFound {
+		t.Fatalf("authorize: got %d", authRec.Code)
+	}
+
+	// 2. callback (GitHub sends code back)
+	cbReq := httptest.NewRequest(http.MethodGet,
+		"/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback: got %d; body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	redirectURL, err := url.Parse(cbRec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	internalCode := redirectURL.Query().Get("code")
+	if internalCode == "" {
+		t.Fatal("callback redirect missing internal code")
+	}
+
+	// 3. token exchange
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(tokenRec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+
+	// access_token must be a gateway JWT, not the GitHub token
+	accessToken, _ := resp["access_token"].(string)
+	if accessToken == "" {
+		t.Fatal("token response missing access_token")
+	}
+	if accessToken == ghAccessToken {
+		t.Error("access_token must not be the GitHub access token")
+	}
+	// gateway JWT has 3 dot-separated parts
+	if strings.Count(accessToken, ".") != 2 {
+		t.Errorf("access_token is not a JWT: %q", accessToken)
+	}
+
+	// refresh_token must be present
+	if rt, _ := resp["refresh_token"].(string); rt == "" {
+		t.Error("token response missing refresh_token")
+	}
+
+	// id_token must be present in builtin mode
+	idToken, _ := resp["id_token"].(string)
+	if idToken == "" {
+		t.Error("token response missing id_token")
+	}
+}
+
+func TestBuiltinGitHubAccessTokenNotLeaked(t *testing.T) {
+	const ghAccessToken = "SUPER_SECRET_GITHUB_TOKEN"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "bob"}, nil
+		},
+	)
+
+	verifier := "test-verifier-12345678901234567890123456789012"
+	challenge := pkceChallenge(verifier)
+	const state = "leak-test-state"
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	redirectURL, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := redirectURL.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+
+	body := tokenRec.Body.String()
+	if strings.Contains(body, ghAccessToken) {
+		t.Errorf("token response must not contain GitHub access token, got body: %s", body)
+	}
+}
+
+func TestBuiltinIDTokenClaims(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "charlie"}, nil
+		},
+	)
+
+	verifier := "test-verifier-abcdefghijklmnopqrstuvwxyz12345"
+	challenge := pkceChallenge(verifier)
+	const state = "claims-test-state"
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	redirectURL, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := redirectURL.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+
+	var resp map[string]any
+	_ = json.NewDecoder(tokenRec.Body).Decode(&resp)
+
+	idToken, _ := resp["id_token"].(string)
+	if idToken == "" {
+		t.Fatal("missing id_token")
+	}
+	claims := parseJWTPayload(t, idToken)
+
+	for _, key := range []string{"iss", "sub", "aud", "exp", "iat"} {
+		if claims[key] == nil {
+			t.Errorf("id_token missing claim %q", key)
+		}
+	}
+	if sub, _ := claims["sub"].(string); sub != "charlie" {
+		t.Errorf("id_token sub: got %q, want %q", sub, "charlie")
+	}
+	if iss, _ := claims["iss"].(string); iss != "http://localhost:8080" {
+		t.Errorf("id_token iss: got %q, want %q", iss, "http://localhost:8080")
+	}
+}
+
+func TestBuiltinStateMismatchRejected(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "dave"}, nil
+		},
+	)
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state=real-state&redirect_uri="+url.QueryEscape(redirectURI), nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	// callback with wrong state
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state=wrong-state", nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusBadRequest {
+		t.Errorf("state mismatch: got %d, want %d", cbRec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestBuiltinCodeVerifierMismatchRejected(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "eve"}, nil
+		},
+	)
+
+	verifier := "correct-verifier-abcdefghijklmnopqrstuvwxyz01"
+	challenge := pkceChallenge(verifier)
+	const state = "pkce-test-state"
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	redirectURL, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := redirectURL.Query().Get("code")
+
+	// wrong verifier
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=wrong-verifier"
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusBadRequest {
+		t.Errorf("PKCE mismatch: got %d, want %d; body=%s", tokenRec.Code, http.StatusBadRequest, tokenRec.Body.String())
+	}
+}
+
+func TestBuiltinRefreshIssuesNewGatewayJWT(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "frank"}, nil
+		},
+	)
+
+	verifier := "refresh-verifier-abcdefghijklmnopqrstuvwxyz0123"
+	challenge := pkceChallenge(verifier)
+	const state = "refresh-test-state"
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	redirectURL, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := redirectURL.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("initial token: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+	}
+
+	var tokenResp map[string]any
+	_ = json.NewDecoder(tokenRec.Body).Decode(&tokenResp)
+	firstAccessToken, _ := tokenResp["access_token"].(string)
+	refreshToken, _ := tokenResp["refresh_token"].(string)
+	if refreshToken == "" {
+		t.Fatal("missing refresh_token in initial response")
+	}
+
+	// Use refresh token to obtain a new gateway JWT
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("refresh: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+
+	var refreshResp map[string]any
+	_ = json.NewDecoder(refreshRec.Body).Decode(&refreshResp)
+	newAccessToken, _ := refreshResp["access_token"].(string)
+	if newAccessToken == "" {
+		t.Fatal("refresh response missing access_token")
+	}
+	if newAccessToken == firstAccessToken {
+		t.Error("refresh must issue a new access_token, not reuse the original")
+	}
+	if strings.Count(newAccessToken, ".") != 2 {
+		t.Errorf("refreshed access_token is not a JWT: %q", newAccessToken)
+	}
+	if newRT, _ := refreshResp["refresh_token"].(string); newRT == "" {
+		t.Error("refresh response missing new refresh_token")
+	}
+}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -3032,3 +3032,188 @@ func TestBuiltinRefreshIssuesNewGatewayJWT(t *testing.T) {
 		t.Error("refresh response missing new refresh_token")
 	}
 }
+
+// runBuiltinFullFlow performs a full authorize→callback→token flow in builtin mode
+// and returns the token response and the issued access_token.
+func runBuiltinFullFlow(t *testing.T, h *Handler, subject string) (resp map[string]any, accessToken string) {
+	t.Helper()
+	verifier := "builtin-flow-verifier-abcdefghijklmnopqrstuvwxyz0"
+	challenge := pkceChallenge(verifier)
+	state := "flow-state-" + subject
+	redirectURI := "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback: got %d; body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	redirectURL, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := redirectURL.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+	}
+	_ = json.NewDecoder(tokenRec.Body).Decode(&resp)
+	accessToken, _ = resp["access_token"].(string)
+	return resp, accessToken
+}
+
+func TestBuiltinValidateTokenCacheMiss(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "zoe"}, nil
+		},
+	)
+
+	_, accessToken := runBuiltinFullFlow(t, h, "zoe")
+
+	// Create a fresh handler with the same key so the token store is empty (cache miss).
+	h2 := newBuiltinTestHandlerWithKey(t, h.privateKey,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "zoe"}, nil
+		},
+	)
+
+	sub, _, err := h2.ValidateToken(context.Background(), accessToken, "")
+	if err != nil {
+		t.Fatalf("ValidateToken on cache miss: %v", err)
+	}
+	if sub != "zoe" {
+		t.Errorf("subject: got %q, want %q", sub, "zoe")
+	}
+}
+
+func TestBuiltinValidateTokenExpiredJWT(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "expired-user"}, nil
+		},
+	)
+
+	// Generate an already-expired gateway JWT directly.
+	expiredToken, err := generateExpiredGatewayToken(h.privateKey, "expired-user", "")
+	if err != nil {
+		t.Fatalf("generate expired token: %v", err)
+	}
+
+	_, _, err = h.ValidateToken(context.Background(), expiredToken, "")
+	if err == nil {
+		t.Error("expected error for expired JWT, got nil")
+	}
+}
+
+func TestBuiltinValidateTokenAudienceStrict(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	p := &provider.Mock{
+		NameValue:     "builtin",
+		ClientIDValue: "builtin-client-id",
+		ScopesValue:   "read:user,user:email",
+		ExchangeCodeFunc: func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		ValidateFunc: func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "strict-user"}, nil
+		},
+	}
+	h, err := NewHandler(Config{
+		BaseURL:              "http://localhost:8080",
+		SessionTTL:           10 * time.Minute,
+		CacheTTL:             5 * time.Minute,
+		ExpiresIn:            90 * 24 * time.Hour,
+		OIDCPrivateKey:       key,
+		TokenAudienceStrict:  true,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	_, accessToken := runBuiltinFullFlow(t, h, "strict-user")
+
+	// ValidateToken with TokenAudienceStrict=true must still succeed for builtin
+	// tokens even on cache miss (audience is taken from the JWT aud claim).
+	sub, _, valErr := h.ValidateToken(context.Background(), accessToken, "")
+	if valErr != nil {
+		t.Fatalf("ValidateToken with TokenAudienceStrict: %v", valErr)
+	}
+	if sub != "strict-user" {
+		t.Errorf("subject: got %q, want %q", sub, "strict-user")
+	}
+}
+
+// newBuiltinTestHandlerWithKey is like newBuiltinTestHandler but uses a given RSA key.
+func newBuiltinTestHandlerWithKey(t *testing.T, key *rsa.PrivateKey, ghExchange func(context.Context, string) (provider.TokenResponse, error), ghValidate func(context.Context, string) (provider.Identity, error)) *Handler {
+	t.Helper()
+	p := &provider.Mock{
+		NameValue:        "builtin",
+		ClientIDValue:    "builtin-client-id",
+		ScopesValue:      "read:user,user:email",
+		ExchangeCodeFunc: ghExchange,
+		ValidateFunc:     ghValidate,
+	}
+	h, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		CacheTTL:       5 * time.Minute,
+		ExpiresIn:      90 * 24 * time.Hour,
+		OIDCPrivateKey: key,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h
+}
+
+// generateExpiredGatewayToken creates a gateway-signed JWT with exp in the past.
+func generateExpiredGatewayToken(key *rsa.PrivateKey, subject, audience string) (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT", "kid": "gateway-key-1"}
+	headerBytes, _ := json.Marshal(header)
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerBytes)
+
+	now := time.Now().Unix()
+	payload := map[string]any{
+		"iss": "http://localhost:8080",
+		"sub": subject,
+		"aud": audience,
+		"iat": now - 7200,
+		"exp": now - 3600, // already expired
+		"jti": "expired-jti",
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	signingInput := headerB64 + "." + payloadB64
+	h := sha256.New()
+	h.Write([]byte(signingInput))
+	hashed := h.Sum(nil)
+	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed)
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), nil
+}

--- a/internal/auth/provider/builtin.go
+++ b/internal/auth/provider/builtin.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrBuiltinValidateNotSupported is returned when ValidateToken is called on the
+// builtin provider. In builtin mode, gateway-issued JWTs are validated directly
+// by the handler (which holds the RSA signing key), not via the upstream provider.
+var ErrBuiltinValidateNotSupported = errors.New("builtin provider: ValidateToken must be handled by the gateway JWT verifier")
+
+// builtinProvider wraps the GitHub OAuth flow so that the gateway can use
+// GitHub as a social login source while issuing its own RS256 JWTs as
+// access tokens. The handler detects Name() == "builtin" and switches to
+// gateway-issued token logic instead of forwarding GitHub tokens to clients.
+type builtinProvider struct {
+	github Provider
+}
+
+// NewBuiltin returns a Provider backed by GitHub OAuth for identity resolution.
+// The handler must check Name() == "builtin" and apply gateway-JWT issuance
+// instead of using the GitHub access token as the client-facing access token.
+func NewBuiltin(githubCfg GitHubConfig) Provider {
+	return &builtinProvider{github: NewGitHub(githubCfg)}
+}
+
+func (p *builtinProvider) Name() string     { return "builtin" }
+func (p *builtinProvider) ClientID() string { return p.github.ClientID() }
+func (p *builtinProvider) Scopes() string   { return p.github.Scopes() }
+
+// AuthorizeURL builds a GitHub OAuth authorization URL for social login.
+// PKCE code_challenge is forwarded to preserve the PKCE binding between the
+// MCP client and this gateway (GitHub classic OAuth ignores it server-side,
+// but the gateway enforces it in tokenAuthCode).
+func (p *builtinProvider) AuthorizeURL(state, codeChallenge string) string {
+	return p.github.AuthorizeURL(state, codeChallenge)
+}
+
+// ExchangeCode exchanges an authorization code for a GitHub access token.
+// The returned TokenResponse.AccessToken is the GitHub access token, which
+// the handler uses solely to resolve identity (GET /user). The handler
+// discards it and issues a gateway-signed JWT to the client instead.
+func (p *builtinProvider) ExchangeCode(ctx context.Context, code string) (TokenResponse, error) {
+	return p.github.ExchangeCode(ctx, code)
+}
+
+// RefreshToken is not used in builtin mode. Gateway refresh token rotation is
+// managed entirely by the handler; GitHub refresh tokens are never persisted.
+func (p *builtinProvider) RefreshToken(_ context.Context, _ string) (TokenResponse, error) {
+	return TokenResponse{}, ErrRefreshNotSupported
+}
+
+// ValidateToken must not be called in builtin mode. The handler validates
+// gateway-issued JWTs directly using its RSA private key.
+func (p *builtinProvider) ValidateToken(_ context.Context, _ string) (Identity, error) {
+	return Identity{}, ErrBuiltinValidateNotSupported
+}

--- a/internal/auth/provider/builtin_test.go
+++ b/internal/auth/provider/builtin_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newBuiltinFromServer(t *testing.T, srv *httptest.Server) Provider {
+	t.Helper()
+	return NewBuiltin(GitHubConfig{
+		ClientID:     "builtin-cid",
+		ClientSecret: "builtin-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "read:user,user:email",
+		AuthorizeURL: srv.URL + "/login/oauth/authorize",
+		TokenURL:     srv.URL + "/login/oauth/access_token",
+		UserAPI:      srv.URL + "/user",
+		HTTPClient:   srv.Client(),
+	})
+}
+
+func TestBuiltinProviderName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	if got := p.Name(); got != "builtin" {
+		t.Errorf("Name(): got %q, want %q", got, "builtin")
+	}
+}
+
+func TestBuiltinProviderClientID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	if got := p.ClientID(); got != "builtin-cid" {
+		t.Errorf("ClientID(): got %q, want %q", got, "builtin-cid")
+	}
+}
+
+func TestBuiltinProviderScopes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	if got := p.Scopes(); got != "read:user,user:email" {
+		t.Errorf("Scopes(): got %q, want %q", got, "read:user,user:email")
+	}
+}
+
+func TestBuiltinAuthorizeURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	got := p.AuthorizeURL("mystate", "mychallenge")
+	if got == "" {
+		t.Error("AuthorizeURL returned empty string")
+	}
+	// Must contain the state param
+	if want := "state=mystate"; !strings.Contains(got, want) {
+		t.Errorf("AuthorizeURL %q missing %q", got, want)
+	}
+}
+
+func TestBuiltinExchangeCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"gh-tok","scope":"read:user"}`))
+	}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	resp, err := p.ExchangeCode(context.Background(), "auth-code")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if resp.AccessToken != "gh-tok" {
+		t.Errorf("AccessToken: got %q, want %q", resp.AccessToken, "gh-tok")
+	}
+}
+
+func TestBuiltinRefreshTokenNotSupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	_, err := p.RefreshToken(context.Background(), "some-token")
+	if !errors.Is(err, ErrRefreshNotSupported) {
+		t.Errorf("RefreshToken: expected ErrRefreshNotSupported, got %v", err)
+	}
+}
+
+func TestBuiltinValidateTokenNotSupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	p := newBuiltinFromServer(t, srv)
+	_, err := p.ValidateToken(context.Background(), "some-token")
+	if !errors.Is(err, ErrBuiltinValidateNotSupported) {
+		t.Errorf("ValidateToken: expected ErrBuiltinValidateNotSupported, got %v", err)
+	}
+}
+

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -41,6 +41,27 @@ func New(cfg Config) (Provider, error) {
 			RedirectURI:  cfg.RedirectURI,
 			Scopes:       cfg.Scopes,
 		}), nil
+	case "builtin":
+		if cfg.ClientID == "" || cfg.ClientSecret == "" {
+			return nil, fmt.Errorf("builtin provider requires ClientID and ClientSecret (GitHub OAuth App credentials)")
+		}
+		if cfg.RedirectURI == "" {
+			return nil, fmt.Errorf("builtin provider requires RedirectURI")
+		}
+		u, err := url.Parse(cfg.RedirectURI)
+		if err != nil || !u.IsAbs() || u.Host == "" || u.Fragment != "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return nil, fmt.Errorf("builtin provider requires an absolute http/https RedirectURI with a host and no fragment, got %q", cfg.RedirectURI)
+		}
+		scopes := cfg.Scopes
+		if scopes == "" {
+			scopes = "read:user,user:email"
+		}
+		return NewBuiltin(GitHubConfig{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURI:  cfg.RedirectURI,
+			Scopes:       scopes,
+		}), nil
 	case "oidc":
 		if cfg.ClientID == "" || cfg.ClientSecret == "" {
 			return nil, fmt.Errorf("oidc provider requires ClientID and ClientSecret")

--- a/internal/auth/provider/factory_test.go
+++ b/internal/auth/provider/factory_test.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestNewBuiltinProvider(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "valid builtin config",
+			cfg: Config{
+				Kind:         "builtin",
+				ClientID:     "cid",
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/callback",
+				Scopes:       "read:user,user:email",
+			},
+			wantErr: false,
+		},
+		{
+			name: "builtin missing ClientID",
+			cfg: Config{
+				Kind:         "builtin",
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/callback",
+			},
+			wantErr: true,
+		},
+		{
+			name: "builtin missing ClientSecret",
+			cfg: Config{
+				Kind:        "builtin",
+				ClientID:    "cid",
+				RedirectURI: "http://localhost:8080/callback",
+			},
+			wantErr: true,
+		},
+		{
+			name: "builtin missing RedirectURI",
+			cfg: Config{
+				Kind:         "builtin",
+				ClientID:     "cid",
+				ClientSecret: "secret",
+			},
+			wantErr: true,
+		},
+		{
+			name: "builtin invalid RedirectURI scheme",
+			cfg: Config{
+				Kind:         "builtin",
+				ClientID:     "cid",
+				ClientSecret: "secret",
+				RedirectURI:  "ftp://localhost:8080/callback",
+			},
+			wantErr: true,
+		},
+		{
+			name: "builtin default scopes applied when Scopes empty",
+			cfg: Config{
+				Kind:         "builtin",
+				ClientID:     "cid",
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/callback",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(tc.cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Name() != "builtin" {
+				t.Errorf("Name(): got %q, want %q", p.Name(), "builtin")
+			}
+		})
+	}
+}
+
+func TestNewBuiltinDefaultScopes(t *testing.T) {
+	p, err := New(Config{
+		Kind:         "builtin",
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		// Scopes intentionally omitted
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.Scopes(); got != "read:user,user:email" {
+		t.Errorf("default Scopes: got %q, want %q", got, "read:user,user:email")
+	}
+}


### PR DESCRIPTION
## Summary

- `OAUTH_PROVIDER=builtin` 新モードを実装。GitHub OAuth を social login source として使用し、gateway 自身が RS256 JWT（access_token / id_token / refresh_token）を発行する
- GitHub access_token はユーザー identity 取得（`GET /user`）のためだけに使用し、callback 処理完了後に破棄する。クライアントには渡さない
- gateway JWT は `/token` エンドポイントで authorization_code / refresh_token grant の両方で発行・再発行される
- `ValidateToken` では gateway JWT をローカルで RS256 検証し、GitHub API への依存を排除
- 既存の `OAUTH_PROVIDER=github`（透過的認証）との並存を維持

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/auth/provider/builtin.go` | 新規：GitHub OAuth をラップする builtin プロバイダー |
| `internal/auth/provider/factory.go` | `OAUTH_PROVIDER=builtin` の分岐追加 |
| `internal/auth/handler.go` | `isBuiltinMode()` / `generateGatewayAccessToken()` / `verifyGatewayJWT()` 追加、各 grant handler に builtin 分岐 |
| `internal/auth/handler_test.go` | builtin モードの結合テスト 7 ケース追加 |
| `CHANGELOG.md` | `[Unreleased]` エントリ追加 |

## フロー（builtin モード）

```
1. GET /authorize?code_challenge=...&state=...
   → GitHub OAuth authorize endpoint へリダイレクト

2. GET /callback?code=gh-code&state=...
   → GitHub /token endpoint で code 交換（GitHub access_token 取得）
   → GET /user で identity 解決
   → GitHub access_token を破棄
   → gateway が authorization_code を発行してクライアントへ

3. POST /token?grant_type=authorization_code&code=...&code_verifier=...
   → PKCE 検証
   → gateway RS256 JWT を access_token として発行
   → id_token + refresh_token も発行

4. POST /token?grant_type=refresh_token&refresh_token=...
   → gateway JWT をローカル検証（GitHub API 不要）
   → 新しい gateway JWT を再発行
```

## Test plan

- [x] `TestBuiltinAuthorizeRedirectsToGitHub` — PKCE + state で GitHub redirect
- [x] `TestBuiltinTokenFlowIssuesGatewayJWT` — フルフローで gateway JWT が発行される
- [x] `TestBuiltinGitHubAccessTokenNotLeaked` — GitHub access_token がレスポンスに含まれない
- [x] `TestBuiltinIDTokenClaims` — id_token の claims（iss, sub, aud, exp, iat）が正しい
- [x] `TestBuiltinStateMismatchRejected` — state 不一致で拒否される
- [x] `TestBuiltinCodeVerifierMismatchRejected` — code_verifier 不一致で拒否される
- [x] `TestBuiltinRefreshIssuesNewGatewayJWT` — refresh token で新しい JWT が発行される
- [x] 既存テスト全通過（`go test ./...`）

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)