### PR TITLE
feat(provider): GitHub Apps への切り替え本体（provider 差し替え・コールバック URL・ドキュメント）

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,11 @@
 
 ### 追加
 
+- GitHub OAuth Apps から GitHub Apps（user-to-server OAuth）へのプロバイダー切り替え（[#139](https://github.com/scottlz0310/mcp-gateway/issues/139)）
+  - `ghu_` ユーザーアクセストークン（GitHub Apps）を `gho_`（OAuth Apps）と同様に受け入れ可能 — プレフィックス検証ロジックが存在しないためコード変更不要
+  - README / README.ja.md: Step 1 を「GitHub App を作成」に更新。`/callback` と `/device_callback` の両コールバック URL 登録手順、最小 Permissions（`Email addresses: Read-only`）、OAuth Apps からの移行手順を追記
+  - docs/configuration.md: "GitHub OAuth App" 参照を "GitHub App" に統一
+  - 内部: テストフィクスチャを `ghu_` プレフィックスに更新、factory エラーメッセージを "GitHub App credentials" に更新
 - OAuth 監査ログと診断機能を追加（[#102](https://github.com/scottlz0310/mcp-gateway/issues/102)）
   - authorize、callback、token exchange、identity resolution、refresh、provider rotation の成否を構造化イベントとして記録
   - OS のユーザー state 領域を既定とし、Git worktree 外へ機密情報を除外した JSON Lines をサイズ・日数・世代数でローテーション保存

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Switch provider from GitHub OAuth Apps to GitHub Apps (user-to-server OAuth) ([#139](https://github.com/scottlz0310/mcp-gateway/issues/139))
+  - `ghu_` user access tokens (GitHub Apps) accepted alongside classic `gho_` tokens — no code changes required, no prefix validation present
+  - README and README.ja.md: Step 1 updated to "Create A GitHub App" with both `/callback` and `/device_callback` callback URL registration instructions, minimum permissions (`Email addresses: Read-only`), and migration note from OAuth Apps
+  - docs/configuration.md: "GitHub OAuth App" references updated to "GitHub App" throughout
+  - Internal: test fixture updated to `ghu_` prefix; factory error message updated to "GitHub App credentials"
 - Device Authorization Grant (RFC 8628) fully implemented as gateway-native flow ([#130](https://github.com/scottlz0310/mcp-gateway/issues/130))
   - `POST /device_authorization` now generates a gateway-own `device_code` and `user_code` (XXXX-XXXX format); no longer delegates to GitHub's device flow
   - `GET /activate` renders a user_code entry form; `POST /activate` validates the code and redirects to the standard `/authorize` flow

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,17 +11,31 @@ VS Code などの MCP クライアントから見た単一の HTTP エントリ�
 
 ## はじめに
 
-### 1. GitHub OAuth App を作成
+### 1. GitHub App を作成
 
-**GitHub -> Settings -> Developer settings -> OAuth Apps -> New OAuth App** を開きます。
+**GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App** を開きます。
 
-ローカル開発では callback URL に次を設定します。
+以下の設定を行います。
 
-```text
-http://127.0.0.1:8080/callback
-```
+- **Callback URLs** — 次の 2 つを両方登録します。
+  ```text
+  http://127.0.0.1:8080/callback
+  http://127.0.0.1:8080/device_callback
+  ```
+  デプロイ環境では `http://127.0.0.1:8080` を `<MCP_GATEWAY_PUBLIC_URL>` に置き換えてください。
+- **Permissions** — 最低限 `Account permissions: Email addresses: Read-only` を設定します。
+  上流 MCP サーバーが必要とする権限を追加してください。
+- **Webhook** — 無効のままにします（OAuth フローでは使用しません）。
+- **Where can this GitHub App be installed?** — 個人利用の場合は `Only on this account` を選択します。
 
-デプロイ環境では `<MCP_GATEWAY_PUBLIC_URL>/callback` を設定します。
+作成後、アプリ設定ページで **Client secret** を生成し、**Client ID** と合わせてコピーします。
+
+> **GitHub OAuth App からの移行**: `OAUTH_CLIENT_ID` と `OAUTH_CLIENT_SECRET` を新しい
+> GitHub App の認証情報に置き換えるだけで移行できます。コードや設定ファイルの変更は不要です。
+> ゲートウェイは `gho_`（OAuth App）と `ghu_`（GitHub App）の両トークンに対応しています。
+>
+> **トークン有効期限について**: "Expire user authorization tokens" は現時点では無効のまま
+> にしてください。短命 `ghu_` トークンのローテーション対応は次のリリースで追加予定です。
 
 ### 2. Docker Compose で起動
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,33 @@ single HTTP entry point for MCP clients such as Claude Desktop and VS Code.
 
 ## Getting Started
 
-### 1. Create A GitHub OAuth App
+### 1. Create A GitHub App
 
-Open **GitHub -> Settings -> Developer settings -> OAuth Apps -> New OAuth App**.
+Open **GitHub -> Settings -> Developer settings -> GitHub Apps -> New GitHub App**.
 
-Use this callback URL for local development:
+Configure the following settings:
 
-```text
-http://127.0.0.1:8080/callback
-```
+- **Callback URLs** — register both endpoints:
+  ```text
+  http://127.0.0.1:8080/callback
+  http://127.0.0.1:8080/device_callback
+  ```
+  For deployed environments, replace `http://127.0.0.1:8080` with `<MCP_GATEWAY_PUBLIC_URL>`.
+- **Permissions** — set at minimum `Account permissions: Email addresses: Read-only`.
+  Add any additional permissions required by your MCP upstreams.
+- **Webhook** — leave disabled (not used by the OAuth flow).
+- **Where can this GitHub App be installed?** — `Only on this account` for personal use.
 
-For deployed environments, use `<MCP_GATEWAY_PUBLIC_URL>/callback`.
+After creation, generate a **Client secret** from the app settings page and copy the **Client ID**.
+
+> **Migrating from a GitHub OAuth App?** Replace `OAUTH_CLIENT_ID` and
+> `OAUTH_CLIENT_SECRET` with the new GitHub App credentials. No code or
+> config changes are needed — the gateway works with both `gho_` (OAuth App)
+> and `ghu_` (GitHub App) user access tokens.
+>
+> **Expiring tokens:** Leave "Expire user authorization tokens" disabled for
+> now. Support for rotating short-lived `ghu_` tokens will be added in a
+> follow-up release.
 
 ### 2. Run With Docker Compose
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` | `5` | 保持するローテーション済み監査ログの最大数。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS` | `30` | ローテーション済み監査ログの最大保持日数。 |
 | `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT` | `false` | Reject legacy tokens that have no recorded audience metadata. Leave disabled during migration. |
-| `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub OAuth user access tokens. Safe to leave on with non-expiring OAuth Apps; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
+| `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` | `false` | Enable transparent rotation of expiring GitHub user access tokens. Safe to leave on when token expiration is disabled on the GitHub App; the rotation path stays dormant unless GitHub returns `refresh_token` + `expires_in`. See [GitHub OAuth Refresh Token Rotation](#github-oauth-refresh-token-rotation). |
 | `MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS` | none | Comma-separated list of hostnames permitted in OAuth redirect_uris. When set, replaces the built-in default list entirely. |
 | `MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES` | none | Comma-separated list of custom URL schemes (RFC 8252) permitted in OAuth redirect_uris in addition to `http` and `https`. When set, replaces the built-in default list entirely. Defaults to `antigravity,antigravity-insiders`. |
 | `LOG_LEVEL` | `info` | JSON log level: `debug`, `info`, `warn`, or `error`. |
@@ -126,8 +126,8 @@ setup:
 | `auth.provider` | OAuth provider kind (`github` or `oidc`). |
 | `auth.client_id` | Generic OAuth client ID. |
 | `auth.client_secret` | Generic OAuth client secret. May be encrypted as `ENC[age:]...`. |
-| `auth.github_client_id` | GitHub OAuth App client ID. |
-| `auth.github_client_secret` | GitHub OAuth App client secret. May be encrypted as `ENC[age:]...`. |
+| `auth.github_client_id` | GitHub App client ID. |
+| `auth.github_client_secret` | GitHub App client secret. May be encrypted as `ENC[age:]...`. |
 | `auth.oidc_issuer_url` | OIDC issuer URL. |
 | `auth.oidc_audience` | OIDC audience. Reserved for future local JWT validation; currently unused/no-op in UserInfo validation. |
 | `gateway.public_url` | Canonical public URL visible to OAuth and MCP clients. |
@@ -246,7 +246,7 @@ Operational implications of refresh-token persistence:
 - A reader of `tokens.json` can hijack the logged-in user's GitHub session for
   the lifetime of the refresh token. With GitHub's expiring-user-token
   configuration this is typically **six months** unless the user revokes the
-  authorization or the OAuth App is reconfigured.
+  authorization or the GitHub App is reconfigured.
 - Backups of `tokens.json` carry the same risk. Encrypt backup volumes at
   rest, or exclude `tokens.json` and `tokens.json.refresh` from broad backup
   scopes.
@@ -341,7 +341,7 @@ client secret、Authorization header、provider response body を保存しない
 
 ## GitHub OAuth Refresh Token Rotation
 
-When the GitHub OAuth App is configured with **Expire user authorization tokens**
+When the GitHub App is configured with **Expire user authorization tokens**
 enabled, GitHub returns a `refresh_token` and an `expires_in` value alongside
 each access token (typically 8 hours of access-token lifetime and 6 months of
 refresh-token lifetime). The gateway can transparently rotate these tokens
@@ -363,9 +363,10 @@ gateway:
   github_refresh_enabled: true
 ```
 
-Defaults to `false`. The flag is safe to leave on even with non-expiring OAuth
-Apps: the rotation path only fires when the cached token entry has a non-zero
-`expires_in` hint and a refresh token, which classic OAuth Apps do not provide.
+Defaults to `false`. The flag is safe to leave on even when token expiration is
+disabled on the GitHub App: the rotation path only fires when the cached token
+entry has a non-zero `expires_in` hint and a refresh token, which non-expiring
+configurations do not provide.
 
 ### Behavior
 
@@ -409,8 +410,8 @@ token, but does not retroactively patch background workers.
 
 | Symptom | Likely cause |
 |---------|--------------|
-| Log entry `rotation_failed err=bad_refresh_token` | The OAuth App revoked the refresh token (manually or because the user reset it). Clients must re-authenticate. |
-| Rotation never fires for any token | The OAuth App is not configured for expiring tokens, or `expires_in` is missing from the token response. Verify the app setting in GitHub Developer Settings. |
+| Log entry `rotation_failed err=bad_refresh_token` | The GitHub App revoked the refresh token (manually or because the user reset it). Clients must re-authenticate. |
+| Rotation never fires for any token | The GitHub App does not have "Expire user authorization tokens" enabled, or `expires_in` is missing from the token response. Verify the app setting in GitHub Developer Settings. |
 | Rotation fires but the upstream still sees 401 | The upstream cached the old bearer in its own state (e.g. a `review-raven` watch goroutine). Phase A intentionally does not patch upstream state — this is the Phase B scope. |
 
 ## OAuth Resource Parameters

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -80,7 +80,7 @@ type Config struct {
 	TokenAudienceStrict bool
 	// GitHubRefreshEnabled turns on transparent rotation of GitHub-issued access
 	// tokens when the upstream provider advertises a refresh token and an
-	// expires_in hint (OAuth Apps with "Expire user authorization tokens"
+	// expires_in hint (GitHub Apps with "Expire user authorization tokens"
 	// enabled). When the upstream is configured for non-expiring tokens this
 	// flag has no effect; it is safe to leave on.
 	GitHubRefreshEnabled bool

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -340,7 +340,7 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 }
 
 // Register implements RFC 7591 Dynamic Client Registration (pseudo).
-// Always returns the configured upstream OAuth App client_id.
+// Always returns the configured upstream GitHub App client_id.
 func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 

--- a/internal/auth/provider/factory.go
+++ b/internal/auth/provider/factory.go
@@ -43,7 +43,7 @@ func New(cfg Config) (Provider, error) {
 		}), nil
 	case "builtin":
 		if cfg.ClientID == "" || cfg.ClientSecret == "" {
-			return nil, fmt.Errorf("builtin provider requires ClientID and ClientSecret (GitHub OAuth App credentials)")
+			return nil, fmt.Errorf("builtin provider requires ClientID and ClientSecret (GitHub App credentials)")
 		}
 		if cfg.RedirectURI == "" {
 			return nil, fmt.Errorf("builtin provider requires RedirectURI")

--- a/internal/auth/provider/github.go
+++ b/internal/auth/provider/github.go
@@ -94,8 +94,8 @@ func (p *githubProvider) ExchangeCode(ctx context.Context, code string) (TokenRe
 	return p.postToken(ctx, form, "exchange")
 }
 
-// RefreshToken rotates a GitHub OAuth refresh token (RFC 6749 §6).  Only
-// works when the OAuth App is configured with expiring user access tokens;
+// RefreshToken rotates a GitHub user access token (RFC 6749 §6).  Only
+// works when the GitHub App is configured with expiring user authorization tokens;
 // otherwise GitHub returns an OAuth error which is surfaced verbatim.
 func (p *githubProvider) RefreshToken(ctx context.Context, refreshToken string) (TokenResponse, error) {
 	if strings.TrimSpace(refreshToken) == "" {

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -190,7 +190,7 @@ func (m *memTokenStore) Sweep() error {
 // it to the upstream OAuth provider on rotation. The file is written with
 // mode 0600, but operators should treat tokens.json as a long-lived
 // credential surface: any reader can hijack a logged-in user's GitHub session
-// until the refresh token is revoked (typically the OAuth App rotation
+// until the refresh token is revoked (typically the GitHub App rotation
 // window — months). Snapshot, backup, and access-control implications are
 // covered in docs/configuration.md under "Token Persistence".
 type fileEntry struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,8 +77,8 @@ type GatewayConfig struct {
 	// Leave false during the migration grace period for tokens issued before #57.
 	TokenAudienceStrict bool `yaml:"token_audience_strict,omitempty"`
 	// GitHubRefreshEnabled turns on transparent rotation of expiring GitHub
-	// OAuth user access tokens (Phase A of issue #70). Safe to leave on when
-	// the OAuth App is configured for non-expiring tokens — the rotation path
+	// user access tokens (Phase A of issue #70). Safe to leave on when
+	// the GitHub App is configured for non-expiring tokens — the rotation path
 	// is dormant unless the upstream advertises refresh_token + expires_in.
 	GitHubRefreshEnabled bool `yaml:"github_refresh_enabled,omitempty"`
 	// AllowedRedirectHosts lists hostnames permitted in OAuth redirect_uris.

--- a/internal/internalapi/handler_test.go
+++ b/internal/internalapi/handler_test.go
@@ -77,7 +77,7 @@ func TestWhoamiHappyPath(t *testing.T) {
 	expiry := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
 	resolver := &fakeResolver{
 		result: auth.DelegatedAccessResult{
-			AccessToken:          "gho_fresh_xyz",
+			AccessToken:          "ghu_fresh_xyz",
 			ProviderAccessExpiry: expiry,
 			Scopes:               []string{"repo", "read:user"},
 		},
@@ -95,7 +95,7 @@ func TestWhoamiHappyPath(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if payload["access_token"] != "gho_fresh_xyz" {
+	if payload["access_token"] != "ghu_fresh_xyz" {
 		t.Errorf("access_token: got %v", payload["access_token"])
 	}
 	if payload["token_type"] != "bearer" {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -23,7 +23,7 @@ const ContextKeyToken contextKey = "auth_token"
 //
 // The second return value (rotatedToken) is non-empty when the underlying
 // provider transparently rotated the upstream access token during validation
-// (e.g. GitHub OAuth Apps with expiring tokens). When non-empty, Auth
+// (e.g. GitHub Apps with expiring tokens). When non-empty, Auth
 // middleware substitutes it for the original bearer token in the request
 // context so that the reverse proxy forwards the fresh token to the upstream
 // MCP server.

--- a/tasks.md
+++ b/tasks.md
@@ -13,6 +13,24 @@
 
 ---
 
+## Issue #139 — GitHub Apps への切り替え本体（provider 差し替え・コールバック URL・ドキュメント）
+
+**目的**: GitHub OAuth Apps から GitHub Apps（user-to-server OAuth）へのプロバイダー切り替えを行う。トークン有効期限対応は Sub-Issue B（#138）に分離。
+
+### サブタスク
+
+- [x] `ghu_` プレフィックストークンの受け入れ確認 — プレフィックス検証ロジックが存在しないため既存コードで対応済み
+- [x] `internal/auth/provider/github.go` コメントを GitHub Apps に更新（`RefreshToken` の docstring）
+- [x] `internal/auth/provider/factory.go` エラーメッセージを "GitHub App credentials" に更新
+- [x] `internal/auth/handler.go` コメント更新（`GitHubRefreshEnabled` フィールド）
+- [x] `internal/internalapi/handler_test.go` テストフィクスチャを `ghu_` プレフィックスに更新
+- [x] `README.md` / `README.ja.md` を GitHub App 作成手順に更新（`/callback` + `/device_callback` 両 URL 登録、最小 Permissions、移行ガイド）
+- [x] `docs/configuration.md` の "GitHub OAuth App" 参照を "GitHub App" に統一
+- [x] `CHANGELOG.md` / `CHANGELOG.ja.md` の `Unreleased` を更新
+- [x] `tasks.md` に本 Issue を記録
+
+---
+
 ## Issue #105 — ルーティング先 MCP サーバーで報告される認証切れをログから調査する
 
 **目的**: mcp-gateway でルーティングしている複数の MCP サーバーから報告されている認証切れエラーについて、ログや設定ファイルを基に原因特定・境界分析を行い、対策を決定する。


### PR DESCRIPTION
## Summary

- README / README.ja.md: Step 1 を「GitHub App を作成」に更新。`/callback` と `/device_callback` 両コールバック URL 登録手順、最小 Permissions（`Email addresses: Read-only`）、OAuth Apps からの移行ガイドを追記
- docs/configuration.md: 「GitHub OAuth App」参照を「GitHub App」に統一
- `internal/auth/provider/github.go` / `handler.go` / `factory.go`: コメントを GitHub Apps 対応に更新
- `internal/internalapi/handler_test.go`: テストフィクスチャを `ghu_` プレフィックスに更新（GitHub Apps ユーザーアクセストークンのプレフィックス）

## Background

`ghu_` トークン受け入れは**既存コードで対応済み**。`github.go` にはトークンプレフィックス検証ロジックが存在しないため、GitHub Apps の `ghu_` トークンはそのまま動作する。

トークン有効期限対応（`tryGitHubRotation` の `ghu_` 互換）は Sub-Issue B（#138）で実施予定。

## Test plan

- [x] `go test ./...` が全パッケージ PASS（pre-push hook でも確認済み）
- [x] lint（staticcheck）0 issues

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)