### PR TITLE
docs: fix stale /data default path references in operations.md

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,13 +41,15 @@ deployments even when `MCP_GATEWAY_BIND_ADDR` is `0.0.0.0:8080`.
 
 ### Bare Binary Or `go run`
 
-When running outside Docker, the default token store path (`/data/tokens.json`)
-usually does not exist. Point runtime files at writable local paths:
+When running outside Docker, runtime files default to the OS user state
+directory (see [configuration reference](configuration.md#environment-variables)).
+The directory is created automatically on first startup. To override to an
+explicit path, set the path variables before starting:
 
 ```bash
-export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
-export MCP_CONFIG_FILE=./config.yaml
-export MCP_GATEWAY_KEY_PATH=./gateway.key
+export MCP_GATEWAY_TOKEN_STORE_PATH=/your/path/tokens.json
+export MCP_CONFIG_FILE=/your/path/config.yaml
+export MCP_GATEWAY_KEY_PATH=/your/path/gateway.key
 export OAUTH_CLIENT_ID=<your-client-id>
 export OAUTH_CLIENT_SECRET=<your-client-secret>
 export ROUTE_GITHUB=/mcp/github|http://127.0.0.1:8082
@@ -360,19 +362,22 @@ For the local default this is:
 http://127.0.0.1:8080/callback
 ```
 
-### Bare Binary Fails Because `/data` Does Not Exist
+### State Directory Cannot Be Created
 
 Symptoms:
 
-- Local `go run ./cmd/server` or a bare binary fails while opening the token
-  store.
+- Local `go run ./cmd/server` or a bare binary fails while creating or opening
+  the state directory / token store (e.g. `permission denied`).
 
 Fix:
 
+The gateway creates the OS default state directory on startup. If the directory
+cannot be created (e.g. due to permissions), pin paths to a writable location:
+
 ```bash
-export MCP_GATEWAY_TOKEN_STORE_PATH=./tokens.json
-export MCP_CONFIG_FILE=./config.yaml
-export MCP_GATEWAY_KEY_PATH=./gateway.key
+export MCP_GATEWAY_TOKEN_STORE_PATH=/your/writable/path/tokens.json
+export MCP_CONFIG_FILE=/your/writable/path/config.yaml
+export MCP_GATEWAY_KEY_PATH=/your/writable/path/gateway.key
 ```
 
 ### Invalid Trusted Proxy CIDR


### PR DESCRIPTION
## Summary

- **Bare Binary / `go run` startup example**: `/data/tokens.json` が「存在しない」前提の説明を削除し、「OS ユーザー状態ディレクトリに自動保存・初回起動時に自動作成される」旨に更新。明示的なパス上書き例は `/your/path/...` プレースホルダーに変更。
- **トラブルシューティング節**: 「`/data` Does Not Exist」という旧 Docker 前提の見出し・説明を「State Directory Cannot Be Created」（権限エラー等）に書き換え。

## Background

PR #148 でマージされた `docs/configuration.md` 修正の残留リスクとして thread-owl が指摘した `docs/operations.md` の旧デフォルト値記載を同期する対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)