### PR TITLE
feat(auth): refresh token rotation and reuse detection (RFC 6819 §5.2.2.3) (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add refresh token rotation and reuse detection (RFC 6819 §5.2.2.3) ([#128](https://github.com/scottlz0310/mcp-gateway/issues/128))
+  - Token family tracking: every refresh token is associated with a `family_id` generated at authorization-code issuance and inherited across rotations
+  - Reuse detection: presenting a revoked (already-used) refresh token immediately revokes the entire token lineage (`invalid_grant`)
+  - Soft-revoke on rotation: consumed tokens are marked `revoked=true` and retained until expiry so replay attacks can be detected within the expiry window
+  - `RevokeFamily` / `Revoke` / `LookupAny` methods added to `RefreshTokenStore`
+  - File-backed store persists `family_id` and `revoked` flag across gateway restarts (`tokens.json.refresh`)
+  - Both `builtin` and `github` modes apply family tracking
 - Add `OAUTH_PROVIDER=builtin` mode: GitHub OAuth 2.0 PKCE social login with gateway-issued RS256 JWT ([#127](https://github.com/scottlz0310/mcp-gateway/issues/127))
   - gateway が自身の RS256 JWT（access_token + id_token + refresh_token）を発行する
   - GitHub は identity 取得のみに使用し、GitHub access_token はクライアントに渡さず callback 後に破棄する

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -547,7 +547,12 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.CacheToken(gatewayToken, result.Subject, result.Audience)
-		refreshToken, rtErr := h.store.CreateRefreshToken(gatewayToken, result.Audience, h.refreshTokenTTL())
+		familyID, fidErr := generateCode()
+		if fidErr != nil {
+			slog.Warn("failed to generate refresh token family ID", "err", fidErr)
+			familyID = ""
+		}
+		refreshToken, rtErr := h.store.CreateRefreshToken(gatewayToken, result.Audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
@@ -558,7 +563,12 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 
 	h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
 	h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
-	refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, h.refreshTokenTTL())
+	familyID, fidErr := generateCode()
+	if fidErr != nil {
+		slog.Warn("failed to generate refresh token family ID", "err", fidErr)
+		familyID = ""
+	}
+	refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, result.Audience, familyID, h.refreshTokenTTL())
 	if rtErr != nil {
 		slog.Warn("failed to create refresh token", "err", rtErr)
 	}
@@ -658,7 +668,12 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		}
 		h.store.CacheToken(result.AccessToken, id.Subject, completed.Audience)
 		h.persistProviderRefresh(result.AccessToken, result.RefreshToken, providerAccessExpiry(result.AccessExpiresIn))
-		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, completed.Audience, h.refreshTokenTTL())
+		deviceFamilyID, deviceFidErr := generateCode()
+		if deviceFidErr != nil {
+			slog.Warn("failed to generate refresh token family ID (device)", "err", deviceFidErr)
+			deviceFamilyID = ""
+		}
+		refreshToken, rtErr := h.store.CreateRefreshToken(result.AccessToken, completed.Audience, deviceFamilyID, h.refreshTokenTTL())
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
@@ -743,7 +758,9 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 
 	// Atomically reserve (remove) the token. Concurrent callers presenting the
 	// same token will fail here, preventing double-rotation.
-	accessToken, audience, rtExpiresAt, err := h.store.ReserveRefreshToken(rt)
+	// On reuse detection (revoked token replay), ReserveRefreshToken revokes the
+	// entire family before returning an error.
+	accessToken, audience, familyID, rtExpiresAt, err := h.store.ReserveRefreshToken(rt)
 	if err != nil {
 		if errors.Is(err, ErrRefreshTokenDeleteFailed) {
 			h.auditFailure("refresh", "store_error", "refresh token store unavailable", err, http.StatusServiceUnavailable, "")
@@ -768,13 +785,13 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	if resources := r.Form["resource"]; len(resources) > 0 {
 		resolved, audErr := h.resolveRequestedAudience(resources)
 		if audErr != nil {
-			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 			h.auditFailure("refresh", "invalid_target", "refresh token target rejected", audErr, http.StatusBadRequest, tokenFingerprint(accessToken))
 			oauthError(w, "invalid_target", audErr.Error(), http.StatusBadRequest)
 			return
 		}
 		if !isSubAudience(resolved, originalAudience) {
-			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 			h.auditFailure("refresh", "invalid_target", "refresh token target widening rejected", nil, http.StatusBadRequest, tokenFingerprint(accessToken))
 			oauthError(w, "invalid_target", "resource is not a valid narrowing of the original audience", http.StatusBadRequest)
 			return
@@ -796,16 +813,17 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		if genErr != nil {
 			h.auditFailure("refresh", "server_error", "gateway token generation failed during refresh", genErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
 			slog.Error("gateway access token generation failed during refresh", "err", genErr)
-			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 			return
 		}
 		h.store.CacheToken(newGatewayToken, sub, audience)
-		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, h.refreshTokenTTL())
+		// Propagate the same familyID so the token lineage remains traceable.
+		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
 			h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(newGatewayToken))
 			slog.Error("failed to rotate refresh token (builtin)", "err", rtErr)
-			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 			return
 		}
@@ -825,7 +843,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("refresh rejected: transient upstream error", "err", valErr)
 			// Restore the token with its original audience so the client can retry,
 			// potentially with a different resource value.
-			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 			oauthError(w, "temporarily_unavailable", "upstream provider unreachable, retry later", http.StatusServiceUnavailable)
 		} else {
 			h.auditFailure("refresh", "invalid_grant", "refresh token underlying access token invalid", valErr, http.StatusBadRequest, tokenFingerprint(accessToken))
@@ -838,13 +856,13 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	// Re-cache the freshly validated token.
 	h.store.CacheToken(accessToken, id.Subject, audience)
 
-	// Issue the rotated refresh token. The original is already consumed (reserved).
-	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, h.refreshTokenTTL())
+	// Issue the rotated refresh token propagating familyID for reuse tracking.
+	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, familyID, h.refreshTokenTTL())
 	if rtErr != nil {
 		h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
 		slog.Error("failed to rotate refresh token", "err", rtErr)
 		// Restore the original token (with its original audience) so the client can retry.
-		h.store.RestoreRefreshToken(rt, accessToken, originalAudience, rtExpiresAt)
+		h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -612,7 +612,7 @@ func TestValidateTokenReseedsSubjectIndexOnCacheHit(t *testing.T) {
 	}
 }
 
-// TestValidateTokenAudiencePrefixMatching covers the gateway-wide → route-scoped
+// TestValidateTokenAudiencePrefixMatching covers the gateway-wide ↁEroute-scoped
 // acceptance path required by MCP clients (e.g. Codex) that acquire a single
 // token at the public URL and then call multiple authenticated sub-routes.
 func TestValidateTokenAudiencePrefixMatching(t *testing.T) {
@@ -1134,7 +1134,7 @@ func TestTokenRefreshSuccess(t *testing.T) {
 	}
 
 	// Seed a refresh token for an existing access token.
-	rt, err := h.store.CreateRefreshToken("gha_existing_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_existing_token", "http://localhost:8080/mcp", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1237,7 +1237,7 @@ func TestTokenRefreshUpstreamErrorPreservesToken(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -1291,7 +1291,7 @@ func TestTokenRefreshConcurrentSameToken(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	rt, err := h.store.CreateRefreshToken("gha_concurrent_token", "http://localhost:8080/mcp", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_concurrent_token", "http://localhost:8080/mcp", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -1385,7 +1385,7 @@ func TestHandlerRefreshTokenSurvivesRestart(t *testing.T) {
 	}
 
 	h1 := newHandlerWithPath(t, storePath)
-	rt, err := h1.store.CreateRefreshToken("gha_access_token", "http://localhost:8080/mcp", 24*time.Hour)
+	rt, err := h1.store.CreateRefreshToken("gha_access_token", "http://localhost:8080/mcp", "", 24*time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -1438,14 +1438,19 @@ type deleteFailRefreshStore struct {
 	inner *memRefreshTokenStore
 }
 
-func (d *deleteFailRefreshStore) Save(rt, at, aud string, exp time.Time) error {
-	return d.inner.Save(rt, at, aud, exp)
+func (d *deleteFailRefreshStore) Save(rt, at, aud, fid string, exp time.Time) error {
+	return d.inner.Save(rt, at, aud, fid, exp)
 }
-func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, time.Time, bool) {
+func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, string, time.Time, bool) {
 	return d.inner.Lookup(rt)
 }
-func (d *deleteFailRefreshStore) Delete(_ string) error { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) Sweep() error          { return d.inner.Sweep() }
+func (d *deleteFailRefreshStore) LookupAny(rt string) (string, string, string, time.Time, bool, bool) {
+	return d.inner.LookupAny(rt)
+}
+func (d *deleteFailRefreshStore) Revoke(_ string) error         { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) RevokeFamily(fid string) error { return d.inner.RevokeFamily(fid) }
+func (d *deleteFailRefreshStore) Delete(_ string) error         { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) Sweep() error                  { return d.inner.Sweep() }
 
 // TestTokenRefreshDeleteFailed503 verifies that when the refresh token store
 // fails to delete the token during rotation (ErrRefreshTokenDeleteFailed),
@@ -1460,7 +1465,7 @@ func TestTokenRefreshDeleteFailed503(t *testing.T) {
 
 	inner := &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
 	failStore := &deleteFailRefreshStore{inner: inner}
-	_ = inner.Save("test-rt", "test-at", "http://localhost:8080/mcp", time.Now().Add(time.Hour))
+	_ = inner.Save("test-rt", "test-at", "http://localhost:8080/mcp", "fid-test", time.Now().Add(time.Hour))
 
 	store := NewStore(time.Minute, 90*24*time.Hour, NewMemTokenStore(),
 		WithRefreshTokenStore(failStore))
@@ -1549,7 +1554,7 @@ func TestTokenRefreshResourceSameAudience(t *testing.T) {
 	const audience = "http://localhost:8080/mcp/route-a"
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{audience})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", audience, h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", audience, "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1577,7 +1582,7 @@ func TestTokenRefreshResourceNarrowing(t *testing.T) {
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
 
 	// Original token is gateway-wide.
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1601,7 +1606,7 @@ func TestTokenRefreshResourceCrossRoute(t *testing.T) {
 		"http://localhost:8080/mcp/route-b",
 	})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp/route-a", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp/route-a", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1628,7 +1633,7 @@ func TestTokenRefreshResourceWidening(t *testing.T) {
 	const routeAud = "http://localhost:8080/mcp/route-a"
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", routeAud, h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", routeAud, "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1654,7 +1659,7 @@ func TestTokenRefreshResourceWidening(t *testing.T) {
 func TestTokenRefreshResourceUnknown(t *testing.T) {
 	h, _ := newTestRefreshHandlerWithGitHub(t, nil)
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1686,7 +1691,7 @@ func TestTokenRefreshResourceLegacyToken(t *testing.T) {
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
 
 	// Empty audience simulates a pre-audience (legacy) refresh token.
-	rt, err := h.store.CreateRefreshToken("gha_token", "", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1707,7 +1712,7 @@ func TestTokenRefreshResourceLegacyToken(t *testing.T) {
 func TestTokenRefreshResourceEmptyValue(t *testing.T) {
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{"http://localhost:8080/mcp/route-a"})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1729,17 +1734,17 @@ func TestTokenRefreshResourceEmptyValue(t *testing.T) {
 }
 
 // TestTokenRefreshResourceMultipleRaw verifies that resource=&resource=https://x
-// (one empty, one valid) is rejected — raw count check ignores empty filtering.
+// (one empty, one valid) is rejected  Eraw count check ignores empty filtering.
 func TestTokenRefreshResourceMultipleRaw(t *testing.T) {
 	const routeAud = "http://localhost:8080/mcp/route-a"
 	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	// resource= (empty) is present first — should be rejected before multi-check
+	// resource= (empty) is present first  Eshould be rejected before multi-check
 	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=&resource=" + url.QueryEscape(routeAud)
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1937,7 +1942,7 @@ func TestValidateTokenGitHubRotation(t *testing.T) {
 					t.Errorf("new cache subject: got %q, want %q", rec.Subject, tc.wantSubject)
 				}
 				// Old entry must remain cached: clients keep presenting it and
-				// dropping it would force a provider round-trip — possibly a
+				// dropping it would force a provider round-trip  Epossibly a
 				// 401 once GitHub expires the original.
 				oldRec, oldCached := h.store.LookupToken("old-access")
 				if !oldCached {
@@ -2226,7 +2231,7 @@ func TestValidateTokenGitHubRotationSkipsWhenSubjectUnknown(t *testing.T) {
 
 // TestValidateTokenGitHubRotationKeepsOriginalEntryRotating verifies that
 // after a successful rotation, presenting the original token again triggers
-// another rotation (using the rotated refresh token) — i.e. the original
+// another rotation (using the rotated refresh token)  Ei.e. the original
 // entry's metadata was refreshed, not cleared.
 func TestValidateTokenGitHubRotationKeepsOriginalEntryRotating(t *testing.T) {
 	const audience = "http://localhost:8080/mcp"
@@ -2610,7 +2615,7 @@ func TestAuthorizeCustomSchemeRedirectURI(t *testing.T) {
 func TestAuthorizeCustomSchemeDefaultSchemes(t *testing.T) {
 	h := newTestHandler(t)
 
-	// デフォルトの AllowedRedirectSchemes が正しく設定されているか検証
+	// チE��ォルト�E AllowedRedirectSchemes が正しく設定されてぁE��か検証
 	wantSchemes := []string{"antigravity", "antigravity-insiders"}
 	for _, scheme := range wantSchemes {
 		t.Run("default includes "+scheme, func(t *testing.T) {

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -354,12 +354,16 @@ func (s *Store) ReleaseDevicePolling(internalCode string) {
 // (MCP_GATEWAY_TOKEN_STORE_PATH is set), the associated access token value is
 // written to disk in the .refresh sibling file (mode 0600); see the
 // MCP_GATEWAY_TOKEN_STORE_PATH documentation for security considerations.
-func (s *Store) CreateRefreshToken(accessToken, audience string, ttl time.Duration) (string, error) {
+//
+// familyID groups tokens from the same authorization grant for reuse detection
+// (RFC 6819 §5.2.2.3). Pass a new random familyID on initial issuance and
+// propagate the same familyID on rotation.
+func (s *Store) CreateRefreshToken(accessToken, audience, familyID string, ttl time.Duration) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", fmt.Errorf("generating refresh token: %w", err)
 	}
-	if err := s.refreshStore.Save(code, accessToken, audience, time.Now().Add(ttl)); err != nil {
+	if err := s.refreshStore.Save(code, accessToken, audience, familyID, time.Now().Add(ttl)); err != nil {
 		return "", fmt.Errorf("saving refresh token: %w", err)
 	}
 	return code, nil
@@ -372,7 +376,7 @@ func (s *Store) CreateRefreshToken(accessToken, audience string, ttl time.Durati
 func (s *Store) UseRefreshToken(refreshToken string) (string, error) {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
-	accessToken, _, _, ok := s.refreshStore.Lookup(refreshToken)
+	accessToken, _, _, _, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
 		return "", fmt.Errorf("refresh token not found or expired")
 	}
@@ -387,7 +391,7 @@ func (s *Store) UseRefreshToken(refreshToken string) (string, error) {
 // when the token is unknown or has expired.  Use ConsumeRefreshToken to
 // delete the token only after the full rotation has succeeded.
 func (s *Store) PeekRefreshToken(refreshToken string) (string, error) {
-	accessToken, _, _, ok := s.refreshStore.Lookup(refreshToken)
+	accessToken, _, _, _, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
 		return "", fmt.Errorf("refresh token not found or expired")
 	}
@@ -403,29 +407,43 @@ func (s *Store) ConsumeRefreshToken(refreshToken string) {
 }
 
 // ReserveRefreshToken atomically removes a refresh token from the store and
-// returns the associated access token and expiry time.  Because the token is
-// deleted immediately, concurrent callers presenting the same token will
-// receive an error here, preventing double-rotation.  On any subsequent
-// failure in the rotation flow, call RestoreRefreshToken to put the token
-// back so the client can retry.
-func (s *Store) ReserveRefreshToken(refreshToken string) (string, string, time.Time, error) {
+// returns the associated access token, audience, familyID, and expiry time.
+// Because the token is deleted immediately, concurrent callers presenting the
+// same token will receive an error here, preventing double-rotation. On any
+// subsequent failure in the rotation flow, call RestoreRefreshToken to put the
+// token back so the client can retry.
+//
+// Reuse detection (RFC 6819 §5.2.2.3): if a revoked-but-still-valid token is
+// presented (replay attack), the entire token family is immediately revoked and
+// the error is returned with details logged.
+func (s *Store) ReserveRefreshToken(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, err error) {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
-	accessToken, audience, expiresAt, ok := s.refreshStore.Lookup(refreshToken)
+	at, aud, fid, exp, ok := s.refreshStore.Lookup(refreshToken)
 	if !ok {
-		return "", "", time.Time{}, fmt.Errorf("refresh token not found or expired")
+		// Check whether this is a revoked token being replayed (reuse attack).
+		_, _, revokedFID, _, revoked, anyOK := s.refreshStore.LookupAny(refreshToken)
+		if anyOK && revoked && revokedFID != "" {
+			slog.Warn("refresh token reuse detected — revoking token family",
+				"family_id", revokedFID,
+			)
+			_ = s.refreshStore.RevokeFamily(revokedFID)
+		}
+		return "", "", "", time.Time{}, fmt.Errorf("refresh token not found or expired")
 	}
-	if err := s.refreshStore.Delete(refreshToken); err != nil {
-		return "", "", time.Time{}, fmt.Errorf("%w: %w", ErrRefreshTokenDeleteFailed, err)
+	// Soft-revoke (not delete) so LookupAny can detect future replay attacks
+	// within the token's expiry window.
+	if revokeErr := s.refreshStore.Revoke(refreshToken); revokeErr != nil {
+		return "", "", "", time.Time{}, fmt.Errorf("%w: %w", ErrRefreshTokenDeleteFailed, revokeErr)
 	}
-	return accessToken, audience, expiresAt, nil
+	return at, aud, fid, exp, nil
 }
 
 // RestoreRefreshToken puts a previously reserved refresh token back into the
 // store.  Call this when the rotation flow fails after ReserveRefreshToken so
 // that the client can retry without full re-authentication.
-func (s *Store) RestoreRefreshToken(refreshToken, accessToken, audience string, expiresAt time.Time) {
-	if err := s.refreshStore.Save(refreshToken, accessToken, audience, expiresAt); err != nil {
+func (s *Store) RestoreRefreshToken(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) {
+	if err := s.refreshStore.Save(refreshToken, accessToken, audience, familyID, expiresAt); err != nil {
 		slog.Warn("refresh token restore failed", "err", err)
 	}
 }

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -263,7 +263,7 @@ func TestInvalidateCachedTokenDeleteError(t *testing.T) {
 func TestCreateAndUseRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("access-token-abc", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("access-token-abc", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestCreateAndUseRefreshToken(t *testing.T) {
 func TestUseRefreshTokenIsOneTimeUse(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestUseRefreshTokenIsOneTimeUse(t *testing.T) {
 func TestUseRefreshTokenExpired(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", -time.Second) // already expired
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", "fid-1", -time.Second) // already expired
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestUseRefreshTokenUnknown(t *testing.T) {
 func TestPeekRefreshTokenDoesNotConsume(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -345,7 +345,7 @@ func TestPeekRefreshTokenDoesNotConsume(t *testing.T) {
 func TestConsumeRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
@@ -366,12 +366,12 @@ func TestConsumeRefreshTokenNoOp(t *testing.T) {
 func TestReserveRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("access-tok", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("access-tok", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
 
-	got, audience, _, err := s.ReserveRefreshToken(rt)
+	got, audience, familyID, _, err := s.ReserveRefreshToken(rt)
 	if err != nil {
 		t.Fatalf("ReserveRefreshToken: %v", err)
 	}
@@ -381,8 +381,11 @@ func TestReserveRefreshToken(t *testing.T) {
 	if audience != "https://gw.example/mcp" {
 		t.Errorf("audience: got %q", audience)
 	}
+	if familyID != "fid-1" {
+		t.Errorf("familyID: got %q, want %q", familyID, "fid-1")
+	}
 	// Token must be gone after reservation (concurrent callers must fail).
-	if _, _, _, err2 := s.ReserveRefreshToken(rt); err2 == nil {
+	if _, _, _, _, err2 := s.ReserveRefreshToken(rt); err2 == nil {
 		t.Fatal("expected error on second ReserveRefreshToken (atomic one-time removal)")
 	}
 }
@@ -390,11 +393,11 @@ func TestReserveRefreshToken(t *testing.T) {
 func TestReserveRefreshTokenExpired(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", -time.Second) // already expired
+	rt, err := s.CreateRefreshToken("tok", "https://gw.example/mcp", "fid-1", -time.Second) // already expired
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
-	if _, _, _, err := s.ReserveRefreshToken(rt); err == nil {
+	if _, _, _, _, err := s.ReserveRefreshToken(rt); err == nil {
 		t.Fatal("expected error for expired refresh token")
 	}
 }
@@ -402,17 +405,17 @@ func TestReserveRefreshTokenExpired(t *testing.T) {
 func TestRestoreRefreshToken(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	rt, err := s.CreateRefreshToken("tok-restore", "https://gw.example/mcp", time.Hour)
+	rt, err := s.CreateRefreshToken("tok-restore", "https://gw.example/mcp", "fid-1", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateRefreshToken: %v", err)
 	}
 
-	_, audience, expiresAt, err := s.ReserveRefreshToken(rt)
+	_, audience, familyID, expiresAt, err := s.ReserveRefreshToken(rt)
 	if err != nil {
 		t.Fatalf("ReserveRefreshToken: %v", err)
 	}
 	// Simulate rotation failure: restore the token.
-	s.RestoreRefreshToken(rt, "tok-restore", audience, expiresAt)
+	s.RestoreRefreshToken(rt, "tok-restore", audience, familyID, expiresAt)
 
 	// Token must be accessible again via Peek after restoration.
 	got, err := s.PeekRefreshToken(rt)
@@ -421,6 +424,74 @@ func TestRestoreRefreshToken(t *testing.T) {
 	}
 	if got != "tok-restore" {
 		t.Errorf("access token after restore: got %q, want %q", got, "tok-restore")
+	}
+}
+
+// TestReserveRefreshTokenReuseRevokesFamily verifies RFC 6819 §5.2.2.3 reuse
+// detection: presenting a revoked (already-used) refresh token must revoke the
+// entire token family, not merely return an error for the presented token.
+func TestReserveRefreshTokenReuseRevokesFamily(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+
+	// Issue initial refresh token (rt1) with family "fid-family".
+	rt1, err := s.CreateRefreshToken("at-1", "https://gw.example/mcp", "fid-family", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken rt1: %v", err)
+	}
+
+	// Normal rotation: consume rt1 → create rt2 in the same family.
+	_, _, gotFID, _, err := s.ReserveRefreshToken(rt1)
+	if err != nil {
+		t.Fatalf("first ReserveRefreshToken: %v", err)
+	}
+	if gotFID != "fid-family" {
+		t.Errorf("familyID: got %q, want %q", gotFID, "fid-family")
+	}
+	rt2, err := s.CreateRefreshToken("at-2", "https://gw.example/mcp", "fid-family", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken rt2: %v", err)
+	}
+
+	// rt1 is now revoked. Replaying it must revoke the entire family (rt2).
+	_, _, _, _, err = s.ReserveRefreshToken(rt1)
+	if err == nil {
+		t.Fatal("expected error on revoked token replay, got nil")
+	}
+
+	// rt2 must also be revoked (family-wide invalidation).
+	_, _, _, _, err = s.ReserveRefreshToken(rt2)
+	if err == nil {
+		t.Fatal("rt2 must be revoked after family invalidation, but ReserveRefreshToken succeeded")
+	}
+}
+
+// TestReserveRefreshTokenFamilyIDPropagates verifies that the family ID is
+// returned by ReserveRefreshToken and can be passed to CreateRefreshToken for
+// rotation, maintaining the lineage.
+func TestReserveRefreshTokenFamilyIDPropagates(t *testing.T) {
+	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
+
+	rt1, err := s.CreateRefreshToken("at", "https://gw.example/mcp", "fid-chain", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+
+	_, _, fid1, _, err := s.ReserveRefreshToken(rt1)
+	if err != nil {
+		t.Fatalf("ReserveRefreshToken: %v", err)
+	}
+
+	rt2, err := s.CreateRefreshToken("at-2", "https://gw.example/mcp", fid1, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken rt2: %v", err)
+	}
+
+	_, _, fid2, _, err := s.ReserveRefreshToken(rt2)
+	if err != nil {
+		t.Fatalf("second ReserveRefreshToken: %v", err)
+	}
+	if fid2 != fid1 {
+		t.Errorf("familyID not propagated: rt1=%q rt2=%q", fid1, fid2)
 	}
 }
 

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -436,12 +436,28 @@ func (f *fileTokenStore) flush() error {
 
 // RefreshTokenStore persists gateway-issued refresh token → access token mappings.
 // Two implementations: memRefreshTokenStore (default) and fileRefreshTokenStore (JSON file).
+//
+// Token family tracking (RFC 6819 §5.2.2.3): every refresh token belongs to a
+// family identified by a familyID generated at authorization-code issuance and
+// inherited across rotations. When a revoked token is presented again (reuse
+// attack), RevokeFamily invalidates the entire lineage.
 type RefreshTokenStore interface {
-	// Save records that refreshToken maps to accessToken/audience and is valid until expiresAt.
-	Save(refreshToken, accessToken, audience string, expiresAt time.Time) error
-	// Lookup returns the access token, audience, and expiry for a non-expired refresh token, or ("", "", zero, false).
+	// Save records that refreshToken maps to accessToken/audience/familyID and is valid until expiresAt.
+	Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error
+	// Lookup returns the access token, audience, familyID, and expiry for an active (non-revoked,
+	// non-expired) refresh token. Returns false when the token is unknown, expired, or revoked.
 	// expiresAt is returned so that RestoreRefreshToken can re-save with the original expiry on rotation failure.
-	Lookup(refreshToken string) (accessToken, audience string, expiresAt time.Time, ok bool)
+	Lookup(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, ok bool)
+	// LookupAny is like Lookup but also returns revoked entries that have not yet expired.
+	// Used for reuse detection: a revoked-but-present entry indicates a replay attack.
+	LookupAny(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, revoked, ok bool)
+	// Revoke marks a single refresh token as revoked without deleting it.
+	// The revoked entry is retained until it expires so that reuse detection
+	// (via LookupAny) can identify replay attacks within the expiry window.
+	Revoke(refreshToken string) error
+	// RevokeFamily marks all non-revoked tokens belonging to familyID as revoked.
+	// Used on reuse detection to invalidate the entire token lineage.
+	RevokeFamily(familyID string) error
 	// Delete removes a single refresh token entry immediately.
 	Delete(refreshToken string) error
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
@@ -453,7 +469,9 @@ type RefreshTokenStore interface {
 type memRTEntry struct {
 	accessToken string
 	audience    string
+	familyID    string
 	expiresAt   time.Time
+	revoked     bool
 }
 
 type memRefreshTokenStore struct {
@@ -467,21 +485,61 @@ func NewMemRefreshTokenStore() RefreshTokenStore {
 	return &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
 }
 
-func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience string, expiresAt time.Time) error {
+func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.entries[tokenKey(refreshToken)] = memRTEntry{accessToken: accessToken, audience: audience, expiresAt: expiresAt}
+	m.entries[tokenKey(refreshToken)] = memRTEntry{
+		accessToken: accessToken,
+		audience:    audience,
+		familyID:    familyID,
+		expiresAt:   expiresAt,
+	}
 	return nil
 }
 
-func (m *memRefreshTokenStore) Lookup(refreshToken string) (string, string, time.Time, bool) {
+func (m *memRefreshTokenStore) Lookup(refreshToken string) (string, string, string, time.Time, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.expiresAt) || e.revoked {
+		return "", "", "", time.Time{}, false
+	}
+	return e.accessToken, e.audience, e.familyID, e.expiresAt, true
+}
+
+func (m *memRefreshTokenStore) LookupAny(refreshToken string) (string, string, string, time.Time, bool, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	e, ok := m.entries[tokenKey(refreshToken)]
 	if !ok || time.Now().After(e.expiresAt) {
-		return "", "", time.Time{}, false
+		return "", "", "", time.Time{}, false, false
 	}
-	return e.accessToken, e.audience, e.expiresAt, true
+	return e.accessToken, e.audience, e.familyID, e.expiresAt, e.revoked, true
+}
+
+func (m *memRefreshTokenStore) Revoke(refreshToken string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(refreshToken)
+	e, ok := m.entries[key]
+	if !ok || time.Now().After(e.expiresAt) {
+		return nil
+	}
+	e.revoked = true
+	m.entries[key] = e
+	return nil
+}
+
+func (m *memRefreshTokenStore) RevokeFamily(familyID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, e := range m.entries {
+		if e.familyID == familyID && !e.revoked {
+			e.revoked = true
+			m.entries[k] = e
+		}
+	}
+	return nil
 }
 
 func (m *memRefreshTokenStore) Delete(refreshToken string) error {
@@ -512,7 +570,9 @@ func (m *memRefreshTokenStore) Sweep() error {
 type fileRTEntry struct {
 	AccessToken string    `json:"a"`
 	Audience    string    `json:"aud,omitempty"`
+	FamilyID    string    `json:"fid,omitempty"`
 	ExpiresAt   time.Time `json:"e"`
+	Revoked     bool      `json:"rv,omitempty"`
 }
 
 type fileRefreshTokenStore struct {
@@ -574,12 +634,12 @@ func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	return s, nil
 }
 
-func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience string, expiresAt time.Time) error {
+func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	key := tokenKey(refreshToken)
 	prev, hasPrev := f.entries[key]
-	f.entries[key] = fileRTEntry{AccessToken: accessToken, Audience: audience, ExpiresAt: expiresAt}
+	f.entries[key] = fileRTEntry{AccessToken: accessToken, Audience: audience, FamilyID: familyID, ExpiresAt: expiresAt}
 	if err := f.flush(); err != nil {
 		if hasPrev {
 			f.entries[key] = prev
@@ -591,14 +651,59 @@ func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience string,
 	return nil
 }
 
-func (f *fileRefreshTokenStore) Lookup(refreshToken string) (string, string, time.Time, bool) {
+func (f *fileRefreshTokenStore) Lookup(refreshToken string) (string, string, string, time.Time, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	e, ok := f.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.ExpiresAt) || e.Revoked {
+		return "", "", "", time.Time{}, false
+	}
+	return e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt, true
+}
+
+func (f *fileRefreshTokenStore) LookupAny(refreshToken string) (string, string, string, time.Time, bool, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	e, ok := f.entries[tokenKey(refreshToken)]
 	if !ok || time.Now().After(e.ExpiresAt) {
-		return "", "", time.Time{}, false
+		return "", "", "", time.Time{}, false, false
 	}
-	return e.AccessToken, e.Audience, e.ExpiresAt, true
+	return e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt, e.Revoked, true
+}
+
+func (f *fileRefreshTokenStore) Revoke(refreshToken string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(refreshToken)
+	e, ok := f.entries[key]
+	if !ok || time.Now().After(e.ExpiresAt) {
+		return nil
+	}
+	prev := e
+	e.Revoked = true
+	f.entries[key] = e
+	if err := f.flush(); err != nil {
+		f.entries[key] = prev
+		return err
+	}
+	return nil
+}
+
+func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	changed := false
+	for k, e := range f.entries {
+		if e.FamilyID == familyID && !e.Revoked {
+			e.Revoked = true
+			f.entries[k] = e
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return f.flush()
 }
 
 func (f *fileRefreshTokenStore) Delete(refreshToken string) error {

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -469,10 +469,10 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 
 	// Save and Lookup — hit
 	exp := time.Now().Add(time.Hour)
-	if err := rts.Save("rt1", "access-tok-1", "https://gw.example/mcp", exp); err != nil {
+	if err := rts.Save("rt1", "access-tok-1", "https://gw.example/mcp", "fid-abc", exp); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, gotAudience, gotExp, ok := rts.Lookup("rt1")
+	got, gotAudience, gotFamilyID, gotExp, ok := rts.Lookup("rt1")
 	if !ok {
 		t.Fatal("Lookup: expected hit after Save")
 	}
@@ -482,12 +482,15 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if gotAudience != "https://gw.example/mcp" {
 		t.Errorf("Lookup: audience got %q, want %q", gotAudience, "https://gw.example/mcp")
 	}
+	if gotFamilyID != "fid-abc" {
+		t.Errorf("Lookup: familyID got %q, want %q", gotFamilyID, "fid-abc")
+	}
 	if gotExp.IsZero() {
 		t.Error("Lookup: expiresAt should not be zero")
 	}
 
 	// Lookup — miss for unknown token
-	if _, _, _, ok := rts.Lookup("unknown"); ok {
+	if _, _, _, _, ok := rts.Lookup("unknown"); ok {
 		t.Error("Lookup: expected miss for unknown token")
 	}
 
@@ -495,15 +498,15 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if err := rts.Delete("rt1"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if _, _, _, ok := rts.Lookup("rt1"); ok {
+	if _, _, _, _, ok := rts.Lookup("rt1"); ok {
 		t.Error("Lookup: expected miss after Delete")
 	}
 
 	// Expired entries are not returned by Lookup
-	if err := rts.Save("rt2", "access-tok-2", "", time.Now().Add(-time.Second)); err != nil {
+	if err := rts.Save("rt2", "access-tok-2", "", "fid-xyz", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save expired: %v", err)
 	}
-	if _, _, _, ok := rts.Lookup("rt2"); ok {
+	if _, _, _, _, ok := rts.Lookup("rt2"); ok {
 		t.Error("Lookup: expected miss for expired entry")
 	}
 
@@ -544,7 +547,7 @@ func TestFileRefreshTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("persist-rt", "access-tok-persist", "https://gw.example/mcp", time.Now().Add(time.Hour)); err != nil {
+	if err := rts1.Save("persist-rt", "access-tok-persist", "https://gw.example/mcp", "fid-persist", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -553,7 +556,7 @@ func TestFileRefreshTokenStorePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	accessTok, audience, _, ok := rts2.Lookup("persist-rt")
+	accessTok, audience, _, _, ok := rts2.Lookup("persist-rt")
 	if !ok {
 		t.Fatal("after reload: expected hit for previously saved refresh token")
 	}
@@ -574,7 +577,7 @@ func TestFileRefreshTokenStoreExpiredNotLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("expired-rt", "access-tok-old", "", time.Now().Add(-time.Second)); err != nil {
+	if err := rts1.Save("expired-rt", "access-tok-old", "", "fid-old", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -583,7 +586,7 @@ func TestFileRefreshTokenStoreExpiredNotLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	if _, _, _, ok := rts2.Lookup("expired-rt"); ok {
+	if _, _, _, _, ok := rts2.Lookup("expired-rt"); ok {
 		t.Error("after reload: expired refresh token should not be returned")
 	}
 }
@@ -599,7 +602,7 @@ func TestFileRefreshTokenStoreFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts.Save("rt", "at", "", time.Now().Add(time.Hour)); err != nil {
+	if err := rts.Save("rt", "at", "", "fid-perm", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
@@ -680,10 +683,10 @@ func TestFileRefreshTokenStoreSweepWritesToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileRefreshTokenStore: %v", err)
 	}
-	if err := rts1.Save("valid-rt", "valid-at", "", time.Now().Add(time.Hour)); err != nil {
+	if err := rts1.Save("valid-rt", "valid-at", "", "fid-v", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save valid: %v", err)
 	}
-	if err := rts1.Save("stale-rt", "stale-at", "", time.Now().Add(-time.Second)); err != nil {
+	if err := rts1.Save("stale-rt", "stale-at", "", "fid-s", time.Now().Add(-time.Second)); err != nil {
 		t.Fatalf("Save stale: %v", err)
 	}
 	if err := rts1.Sweep(); err != nil {
@@ -695,10 +698,10 @@ func TestFileRefreshTokenStoreSweepWritesToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
 	}
-	if _, _, _, ok := rts2.Lookup("valid-rt"); !ok {
+	if _, _, _, _, ok := rts2.Lookup("valid-rt"); !ok {
 		t.Error("after sweep+reload: valid refresh token should still be present")
 	}
-	if _, _, _, ok := rts2.Lookup("stale-rt"); ok {
+	if _, _, _, _, ok := rts2.Lookup("stale-rt"); ok {
 		t.Error("after sweep+reload: stale refresh token should have been removed")
 	}
 }
@@ -713,21 +716,120 @@ type alwaysFailRefreshStore struct{}
 
 var errInjectedStoreFailure = errors.New("test: injected store failure")
 
-func (f *alwaysFailRefreshStore) Save(_, _, _ string, _ time.Time) error {
+func (f *alwaysFailRefreshStore) Save(_, _, _, _ string, _ time.Time) error {
 	return errInjectedStoreFailure
 }
-func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, time.Time, bool) {
-	return "", "", time.Time{}, false
+func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, string, time.Time, bool) {
+	return "", "", "", time.Time{}, false
 }
-func (f *alwaysFailRefreshStore) Delete(_ string) error { return errInjectedStoreFailure }
-func (f *alwaysFailRefreshStore) Sweep() error          { return nil }
+func (f *alwaysFailRefreshStore) LookupAny(_ string) (string, string, string, time.Time, bool, bool) {
+	return "", "", "", time.Time{}, false, false
+}
+func (f *alwaysFailRefreshStore) Revoke(_ string) error       { return nil }
+func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error { return nil }
+func (f *alwaysFailRefreshStore) Delete(_ string) error       { return errInjectedStoreFailure }
+func (f *alwaysFailRefreshStore) Sweep() error                { return nil }
+
+// testRefreshTokenStoreReuseDetection exercises LookupAny and RevokeFamily on
+// the given RefreshTokenStore.  It is shared across in-memory and file-backed
+// implementations.
+func testRefreshTokenStoreReuseDetection(t *testing.T, rts RefreshTokenStore) {
+	t.Helper()
+	exp := time.Now().Add(time.Hour)
+
+	// Save two tokens in the same family.
+	if err := rts.Save("rt-a", "at-a", "aud", "fid-one", exp); err != nil {
+		t.Fatalf("Save rt-a: %v", err)
+	}
+	if err := rts.Save("rt-b", "at-b", "aud", "fid-one", exp); err != nil {
+		t.Fatalf("Save rt-b: %v", err)
+	}
+
+	// Simulate rotation: delete rt-a (reserve it).
+	if err := rts.Delete("rt-a"); err != nil {
+		t.Fatalf("Delete rt-a: %v", err)
+	}
+
+	// Lookup must miss for deleted (not expired) rt-a.
+	if _, _, _, _, ok := rts.Lookup("rt-a"); ok {
+		t.Error("Lookup: expected miss for deleted rt-a")
+	}
+
+	// LookupAny must also miss because the entry was hard-deleted (not just revoked).
+	if _, _, _, _, _, ok := rts.LookupAny("rt-a"); ok {
+		t.Error("LookupAny: expected miss for hard-deleted rt-a")
+	}
+
+	// Save a token then revoke the family — rt-b must become inaccessible via Lookup.
+	if err := rts.RevokeFamily("fid-one"); err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+	if _, _, _, _, ok := rts.Lookup("rt-b"); ok {
+		t.Error("Lookup: expected miss for rt-b after RevokeFamily")
+	}
+	// LookupAny must still find rt-b (as revoked=true) until it expires.
+	_, _, fid, _, revoked, ok := rts.LookupAny("rt-b")
+	if !ok {
+		t.Error("LookupAny: expected hit for revoked rt-b")
+	}
+	if !revoked {
+		t.Error("LookupAny: expected revoked=true for rt-b after RevokeFamily")
+	}
+	if fid != "fid-one" {
+		t.Errorf("LookupAny: familyID got %q, want %q", fid, "fid-one")
+	}
+}
+
+func TestMemRefreshTokenStoreReuseDetection(t *testing.T) {
+	testRefreshTokenStoreReuseDetection(t, NewMemRefreshTokenStore())
+}
+
+func TestFileRefreshTokenStoreReuseDetection(t *testing.T) {
+	rts, err := NewFileRefreshTokenStore(tempRefreshStorePath(t))
+	if err != nil {
+		t.Fatalf("NewFileRefreshTokenStore: %v", err)
+	}
+	testRefreshTokenStoreReuseDetection(t, rts)
+}
+
+// TestFileRefreshTokenStoreRevokedPersists verifies that the revoked flag
+// survives a store reload (process restart simulation).
+func TestFileRefreshTokenStoreRevokedPersists(t *testing.T) {
+	path := tempRefreshStorePath(t)
+	rts1, err := NewFileRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("initial NewFileRefreshTokenStore: %v", err)
+	}
+	exp := time.Now().Add(time.Hour)
+	if err := rts1.Save("rt-rv", "at-rv", "aud", "fid-rv", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := rts1.RevokeFamily("fid-rv"); err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+
+	rts2, err := NewFileRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileRefreshTokenStore: %v", err)
+	}
+	if _, _, _, _, ok := rts2.Lookup("rt-rv"); ok {
+		t.Error("after reload: revoked token must not be returned by Lookup")
+	}
+	_, _, _, _, revoked, ok := rts2.LookupAny("rt-rv")
+	if !ok {
+		t.Error("after reload: revoked token must still be findable via LookupAny")
+	}
+	if !revoked {
+		t.Error("after reload: revoked flag must be persisted")
+	}
+}
 
 // TestCreateRefreshTokenSaveError verifies that CreateRefreshToken returns an
 // error when the underlying RefreshTokenStore.Save call fails.
 func TestCreateRefreshTokenSaveError(t *testing.T) {
 	store := NewStore(time.Minute, time.Minute, NewMemTokenStore(),
 		WithRefreshTokenStore(&alwaysFailRefreshStore{}))
-	_, err := store.CreateRefreshToken("access-tok", "https://gw.example/mcp", time.Minute)
+	_, err := store.CreateRefreshToken("access-tok", "https://gw.example/mcp", "fid-1", time.Minute)
 	if err == nil {
 		t.Fatal("expected Save error, got nil")
 	}
@@ -748,5 +850,5 @@ func TestRestoreRefreshTokenSaveError(t *testing.T) {
 	store := NewStore(time.Minute, time.Minute, NewMemTokenStore(),
 		WithRefreshTokenStore(&alwaysFailRefreshStore{}))
 	// Save always fails; RestoreRefreshToken must log and return without panicking.
-	store.RestoreRefreshToken("refresh-tok", "access-tok", "https://gw.example/mcp", time.Now().Add(time.Hour))
+	store.RestoreRefreshToken("refresh-tok", "access-tok", "https://gw.example/mcp", "fid-1", time.Now().Add(time.Hour))
 }


### PR DESCRIPTION
## Summary

- **Token family tracking**: every refresh token is assigned a `family_id` at authorization-code issuance and inherited across rotations, enabling lineage tracing
- **Reuse detection**: presenting a revoked (already-used) refresh token immediately revokes the entire token family via `RevokeFamily` and returns `invalid_grant` — replay attacks are blocked even if the attacker stole a rotated-away token
- **Soft-revoke on rotation**: consumed tokens are marked `revoked=true` (not hard-deleted) so `LookupAny` can detect replays within the expiry window; expired entries are cleaned up by the existing Sweep janitor
- Both `builtin` and `github` modes apply family tracking

## Changes

### `tokenstore.go`
- `RefreshTokenStore` interface: added `Revoke`, `LookupAny`, `RevokeFamily` methods; `Save`/`Lookup` gain `familyID` parameter
- `memRTEntry` / `fileRTEntry`: added `familyID` and `revoked` fields (`"fid"` / `"rv"` JSON keys)
- `fileRTEntry` persists the revoked flag so replay detection survives gateway restarts

### `session.go`
- `CreateRefreshToken(accessToken, audience, familyID string, ttl)` — family ID propagated on rotation
- `ReserveRefreshToken` — soft-revokes on consume; detects revoked-token replay and calls `RevokeFamily`
- `RestoreRefreshToken` — carries `familyID` to preserve lineage on rotation rollback

### `handler.go`
- New `familyID` generated via `generateCode()` at authorization-code and device-code token issuance
- `familyID` propagated through `tokenRefresh` rotation path for both `builtin` and `github` modes

## Test plan

- [x] `TestReserveRefreshTokenReuseRevokesFamily` — revoked token replay revokes entire family; subsequent use of sibling token also fails
- [x] `TestReserveRefreshTokenFamilyIDPropagates` — family_id is identical across rotation chain
- [x] `TestMemRefreshTokenStoreReuseDetection` / `TestFileRefreshTokenStoreReuseDetection` — `LookupAny` / `RevokeFamily` contract on both store implementations
- [x] `TestFileRefreshTokenStoreRevokedPersists` — revoked flag survives reload (file store)
- [x] All existing refresh-token rotation tests pass unchanged
- [x] Full test suite: `go test ./...` — all green
- [x] pre-push: build ✔ lint ✔ test ✔

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)