### PR TITLE
docs: sync configuration.md and READMEs with OS state dir defaults (#147)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,9 +7,12 @@
 
 ### 追加
 
-- 実行時状態ファイルのデフォルトパスを OS のユーザーデータディレクトリに変更（[#144](https://github.com/scottlz0310/mcp-gateway/issues/144)）
-  - `MCP_GATEWAY_KEY_PATH`・`MCP_CONFIG_FILE`・`MCP_GATEWAY_TOKEN_STORE_PATH` のデフォルトがプロセスのカレントディレクトリや Docker 専用の `/data/` から OS ユーザー状態ディレクトリ（Windows: `%LOCALAPPDATA%\mcp-gateway\`、Linux: `~/.local/share/mcp-gateway/`、macOS: `~/Library/Application Support/mcp-gateway/`）に変更
+- 実行時状態ファイルのデフォルトパスを OS のユーザー状態ディレクトリに変更（[#144](https://github.com/scottlz0310/mcp-gateway/issues/144)）
+  - `MCP_GATEWAY_KEY_PATH`・`MCP_CONFIG_FILE`・`MCP_GATEWAY_TOKEN_STORE_PATH` のデフォルトが OS ユーザー状態ディレクトリ（Windows: `%LOCALAPPDATA%\mcp-gateway\`、Linux: `$XDG_STATE_HOME/mcp-gateway/` → `~/.local/state/mcp-gateway/`、macOS: `~/Library/Application Support/mcp-gateway/`）に変更
+  - 起動時に `MkdirAll 0700` でディレクトリを自動作成。クリーンインストールの初回起動失敗が解消
   - Docker 環境では引き続き環境変数で上書きするため影響なし。変更が適用されるのは非コンテナ環境のみ
+- `docs/configuration.md`・`README.md`・`README.ja.md` のデフォルトパス記載を #144 実装と同期（[#147](https://github.com/scottlz0310/mcp-gateway/issues/147)）
+  - 環境変数テーブルを `{state-dir}` 記法に更新し、OS 別パスの脚注を追加
 - GitHub App 推奨 Permission 設定をドキュメントに追記（[#145](https://github.com/scottlz0310/mcp-gateway/issues/145)）
   - `README.md`・`README.ja.md`: Permission セクションを拡充。`review-raven` / `github-mcp-server` upstream が必要とする Repository 権限（Contents / Issues / Pull requests / Metadata）と Account 権限（Email addresses）をテーブル形式で説明
   - `examples/copilot-review-routing/.env.example`: GitHub App 作成コメントに同内容の推奨 Permission を追記

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - OS-appropriate default paths for runtime state files ([#144](https://github.com/scottlz0310/mcp-gateway/issues/144))
-  - `MCP_GATEWAY_KEY_PATH`, `MCP_CONFIG_FILE`, `MCP_GATEWAY_TOKEN_STORE_PATH` now default to the OS user state directory (`%LOCALAPPDATA%\mcp-gateway\` on Windows, `~/.local/share/mcp-gateway/` on Linux, `~/Library/Application Support/mcp-gateway/` on macOS) instead of the process working directory or a Docker-only `/data/` path
+  - `MCP_GATEWAY_KEY_PATH`, `MCP_CONFIG_FILE`, `MCP_GATEWAY_TOKEN_STORE_PATH` now default to the OS user state directory (`%LOCALAPPDATA%\mcp-gateway\` on Windows, `~/.local/state/mcp-gateway/` on Linux via `$XDG_STATE_HOME`, `~/Library/Application Support/mcp-gateway/` on macOS) instead of the process working directory or a Docker-only `/data/` path
+  - State directory is created automatically on startup (`MkdirAll 0700`); clean installs no longer fail on first run
   - Docker operators continue to override via environment variables; this change only affects bare-metal / non-containerised deployments
+- Sync `docs/configuration.md`, `README.md`, and `README.ja.md` default path descriptions to reflect `#144` implementation ([#147](https://github.com/scottlz0310/mcp-gateway/issues/147))
+  - Environment variable table updated with `{state-dir}` notation and OS-breakdown footnote
 - Recommended GitHub App permission settings documented ([#145](https://github.com/scottlz0310/mcp-gateway/issues/145))
   - `README.md`, `README.ja.md`: expanded Permissions section with a table covering Repository (Contents/Issues/Pull requests/Metadata) and Account (Email addresses) permissions needed by `review-raven` / `github-mcp-server` upstreams
   - `examples/copilot-review-routing/.env.example`: updated GitHub App creation comment with the same permission table

--- a/README.ja.md
+++ b/README.ja.md
@@ -222,12 +222,12 @@ environment:
 
 | Setting | Default | Notes |
 |---------|---------|-------|
-| `MCP_CONFIG_FILE` | `./config.yaml` | setup 結果と暗号化 secret。 |
-| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity。安全にバックアップしてください。 |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker 向け token 永続化 path。Docker 以外では書き込み可能な path を指定してください。 |
+| `MCP_CONFIG_FILE` | `{state-dir}/config.yaml` | setup 結果と暗号化 secret。 |
+| `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity。安全にバックアップしてください。 |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | token 永続化 path。Docker 環境では環境変数で上書きすること。 |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS のユーザー state 領域。公式 image では `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines。相対 path と Git worktree 配下は拒否されます。 |
 
-詳細は [docs/configuration.md](docs/configuration.md) を参照してください。
+`{state-dir}` は起動時に解決される OS ユーザー状態ディレクトリです（Windows: `%LOCALAPPDATA%\mcp-gateway`、macOS: `~/Library/Application Support/mcp-gateway`、Linux: `$XDG_STATE_HOME/mcp-gateway` → `~/.local/state/mcp-gateway`）。Docker 環境では必ず環境変数でパスを上書きしてください。詳細は [docs/configuration.md](docs/configuration.md) を参照してください。
 
 ## エンドポイント
 

--- a/README.md
+++ b/README.md
@@ -232,12 +232,12 @@ Important paths:
 
 | Setting | Default | Notes |
 |---------|---------|-------|
-| `MCP_CONFIG_FILE` | `./config.yaml` | Persisted setup and encrypted secrets. |
-| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | age X25519 identity. Back it up securely. |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Docker-friendly token persistence path. Use a writable local path outside Docker. |
+| `MCP_CONFIG_FILE` | `{state-dir}/config.yaml` | Persisted setup and encrypted secrets. |
+| `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity. Back it up securely. |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | Persistent token store. Docker deployments pin this via env var. |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS user state directory; `/data/mcp-gateway/logs/auth-audit.jsonl` in the official image | Rotating OAuth audit JSON Lines file. Relative paths and Git worktree paths are rejected. |
 
-The full reference is in [docs/configuration.md](docs/configuration.md).
+`{state-dir}` is the OS user state directory resolved at startup (Windows: `%LOCALAPPDATA%\mcp-gateway`, macOS: `~/Library/Application Support/mcp-gateway`, Linux: `$XDG_STATE_HOME/mcp-gateway` → `~/.local/state/mcp-gateway`). Docker deployments always override paths via environment variables. See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ## Endpoints
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,11 +222,13 @@ Secrets and key material are not logged. A corrupt, empty, or unreadable
 
 ## Token Persistence
 
-By default, validated token state is stored in `/data/tokens.json`, which is
-created in the Docker image. For non-Docker runs, set a writable path:
+By default, validated token state is stored in `{state-dir}/tokens.json` (see
+the OS state directory table in the [Environment Variables](#environment-variables)
+section above). Docker deployments override this via `MCP_GATEWAY_TOKEN_STORE_PATH`
+in `docker-compose.yml`. To point to an explicit path:
 
 ```bash
-MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
+MCP_GATEWAY_TOKEN_STORE_PATH=/var/lib/mcp-gateway/tokens.json
 ```
 
 Set the variable to an empty value to disable persistence:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,8 +58,8 @@ is logged that the legacy is ignored.
 | `GITHUB_MCP_CLIENT_SECRET` | none | **Deprecated** — use `OAUTH_CLIENT_SECRET`. Still accepted with a startup warning. |
 | `GITHUB_MCP_OAUTH_SCOPES` | none | **Deprecated** — use `OAUTH_SCOPES`. Still accepted with a startup warning. |
 | `ROUTE_<NAME>` | none | Route definition in `<prefix>|<upstream_url>[|auth=none]` form. At least one route is required unless configured in `config.yaml`. |
-| `MCP_CONFIG_FILE` | `./config.yaml` | Path to persisted YAML configuration. |
-| `MCP_GATEWAY_KEY_PATH` | `./gateway.key` | Path to the age X25519 identity used to encrypt `auth.github_client_secret`. |
+| `MCP_CONFIG_FILE` | OS state dir¹ `/config.yaml` | Path to persisted YAML configuration. |
+| `MCP_GATEWAY_KEY_PATH` | OS state dir¹ `/gateway.key` | Path to the age X25519 identity used to encrypt `auth.github_client_secret`. |
 | `MCP_GATEWAY_MASTER_KEY` | none | Optional deterministic key seed. Use 32+ random bytes encoded as a string, for example `openssl rand -base64 32`. Used only when creating `gateway.key`. |
 | `MCP_MASTER_KEY` | none | Legacy alias for `MCP_GATEWAY_MASTER_KEY`. |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:<port>` | Canonical client-visible URL used for OAuth callbacks, discovery metadata, and Protected Resource Metadata. |
@@ -67,8 +67,8 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_PORT` | `8080` | Port used to derive default `public_url` and `bind_addr` when those settings are not explicit. |
 | `MCP_GATEWAY_BASE_URL` | none | Deprecated alias for `MCP_GATEWAY_PUBLIC_URL`. Emits a startup warning when set. |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | none | Comma-separated CIDR list for immediate reverse proxies whose `X-Forwarded-*` headers are trusted. |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `/data/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. |
-| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS-specific user state path; official image: `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | OS state dir¹ `/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. Docker deployments override this via env var. |
+| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS state dir¹ `/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB` | `10` | 監査ログ1ファイルの最大サイズ（MiB）。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` | `5` | 保持するローテーション済み監査ログの最大数。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS` | `30` | ローテーション済み監査ログの最大保持日数。 |
@@ -81,6 +81,19 @@ is logged that the legacy is ignored.
 | `TOKEN_CACHE_TTL_MIN` | `30` | In-memory validation cache TTL in minutes. Used when token persistence is disabled. |
 | `TOKEN_EXPIRES_IN_SEC` | `7776000` | Token lifetime advertised to clients and persistent token entry TTL. Default is 90 days. |
 | `GITHUB_MCP_UPSTREAM_URL` | none | Deprecated single-upstream fallback when no `ROUTE_*` or `routes:` entries exist. |
+
+¹ **OS state directory** — resolved by `gatewayStateDir()` at startup:
+
+| OS | Default state directory |
+|----|------------------------|
+| Windows | `%LOCALAPPDATA%\mcp-gateway\` |
+| macOS | `~/Library/Application Support/mcp-gateway/` |
+| Linux / other | `$XDG_STATE_HOME/mcp-gateway/` → `~/.local/state/mcp-gateway/` |
+| Docker (official image) | `/data/mcp-gateway/` (via `XDG_STATE_HOME=/data`) |
+
+The directory is created automatically on startup (`MkdirAll 0700`). Docker and
+other containerised deployments should always pin paths explicitly via environment
+variables; the OS default applies to bare-metal installations only.
 
 `MCP_GATEWAY_MASTER_KEY` is checked as the byte length of the supplied string
 after trimming whitespace. A base64 string generated with `openssl rand -base64

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ is logged that the legacy is ignored.
 | `MCP_GATEWAY_BASE_URL` | none | Deprecated alias for `MCP_GATEWAY_PUBLIC_URL`. Emits a startup warning when set. |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | none | Comma-separated CIDR list for immediate reverse proxies whose `X-Forwarded-*` headers are trusted. |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | OS state dir¹ `/tokens.json` | Persistent token store path. Set to an empty value to disable persistence. Docker deployments override this via env var. |
-| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS state dir¹ `/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
+| `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS audit dir² | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB` | `10` | 監査ログ1ファイルの最大サイズ（MiB）。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` | `5` | 保持するローテーション済み監査ログの最大数。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_AGE_DAYS` | `30` | ローテーション済み監査ログの最大保持日数。 |
@@ -94,6 +94,16 @@ is logged that the legacy is ignored.
 The directory is created automatically on startup (`MkdirAll 0700`). Docker and
 other containerised deployments should always pin paths explicitly via environment
 variables; the OS default applies to bare-metal installations only.
+
+² **OS audit log directory** — resolved independently by `authaudit.defaultPath()`
+(separate from `gatewayStateDir()`):
+
+| OS | Default audit log path |
+|----|------------------------|
+| Windows | `%LOCALAPPDATA%\mcp-gateway\logs\auth-audit.jsonl` |
+| macOS | `~/Library/Logs/mcp-gateway/auth-audit.jsonl` |
+| Linux / other | `$XDG_STATE_HOME/mcp-gateway/logs/auth-audit.jsonl` → `~/.local/state/mcp-gateway/logs/auth-audit.jsonl` |
+| Docker (official image) | `/data/mcp-gateway/logs/auth-audit.jsonl` (via `XDG_STATE_HOME=/data`) |
 
 `MCP_GATEWAY_MASTER_KEY` is checked as the byte length of the supplied string
 after trimming whitespace. A base64 string generated with `openssl rand -base64


### PR DESCRIPTION
## Summary

- `docs/configuration.md`: `MCP_CONFIG_FILE` / `MCP_GATEWAY_KEY_PATH` / `MCP_GATEWAY_TOKEN_STORE_PATH` のデフォルト値を旧値（`./config.yaml`・`./gateway.key`・`/data/tokens.json`）から `{state-dir}` 記法に更新し、OS 別パスの脚注テーブルを追加
- `README.md` / `README.ja.md`: "Important paths" テーブルを同様に `{state-dir}` 記法に更新し、OS サマリ行を追記
- `CHANGELOG.md` / `CHANGELOG.ja.md`: `#144` エントリの `~/.local/share` を `~/.local/state` に修正

## 背景

PR #146 で `gatewayStateDir()` の実装が `XDG_STATE_HOME` / `~/.local/state` に変更されたが、ドキュメント側の記載が旧デフォルト値のままだった（thread-owl residual risk 指摘）。

Closes #147

## Test plan

- [ ] `docs/configuration.md` の脚注テーブルが OS 別パスをすべてカバーしていること
- [ ] `README.md` / `README.ja.md` の {state-dir} 説明が実装と一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)