### PR TITLE
docs(ja): translate docs/README.md and docs/architecture.md to Japanese (#150)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,26 +1,23 @@
-# Documentation
+# ドキュメント
 
-This directory contains operational and reference documentation for
-mcp-gateway.
+このディレクトリには mcp-gateway の運用リファレンスドキュメントが含まれています。
 
-## Guides
+## ガイド
 
-| Document | Purpose |
-|----------|---------|
-| [Architecture](architecture.md) | Review platform overview, responsibility boundaries, route examples, and design principles. |
-| [Operations Guide](operations.md) | Start/stop procedures, health checks, structured logs, troubleshooting, and deployment migration notes. |
-| [Configuration Reference](configuration.md) | Environment variables, `config.yaml`, route syntax, token persistence, reverse proxy settings, and endpoint reference. |
-| [v0.1.0 E2E Runbook](runbook-e2e-v0.1.0.md) | End-to-end acceptance runbook for setup wizard, encryption, routing, token persistence, and device flow. |
-| [Copilot API Auth Spike](spike-18-copilot-api-auth.md) | Investigation notes for the Copilot API upstream authentication model. |
+| ドキュメント | 用途 |
+|------------|------|
+| [アーキテクチャ](architecture.md) | レビュープラットフォーム概要、責務境界、ルート例、設計原則。 |
+| [運用ガイド](operations.md) | 起動・停止手順、ヘルスチェック、構造化ログ、トラブルシュート、デプロイ移行手順。 |
+| [設定リファレンス](configuration.md) | 環境変数、`config.yaml`、ルート構文、トークン永続化、リバースプロキシ設定、エンドポイントリファレンス。 |
+| [v0.1.0 E2E ランブック](runbook-e2e-v0.1.0.md) | セットアップウィザード・暗号化・ルーティング・トークン永続化・デバイスフローの E2E 受け入れランブック。 |
+| [Copilot API Auth Spike](spike-18-copilot-api-auth.md) | Copilot API upstream 認証モデルの調査ノート。 |
 
-## Examples
+## サンプル
 
-| Path | Purpose |
-|------|---------|
-| [`../examples/copilot-review-routing/`](../examples/copilot-review-routing/) | Docker Compose example for routing both `github-mcp-server` and `copilot-review-mcp` through one gateway. |
+| パス | 用途 |
+|------|------|
+| [`../examples/copilot-review-routing/`](../examples/copilot-review-routing/) | `github-mcp-server` と `copilot-review-mcp` を 1 つのゲートウェイでルーティングする Docker Compose サンプル。 |
 
-## README Split
+## README の構成方針
 
-The root [README](../README.md) is intentionally focused on the first-run path,
-architecture overview, and links into these documents. Detailed configuration
-and operations material should live here to keep the README scannable.
+ルートの [README](../README.md) は意図的に初回起動手順・アーキテクチャ概要・各ドキュメントへのリンクに絞っています。詳細な設定・運用の内容はここに置き、README をスキャンしやすく保ちます。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,72 +1,67 @@
-# Architecture: mcp-gateway as Review Platform MCP Gateway
+# アーキテクチャ: レビュープラットフォーム MCP ゲートウェイとしての mcp-gateway
 
-This document defines the role of mcp-gateway within the review platform,
-its responsibility boundaries, and its relationship to the other components
-in the five-repo review infrastructure.
+このドキュメントは、レビュープラットフォーム内における mcp-gateway の役割、責務境界、および 5 リポジトリ構成の他コンポーネントとの関係を定義します。
 
-## Review Platform Overview
+## レビュープラットフォーム概要
 
-The semi-automated PR review platform is composed of five repositories, each
-with a distinct responsibility boundary.
+半自動 PR レビュープラットフォームは、それぞれ独立した責務境界を持つ 5 つのリポジトリで構成されています。
 
 ```text
-CLI agents / Desktop clients
-  ↓ single stable MCP endpoint
+CLI エージェント / デスクトップクライアント
+  ↓ 単一の安定した MCP エンドポイント
 mcp-gateway
-  ├─ /mcp/thread-owl     -> thread-owl MCP server
-  ├─ /mcp/review-raven   -> review-raven MCP server
-  ├─ /mcp/github         -> github-mcp or compatible server
-  └─ /mcp/...            -> additional MCP servers
+  ├─ /mcp/thread-owl     -> thread-owl MCP サーバー
+  ├─ /mcp/review-raven   -> review-raven MCP サーバー
+  ├─ /mcp/github         -> github-mcp または互換サーバー
+  └─ /mcp/...            -> 追加の MCP サーバー
                 ↑
-        mcp-docker manages containers, gateway config, and CLI agent config
+        mcp-docker がコンテナ・ゲートウェイ設定・CLI エージェント設定を管理
 ```
 
-| # | Repository | Role | Responsibility |
-|---|-----------|------|----------------|
-| 1 | **thread-owl** | Reviewer / subscribe target | GitHub App auth, webhook handling, review candidate judgment, queue management, MCP tools/resources |
-| 2 | **mcp-resource-subscriber** | Subscription client / agent workflow bridge | `resources/subscribe` → `notifications/resources/updated` wait → `resources/read` → structured output |
-| 3 | **review-raven** | Reviewed side | Fetch Copilot review threads, reply, resolve, re-request review |
-| 4 | **mcp-gateway** | MCP reverse proxy / routing gateway / auth boundary | Routing and auth boundary for MCP server group |
-| 5 | **mcp-docker** | MCP container orchestration | Container management, gateway route generation, CLI agent config automation |
+| # | リポジトリ | 役割 | 責務 |
+|---|-----------|------|------|
+| 1 | **thread-owl** | レビュアー / subscribe ターゲット | GitHub App 認証、webhook 処理、レビュー候補判定、キュー管理、MCP tools/resources |
+| 2 | **mcp-resource-subscriber** | サブスクリプションクライアント / エージェントワークフロー橋渡し | `resources/subscribe` → `notifications/resources/updated` 待機 → `resources/read` → 構造化出力 |
+| 3 | **review-raven** | レビューされる側 | Copilot レビュースレッドの取得・返信・解決・再レビュー依頼 |
+| 4 | **mcp-gateway** | MCP リバースプロキシ / ルーティングゲートウェイ / 認証境界 | MCP サーバー群のルーティングと認証境界 |
+| 5 | **mcp-docker** | MCP コンテナオーケストレーション | コンテナ管理、ゲートウェイルート生成、CLI エージェント設定自動化 |
 
-## Responsibilities of mcp-gateway
+## mcp-gateway の責務
 
-mcp-gateway is the single HTTP entry point for CLI agents and desktop clients.
-It handles the following:
+mcp-gateway は CLI エージェントおよびデスクトップクライアントの単一 HTTP エントリポイントです。以下を担当します。
 
-- Route multiple MCP server HTTP endpoints under a single gateway
-- Stabilize the MCP entrypoint visible to CLI agents and desktop clients
-- Provide the OAuth / caller authentication / token mediation boundary
-- Allow upstream MCP servers to be treated as private/internal endpoints
-- Identify each review platform MCP server by gateway path
-- Provide operational APIs such as route config, health, whoami, and token-source (future)
+- 複数の MCP サーバー HTTP エンドポイントを単一ゲートウェイ配下にルーティング
+- CLI エージェントおよびデスクトップクライアントから見える MCP エントリポイントを安定させる
+- OAuth / 呼び出し元認証 / トークン仲介の境界を提供
+- upstream MCP サーバーをプライベート / 内部エンドポイントとして扱えるようにする
+- ゲートウェイパスで各レビュープラットフォーム MCP サーバーを識別する
+- ルート設定・ヘルス・whoami・トークンソース等の運用 API を提供（一部将来実装）
 
-## What mcp-gateway Does NOT Do
+## mcp-gateway が担当しないこと
 
-The following responsibilities belong to other components and must not be
-implemented in mcp-gateway:
+以下の責務は他コンポーネントに属し、mcp-gateway に実装してはなりません。
 
-| Responsibility | Owner |
-|----------------|-------|
-| Review candidate judgment | thread-owl |
-| Webhook handling | thread-owl |
-| Review queue management | thread-owl |
-| PR review content generation | review-raven |
-| Review thread reply / resolve | review-raven |
-| Long-lived resource subscription wait CLI | mcp-resource-subscriber |
-| MCP server container lifecycle management | mcp-docker |
-| CLI agent config file generation | mcp-docker |
+| 責務 | オーナー |
+|------|---------|
+| レビュー候補判定 | thread-owl |
+| webhook 処理 | thread-owl |
+| レビューキュー管理 | thread-owl |
+| PR レビューコンテンツ生成 | review-raven |
+| レビュースレッド返信 / 解決 | review-raven |
+| 長命 resource subscription 待機 CLI | mcp-resource-subscriber |
+| MCP サーバーコンテナのライフサイクル管理 | mcp-docker |
+| CLI エージェント設定ファイル生成 | mcp-docker |
 
-## Route Examples
+## ルート例
 
 ```text
-/mcp/thread-owl     -> thread-owl MCP server
-/mcp/review-raven   -> review-raven MCP server
-/mcp/github         -> github-mcp or compatible server
-/mcp/other          -> additional MCP servers
+/mcp/thread-owl     -> thread-owl MCP サーバー
+/mcp/review-raven   -> review-raven MCP サーバー
+/mcp/github         -> github-mcp または互換サーバー
+/mcp/other          -> 追加の MCP サーバー
 ```
 
-Configure upstream routes via environment variables:
+upstream ルートは環境変数で設定します。
 
 ```yaml
 environment:
@@ -75,31 +70,29 @@ environment:
   ROUTE_GITHUB:       /mcp/github|http://github-mcp:8082
 ```
 
-## Relationship with mcp-docker
+## mcp-docker との関係
 
-mcp-docker manages container lifecycle and generates gateway configuration.
-mcp-gateway reads the generated config and handles runtime routing and auth.
+mcp-docker がコンテナのライフサイクルを管理し、ゲートウェイ設定を生成します。mcp-gateway は生成された設定を読み込み、ランタイムのルーティングと認証を処理します。
 
 ```text
 mcp-docker
-  ├─ starts and manages containers
-  ├─ generates and updates gateway config
-  └─ generates CLI agent config
+  ├─ コンテナの起動・管理
+  ├─ ゲートウェイ設定の生成・更新
+  └─ CLI エージェント設定の生成
 
 mcp-gateway
-  ├─ reads generated config
-  ├─ routes /mcp/* to upstream MCP servers
-  └─ handles caller auth / token mediation
+  ├─ 生成された設定の読み込み
+  ├─ /mcp/* を upstream MCP サーバーへルーティング
+  └─ 呼び出し元認証 / トークン仲介の処理
 ```
 
-Gateway config can be generated by mcp-docker or written by hand. Both are
-supported; mcp-docker-generated config is the intended operational path.
+ゲートウェイ設定は mcp-docker が生成することも手書きで記述することも可能です。両方をサポートしていますが、mcp-docker による生成が推奨の運用パスです。
 
-## Design Principles
+## 設計原則
 
-- Avoid registering many individual MCP servers directly to agents
-- Aggregate client-facing URLs at mcp-gateway
-- Treat upstream MCP servers as private/internal endpoints
-- Gateway focuses on routing and auth; it must not hold review domain logic
-- Gateway does not manage container lifecycle — that belongs to mcp-docker
-- Gateway config supports both hand-written and mcp-docker-generated forms
+- 多数の個別 MCP サーバーをエージェントに直接登録することを避ける
+- クライアント向け URL を mcp-gateway に集約する
+- upstream MCP サーバーをプライベート / 内部エンドポイントとして扱う
+- ゲートウェイはルーティングと認証に集中し、レビュードメインロジックを持たない
+- ゲートウェイはコンテナのライフサイクルを管理しない（それは mcp-docker の責務）
+- ゲートウェイ設定は手書き形式と mcp-docker 生成形式の両方をサポートする


### PR DESCRIPTION
## Summary

- `docs/README.md`: 日本語化（ガイドテーブル・サンプル・構成方針の説明）
- `docs/architecture.md`: 日本語化（レビュープラットフォーム概要・責務境界・ルート例・設計原則）

技術的固有名詞（リポジトリ名・コマンド・環境変数名・パス等）は英語のまま維持しています。

Part of #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)