### PR TITLE
feat(auth): separate aud claim by route via required_audience config (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Separate `aud` claim by route via `required_audience` config ([#129](https://github.com/scottlz0310/mcp-gateway/issues/129))
+  - `RouteConfig.required_audience` / `Route.RequiredAudience` field: per-route JWT audience (e.g. `"mcp-server"`, `"external-mcp"`); defaults to `"mcp-gateway"`
+  - `/token` and device-authorize endpoints accept `resource=<route-name>` (RFC 8707); gateway resolves audience from route config and stamps it in issued access tokens
+  - `"mcp-gateway"` narrowing: refresh token with gateway-wide `mcp-gateway` audience may be narrowed to any per-route audience on subsequent refresh
+  - `ResourceAudienceMap` (`auth.Config`) replaces the former `AllowedAudiences` slice; keys are route names, values are `required_audience` values
+  - `routeResource` (RFC 9728 PRM discovery URL) is kept as a separate URL-form identifier and is not used for JWT aud validation
 - Migrate refresh token store from file-backed JSON to SQLite ([#134](https://github.com/scottlz0310/mcp-gateway/issues/134))
   - Atomic `Revoke` / `RevokeFamily` via single-statement `UPDATE` — eliminates in-process TOCTOU between `Lookup` and `Revoke`
   - Flush-failure rollback is now guaranteed by SQLite transactions (no manual `prev`-state bookkeeping)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -249,7 +249,7 @@ func main() {
 		CacheTTL:             time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
 		ExpiresIn:            time.Duration(cfg.tokenExpiresInSec) * time.Second,
 		TokenStorePath:       cfg.tokenStorePath,
-		AllowedAudiences:     routeAudiences(strings.TrimRight(cfg.publicURL, "/"), routes),
+		ResourceAudienceMap:  buildResourceAudienceMap(routes),
 		TokenAudienceStrict:  cfg.tokenAudienceStrict,
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
 		OIDCPrivateKey:       oidcPrivateKey,
@@ -296,6 +296,8 @@ func main() {
 		if route.NoAuth {
 			wrapped = h
 		} else {
+			// routeResource is the RFC 9728 PRM identifier (URL form) — used
+			// only for discovery metadata, not for JWT aud validation.
 			routeResource := publicURL
 			if route.Prefix != "/" {
 				routeResource = publicURL + route.Prefix
@@ -308,7 +310,7 @@ func main() {
 			// gateway-wide resource_metadata URL via WithBaseURL.
 			authOpts := []middleware.AuthOption{
 				middleware.WithBaseURL(cfg.publicURL),
-				middleware.WithAudience(routeResource),
+				middleware.WithAudience(route.RequiredAudience),
 			}
 			if route.Prefix != "/" {
 				routePRMPath := "/.well-known/oauth-protected-resource" + route.Prefix
@@ -490,24 +492,19 @@ func splitCSV(value string) []string {
 	return out
 }
 
-func routeAudiences(publicURL string, routes []router.Route) []string {
-	audiences := []string{publicURL}
-	seen := map[string]struct{}{publicURL: {}}
+// buildResourceAudienceMap builds the map from route name → required_audience
+// used by auth.Handler to resolve the resource parameter in /token requests.
+// The "mcp-gateway" default is always reachable via resource=mcp-gateway (or
+// by omitting the resource parameter entirely).
+func buildResourceAudienceMap(routes []router.Route) map[string]string {
+	m := make(map[string]string, len(routes))
 	for _, route := range routes {
 		if route.NoAuth {
 			continue
 		}
-		audience := publicURL
-		if route.Prefix != "/" {
-			audience += route.Prefix
-		}
-		if _, ok := seen[audience]; ok {
-			continue
-		}
-		seen[audience] = struct{}{}
-		audiences = append(audiences, audience)
+		m[route.Name] = route.RequiredAudience
 	}
-	return audiences
+	return m
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -68,6 +68,12 @@ type Config struct {
 	// AllowedAudiences is the set of RFC 8707 resource indicator values accepted
 	// by this gateway. BaseURL is always allowed.
 	AllowedAudiences []string
+	// ResourceAudienceMap maps resource parameter values (route names) to the aud
+	// claim to set in issued access tokens. Built from Route.RequiredAudience at
+	// startup by cmd/server. When a /token request includes resource=<key>, the
+	// corresponding value is used as the JWT aud claim.
+	// Example: {"mcp": "mcp-server", "external-mcp": "external-mcp"}
+	ResourceAudienceMap map[string]string
 	// AllowedRedirectSchemes is the set of custom URL schemes (RFC 8252) permitted
 	// as redirect_uri in addition to http and https. When empty, defaults to
 	// ["antigravity", "antigravity-insiders"]. Set explicitly to override.
@@ -98,12 +104,11 @@ const defaultGitHubRefreshLeeway = 5 * time.Minute
 // Handler implements the OAuth façade endpoints, delegating provider-specific
 // operations to a provider.Provider.
 type Handler struct {
-	cfg              Config
-	provider         provider.Provider
-	store            *Store
-	allowedAudiences map[string]struct{}
-	privateKey       *rsa.PrivateKey
-	audit            authaudit.Recorder
+	cfg        Config
+	provider   provider.Provider
+	store      *Store
+	privateKey *rsa.PrivateKey
+	audit      authaudit.Recorder
 	// rotationGroup serializes concurrent GitHub refresh-token rotations
 	// targeting the same access token. Without this, a burst of requests
 	// arriving inside the leeway window would race to call the provider's
@@ -136,7 +141,6 @@ func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handle
 		return nil, fmt.Errorf("auth.NewHandler: provider must not be nil")
 	}
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
-	cfg.AllowedAudiences = normalizeAllowedAudiences(cfg.BaseURL, cfg.AllowedAudiences)
 	if len(cfg.AllowedRedirectHosts) == 0 {
 		cfg.AllowedRedirectHosts = []string{"localhost", "127.0.0.1", "vscode.dev", "antigravity.google"}
 	}
@@ -187,11 +191,10 @@ func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handle
 	}
 
 	handler := &Handler{
-		cfg:              cfg,
-		provider:         p,
-		store:            NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
-		allowedAudiences: audienceSet(cfg.AllowedAudiences),
-		privateKey:       privateKey,
+		cfg:        cfg,
+		provider:   p,
+		store:      NewStore(cfg.SessionTTL, tokensTTL, ts, storeOpts...),
+		privateKey: privateKey,
 	}
 	for _, opt := range opts {
 		opt(handler)
@@ -1514,20 +1517,20 @@ func (h *Handler) resolveRequestedAudience(resources []string) (string, error) {
 		}
 	}
 	if len(resources) == 0 {
-		return h.cfg.BaseURL, nil
+		return "mcp-gateway", nil
 	}
 	if len(resources) > 1 {
 		return "", fmt.Errorf("multiple resource parameters are not supported")
 	}
-	resource := normalizeAudience(resources[0])
-	u, err := url.Parse(resource)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.Fragment != "" {
-		return "", fmt.Errorf("resource must be an absolute http/https URL without fragment")
+	resource := strings.TrimSpace(resources[0])
+	// "mcp-gateway" is the built-in default audience; always resolvable.
+	if resource == "mcp-gateway" {
+		return "mcp-gateway", nil
 	}
-	if _, ok := h.allowedAudiences[resource]; !ok {
-		return "", fmt.Errorf("resource is not registered with this gateway")
+	if aud, ok := h.cfg.ResourceAudienceMap[resource]; ok {
+		return aud, nil
 	}
-	return resource, nil
+	return "", fmt.Errorf("resource %q is not registered with this gateway", resource)
 }
 
 // validateAudience accepts the requested audience when any recorded audience
@@ -1566,44 +1569,29 @@ func (h *Handler) validateAudience(token string, record TokenRecord, audience st
 	return audienceCheckError{ErrTokenAudienceMismatch}
 }
 
-func normalizeAllowedAudiences(baseURL string, audiences []string) []string {
-	out := make([]string, 0, len(audiences)+1)
-	seen := map[string]struct{}{}
-	for _, audience := range append([]string{baseURL}, audiences...) {
-		audience = normalizeAudience(audience)
-		if audience == "" {
-			continue
-		}
-		if _, ok := seen[audience]; ok {
-			continue
-		}
-		seen[audience] = struct{}{}
-		out = append(out, audience)
-	}
-	return out
-}
-
-func audienceSet(audiences []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(audiences))
-	for _, audience := range audiences {
-		set[audience] = struct{}{}
-	}
-	return set
-}
 
 func normalizeAudience(audience string) string {
 	return strings.TrimRight(strings.TrimSpace(audience), "/")
 }
 
-// isSubAudience reports whether requested is equal to or a strict narrowing of
-// original (i.e. requested starts with original+"/"). When original is empty
-// the token was issued without audience metadata (legacy grace-period token),
-// and any registered audience is accepted.
+// isSubAudience reports whether requested is equal to or a valid narrowing of
+// original. For URL-based audiences, narrowing means a strict path prefix.
+// For the identifier "mcp-gateway", any audience is a valid narrowing because
+// it represents gateway-wide access. When original is empty the token was
+// issued without audience metadata (legacy grace-period token), and any
+// audience is accepted.
 func isSubAudience(requested, original string) bool {
 	if original == "" {
 		return true
 	}
-	return requested == original || strings.HasPrefix(requested, original+"/")
+	if requested == original {
+		return true
+	}
+	// Gateway-wide audience may be narrowed to any per-route audience on refresh.
+	if original == "mcp-gateway" {
+		return true
+	}
+	return strings.HasPrefix(requested, original+"/")
 }
 
 func tokenFingerprint(token string) string {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1,4 +1,4 @@
-package auth
+﻿package auth
 
 import (
 	"context"
@@ -395,7 +395,7 @@ func TestOAuthAuditEventsAndSecretRedaction(t *testing.T) {
 		t.Fatal("token response missing gateway refresh token")
 	}
 
-	if _, rotated, err := h.ValidateToken(context.Background(), "secret-access-token", "http://localhost:8080"); err != nil {
+	if _, rotated, err := h.ValidateToken(context.Background(), "secret-access-token", "mcp-gateway"); err != nil {
 		t.Fatalf("ValidateToken: %v", err)
 	} else if rotated != "rotated-secret-access-token" {
 		t.Fatalf("rotated token: got %q", rotated)
@@ -461,7 +461,7 @@ func TestOAuthAuditEventsAndSecretRedaction(t *testing.T) {
 }
 
 func TestAuthorizeResourceAudienceStoredOnToken(t *testing.T) {
-	const routeAudience = "http://localhost:8080/mcp/foo"
+	const routeAudience = "mcp-server"
 	p := &provider.Mock{
 		ClientIDValue: "test-client-id",
 		ScopesValue:   "repo,user",
@@ -476,18 +476,18 @@ func TestAuthorizeResourceAudienceStoredOnToken(t *testing.T) {
 		},
 	}
 	h, err := NewHandler(Config{
-		BaseURL:          "http://localhost:8080",
-		SessionTTL:       10 * time.Minute,
-		CacheTTL:         5 * time.Minute,
-		ExpiresIn:        90 * 24 * time.Hour,
-		AllowedAudiences: []string{routeAudience},
+		BaseURL:             "http://localhost:8080",
+		SessionTTL:          10 * time.Minute,
+		CacheTTL:            5 * time.Minute,
+		ExpiresIn:           90 * 24 * time.Hour,
+		ResourceAudienceMap: map[string]string{"foo": routeAudience},
 	}, p)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
 	authReq := httptest.NewRequest(http.MethodGet,
-		"/authorize?response_type=code&state=state-aud&redirect_uri=http://localhost/cb&resource="+url.QueryEscape(routeAudience), nil)
+		"/authorize?response_type=code&state=state-aud&redirect_uri=http://localhost/cb&resource=foo", nil)
 	authRec := httptest.NewRecorder()
 	h.Authorize(authRec, authReq)
 	if authRec.Code != http.StatusFound {
@@ -540,7 +540,7 @@ func TestAuthorizeResourceAudienceStoredOnToken(t *testing.T) {
 func TestAuthorizeRejectsUnknownResource(t *testing.T) {
 	h := newTestHandler(t)
 	r := httptest.NewRequest(http.MethodGet,
-		"/authorize?response_type=code&state=s&redirect_uri=http://localhost/cb&resource=http%3A%2F%2Flocalhost%3A8080%2Fmcp%2Fmissing", nil)
+		"/authorize?response_type=code&state=s&redirect_uri=http://localhost/cb&resource=missing-route", nil)
 	w := httptest.NewRecorder()
 
 	h.Authorize(w, r)
@@ -1524,8 +1524,8 @@ func TestNewHandlerRefreshStoreInitError(t *testing.T) {
 }
 
 // newTestRefreshHandlerWithGitHub creates a Handler wired to a stub GitHub user API
-// and configured with extra allowed audiences.
-func newTestRefreshHandlerWithGitHub(t *testing.T, extraAudiences []string) (*Handler, *httptest.Server) {
+// and configured with a ResourceAudienceMap for refresh token audience tests.
+func newTestRefreshHandlerWithGitHub(t *testing.T, resourceMap map[string]string) (*Handler, *httptest.Server) {
 	t.Helper()
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1541,11 +1541,11 @@ func newTestRefreshHandlerWithGitHub(t *testing.T, extraAudiences []string) (*Ha
 		HTTPClient:   ghServer.Client(),
 	})
 	h, err := NewHandler(Config{
-		BaseURL:          "http://localhost:8080",
-		SessionTTL:       10 * time.Minute,
-		CacheTTL:         5 * time.Minute,
-		ExpiresIn:        90 * 24 * time.Hour,
-		AllowedAudiences: extraAudiences,
+		BaseURL:             "http://localhost:8080",
+		SessionTTL:          10 * time.Minute,
+		CacheTTL:            5 * time.Minute,
+		ExpiresIn:           90 * 24 * time.Hour,
+		ResourceAudienceMap: resourceMap,
 	}, p)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
@@ -1556,15 +1556,15 @@ func newTestRefreshHandlerWithGitHub(t *testing.T, extraAudiences []string) (*Ha
 // TestTokenRefreshResourceSameAudience verifies that a resource matching the
 // original audience is accepted and returns 200.
 func TestTokenRefreshResourceSameAudience(t *testing.T) {
-	const audience = "http://localhost:8080/mcp/route-a"
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{audience})
+	const audience = "mcp-server"
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": audience})
 
 	rt, err := h.store.CreateRefreshToken("gha_token", audience, "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(audience)
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=route-a"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1581,18 +1581,18 @@ func TestTokenRefreshResourceSameAudience(t *testing.T) {
 }
 
 // TestTokenRefreshResourceNarrowing verifies that a client may narrow a
-// gateway-wide audience to a per-route sub-path on refresh.
+// gateway-wide audience to a per-route audience on refresh.
 func TestTokenRefreshResourceNarrowing(t *testing.T) {
-	const routeAud = "http://localhost:8080/mcp/route-a"
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+	const routeAud = "mcp-server"
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": routeAud})
 
-	// Original token is gateway-wide.
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
+	// Original token is gateway-wide (mcp-gateway).
+	rt, err := h.store.CreateRefreshToken("gha_token", "mcp-gateway", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(routeAud)
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=route-a"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1604,19 +1604,19 @@ func TestTokenRefreshResourceNarrowing(t *testing.T) {
 }
 
 // TestTokenRefreshResourceCrossRoute verifies that switching from one route
-// audience to a sibling route is rejected with 400 invalid_target.
+// audience to a distinct sibling audience is rejected with 400 invalid_target.
 func TestTokenRefreshResourceCrossRoute(t *testing.T) {
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{
-		"http://localhost:8080/mcp/route-a",
-		"http://localhost:8080/mcp/route-b",
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{
+		"route-a": "mcp-server",
+		"route-b": "external-mcp",
 	})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080/mcp/route-a", "", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "mcp-server", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("http://localhost:8080/mcp/route-b")
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=route-b"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1633,17 +1633,17 @@ func TestTokenRefreshResourceCrossRoute(t *testing.T) {
 }
 
 // TestTokenRefreshResourceWidening verifies that broadening a per-route
-// audience to gateway-wide is rejected with 400 invalid_target.
+// audience to the gateway-wide audience is rejected with 400 invalid_target.
 func TestTokenRefreshResourceWidening(t *testing.T) {
-	const routeAud = "http://localhost:8080/mcp/route-a"
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+	const routeAud = "mcp-server"
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": routeAud})
 
 	rt, err := h.store.CreateRefreshToken("gha_token", routeAud, "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("http://localhost:8080")
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=mcp-gateway"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1664,12 +1664,12 @@ func TestTokenRefreshResourceWidening(t *testing.T) {
 func TestTokenRefreshResourceUnknown(t *testing.T) {
 	h, _ := newTestRefreshHandlerWithGitHub(t, nil)
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "mcp-gateway", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape("https://unknown.example/mcp")
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=unknown-route"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1692,8 +1692,8 @@ func TestTokenRefreshResourceUnknown(t *testing.T) {
 // TestTokenRefreshResourceLegacyToken verifies that a legacy token (empty
 // stored audience) accepts any registered resource as a valid narrowing.
 func TestTokenRefreshResourceLegacyToken(t *testing.T) {
-	const routeAud = "http://localhost:8080/mcp/route-a"
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+	const routeAud = "mcp-server"
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": routeAud})
 
 	// Empty audience simulates a pre-audience (legacy) refresh token.
 	rt, err := h.store.CreateRefreshToken("gha_token", "", "", h.refreshTokenTTL())
@@ -1701,7 +1701,7 @@ func TestTokenRefreshResourceLegacyToken(t *testing.T) {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=" + url.QueryEscape(routeAud)
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=route-a"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -1713,11 +1713,11 @@ func TestTokenRefreshResourceLegacyToken(t *testing.T) {
 }
 
 // TestTokenRefreshResourceEmptyValue verifies that resource= (empty value) is
-// rejected as invalid_target (RFC 8707 requires a non-empty absolute URI).
+// rejected as invalid_target.
 func TestTokenRefreshResourceEmptyValue(t *testing.T) {
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{"http://localhost:8080/mcp/route-a"})
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": "mcp-server"})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "mcp-gateway", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
@@ -1738,19 +1738,18 @@ func TestTokenRefreshResourceEmptyValue(t *testing.T) {
 	}
 }
 
-// TestTokenRefreshResourceMultipleRaw verifies that resource=&resource=https://x
-// (one empty, one valid) is rejected  Eraw count check ignores empty filtering.
+// TestTokenRefreshResourceMultipleRaw verifies that resource=&resource=route-a
+// (one empty, one valid) is rejected — empty value check runs before multi-check.
 func TestTokenRefreshResourceMultipleRaw(t *testing.T) {
-	const routeAud = "http://localhost:8080/mcp/route-a"
-	h, _ := newTestRefreshHandlerWithGitHub(t, []string{routeAud})
+	const routeAud = "mcp-server"
+	h, _ := newTestRefreshHandlerWithGitHub(t, map[string]string{"route-a": routeAud})
 
-	rt, err := h.store.CreateRefreshToken("gha_token", "http://localhost:8080", "", h.refreshTokenTTL())
+	rt, err := h.store.CreateRefreshToken("gha_token", "mcp-gateway", "", h.refreshTokenTTL())
 	if err != nil {
 		t.Fatalf("seeding refresh token: %v", err)
 	}
 
-	// resource= (empty) is present first  Eshould be rejected before multi-check
-	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=&resource=" + url.QueryEscape(routeAud)
+	body := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt) + "&resource=&resource=route-a"
 	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,11 @@ type RouteConfig struct {
 	// UpstreamBearerTokenEnv names the env var whose value is injected as the
 	// upstream Authorization Bearer token. When empty, the client OAuth token is used.
 	UpstreamBearerTokenEnv string `yaml:"upstream_bearer_token_env,omitempty" json:"upstream_bearer_token_env,omitempty"`
+	// RequiredAudience is the aud claim value required in access tokens for this
+	// route (e.g. "mcp-server", "external-mcp"). Defaults to "mcp-gateway" when
+	// empty. Clients obtain a token with this audience by passing resource=<route-name>
+	// to the /token endpoint.
+	RequiredAudience string `yaml:"required_audience,omitempty" json:"required_audience,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -184,11 +184,16 @@ func parseRoutes(env []string) ([]Route, error) {
 func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 	var routes []Route
 	seen := make(map[string]struct{})
+	seenNames := make(map[string]struct{})
 	for _, r := range cfgRoutes {
 		name := strings.ToLower(strings.TrimSpace(r.Name))
 		if name == "" {
 			return nil, fmt.Errorf("route name must not be empty")
 		}
+		if _, dup := seenNames[name]; dup {
+			return nil, fmt.Errorf("route %q: duplicate route name", name)
+		}
+		seenNames[name] = struct{}{}
 		prefix := r.Prefix
 		if prefix != "/" {
 			prefix = strings.TrimRight(prefix, "/")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,6 +10,11 @@ import (
 	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 )
 
+// DefaultRequiredAudience is the aud claim value used when a route does not
+// specify required_audience. It matches the default resource for clients that
+// do not pass a resource parameter to /token.
+const DefaultRequiredAudience = "mcp-gateway"
+
 // Route maps a URL path prefix to an upstream MCP server.
 type Route struct {
 	Name     string
@@ -26,6 +31,10 @@ type Route struct {
 	// than terminating. Operators must restart the gateway after rotating
 	// this credential to restore fail-closed protection.
 	UpstreamBearerTokenEnv string
+	// RequiredAudience is the aud claim value that access tokens must carry to
+	// access this route. Clients request a token with this audience by passing
+	// resource=<route-name> to the /token endpoint. Defaults to "mcp-gateway".
+	RequiredAudience string
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
@@ -104,6 +113,17 @@ func parseRoutes(env []string) ([]Route, error) {
 			delete(options, "upstream_bearer_token_env")
 		}
 
+		// required_audience: the aud claim value access tokens must carry to reach this route.
+		requiredAudience := DefaultRequiredAudience
+		if aud, ok := options["required_audience"]; ok {
+			aud = strings.TrimSpace(aud)
+			if aud == "" {
+				return nil, fmt.Errorf("%s: required_audience value must not be empty", key)
+			}
+			requiredAudience = aud
+			delete(options, "required_audience")
+		}
+
 		// Reject any unrecognised option keys.
 		if len(options) > 0 {
 			unknown := make([]string, 0, len(options))
@@ -147,6 +167,7 @@ func parseRoutes(env []string) ([]Route, error) {
 			Upstream:               u,
 			NoAuth:                 noAuth,
 			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
+			RequiredAudience:       requiredAudience,
 		})
 	}
 	// Longest prefix first for correct matching order.
@@ -204,6 +225,10 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 				return nil, fmt.Errorf("route %q: upstream_bearer_token_env=%s is not set or empty (fail-closed)", name, upstreamBearerTokenEnv)
 			}
 		}
+		requiredAudience := strings.TrimSpace(r.RequiredAudience)
+		if requiredAudience == "" {
+			requiredAudience = DefaultRequiredAudience
+		}
 		seen[prefix] = struct{}{}
 		routes = append(routes, Route{
 			Name:                   name,
@@ -211,6 +236,7 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			Upstream:               u,
 			NoAuth:                 r.NoAuth,
 			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
+			RequiredAudience:       requiredAudience,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"strings"
 	"testing"
 
 	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
@@ -284,6 +285,20 @@ func TestParseFromConfig_DuplicatePrefix(t *testing.T) {
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
 		t.Fatal("expected error for duplicate prefix")
+	}
+}
+
+func TestParseFromConfig_DuplicateName(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "mcp", Prefix: "/mcp/a", Upstream: "http://a:8080"},
+		{Name: "mcp", Prefix: "/mcp/b", Upstream: "http://b:8081"},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for duplicate route name")
+	}
+	if !strings.Contains(err.Error(), "duplicate route name") {
+		t.Errorf("error should mention duplicate route name, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `RouteConfig.required_audience` / `Route.RequiredAudience` フィールドを追加（デフォルト: `"mcp-gateway"`）
- `/token` エンドポイントが `resource=<route-name>` (RFC 8707) を受け付け、`ResourceAudienceMap` からルート名 → JWT aud を解決
- `mcp-gateway` narrowing: gateway-wide トークン (`aud=mcp-gateway`) は refresh 時に任意の per-route audience に narrowing 可能
- `AllowedAudiences` / `audienceSet` / `normalizeAllowedAudiences` を削除し `ResourceAudienceMap` に一本化
- `routeResource` (RFC 9728 PRM 用 URL 形式識別子) を JWT aud 検証から分離

## Design

```
resource=<route-name>  →  ResourceAudienceMap  →  JWT aud  →  proxy middleware validation
                                 ↑
                    Route.RequiredAudience (config)
```

- `resource` パラメータはルート名（識別子）: `resource=mcp`, `resource=external-mcp`
- `routeResource` (URL 形式: `http://gateway.example.com/mcp`) は RFC 9728 PRM discovery メタデータ専用
- これにより `/token` での resource 解決と proxy での aud 検証が同一設定（`RequiredAudience`）を参照する一貫した構造になる

## Test plan

- [x] `go test ./...` — 全 PASS (pre-push hook で確認済み)
- [x] `TestAuthorizeResourceAudienceStoredOnToken` — ルート名 resource → aud claim がトークンに記録される
- [x] `TestTokenRefreshResourceNarrowing` — `mcp-gateway` → `mcp-server` への narrowing が許可される
- [x] `TestTokenRefreshResourceCrossRoute` — 異なる audience 間の切り替えが拒否される
- [x] `TestTokenRefreshResourceWidening` — `mcp-server` → `mcp-gateway` への widening が拒否される
- [x] `TestTokenRefreshResourceLegacyToken` — 旧形式の空 audience トークンは任意の registered resource を許可

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)