### PR TITLE
docs(ja): translate docs/operations.md to Japanese (#150)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,15 +1,14 @@
-# Operations Guide
+# 運用ガイド
 
-This guide covers day-to-day operation, health checks, log inspection, migration
-notes, and common recovery procedures for mcp-gateway.
+このガイドは mcp-gateway の日常運用、ヘルスチェック、ログ確認、移行手順、および一般的なリカバリ手順を説明します。
 
-For the full configuration reference, see [configuration.md](configuration.md).
+設定の詳細リファレンスは [configuration.md](configuration.md) を参照してください。
 
-## Start And Stop
+## 起動と停止
 
 ### Docker Compose
 
-Use Docker Compose for the normal self-hosted stack.
+通常のセルフホストスタックには Docker Compose を使用します。
 
 ```bash
 docker compose up -d mcp-gateway
@@ -18,8 +17,7 @@ docker compose stop mcp-gateway
 docker compose restart mcp-gateway
 ```
 
-Docker port forwarding requires the gateway to listen on all interfaces inside
-the container:
+Docker ポートフォワーディングを使用するには、ゲートウェイがコンテナ内のすべてのインターフェースでリッスンする必要があります:
 
 ```yaml
 services:
@@ -35,16 +33,11 @@ services:
       ROUTE_GITHUB: /mcp/github|http://github-mcp:8082
 ```
 
-`MCP_GATEWAY_PUBLIC_URL` must be the URL that OAuth clients and the user's
-browser can reach. It is often `http://127.0.0.1:8080` for local Docker
-deployments even when `MCP_GATEWAY_BIND_ADDR` is `0.0.0.0:8080`.
+`MCP_GATEWAY_PUBLIC_URL` は OAuth クライアントとユーザーのブラウザが到達できる URL である必要があります。`MCP_GATEWAY_BIND_ADDR` が `0.0.0.0:8080` の場合でも、ローカル Docker デプロイでは `http://127.0.0.1:8080` になることが多いです。
 
-### Bare Binary Or `go run`
+### ベアバイナリまたは `go run`
 
-When running outside Docker, runtime files default to the OS user state
-directory (see [configuration reference](configuration.md#environment-variables)).
-The directory is created automatically on first startup. To override to an
-explicit path, set the path variables before starting:
+Docker 外で実行する場合、ランタイムファイルはデフォルトで OS ユーザー状態ディレクトリに保存されます（[設定リファレンス](configuration.md#環境変数) を参照）。ディレクトリは初回起動時に自動作成されます。明示的なパスに変更する場合は起動前に設定します:
 
 ```bash
 export MCP_GATEWAY_TOKEN_STORE_PATH=/your/path/tokens.json
@@ -57,118 +50,108 @@ export ROUTE_GITHUB=/mcp/github|http://127.0.0.1:8082
 go run ./cmd/server
 ```
 
-Build and run a local binary:
+ローカルバイナリのビルドと実行:
 
 ```bash
 go build -o mcp-gateway ./cmd/server
 ./mcp-gateway
 ```
 
-Stop the process with the supervisor that started it (`Ctrl-C`, `docker compose
-stop`, `systemctl stop`, etc.). mcp-gateway does not require a special shutdown
-endpoint.
+起動したスーパーバイザーでプロセスを停止します（`Ctrl-C`、`docker compose stop`、`systemctl stop` など）。mcp-gateway は特別なシャットダウンエンドポイントを必要としません。
 
-## Health Checks
+## ヘルスチェック
 
-In normal mode:
+通常モードでのヘルスチェック:
 
 ```bash
 curl -fsS http://127.0.0.1:8080/health
 ```
 
-Expected response:
+期待されるレスポンス:
 
 ```json
 {"status":"ok"}
 ```
 
-If the gateway is in setup mode, `/health` returns `503 setup_required` because
-only `/setup` is available until the required configuration is saved.
-Use `curl -i http://127.0.0.1:8080/health` when checking setup mode; `curl -f`
-exits non-zero for the expected 503 and may hide the response body.
+ゲートウェイがセットアップモードの場合、`/health` は `503 setup_required` を返します（必要な設定が保存されるまで `/setup` のみが利用可能なため）。セットアップモードを確認する場合は `curl -i http://127.0.0.1:8080/health` を使用してください。`curl -f` は期待される 503 で非ゼロ終了し、レスポンスボディが隠れる場合があります。
 
-For container health checks, use the same endpoint from the host or from another
-container that can reach the published port:
+コンテナのヘルスチェックには、ホストから、または公開ポートに到達できる別のコンテナから同じエンドポイントを使用します:
 
 ```bash
 curl -fsS http://mcp-gateway:8080/health
 ```
 
-## Reading Logs
+## ログの読み方
 
-mcp-gateway writes JSON logs with Go `log/slog` to stdout. Set `LOG_LEVEL` to
-`debug`, `info`, `warn`, or `error`; the default is `info`.
+mcp-gateway は Go の `log/slog` を使用して JSON ログを stdout に出力します。`LOG_LEVEL` を `debug`、`info`、`warn`、`error` のいずれかに設定します。デフォルトは `info` です。
 
-Each log entry includes the standard `slog` fields:
+各ログエントリには標準 `slog` フィールドが含まれます:
 
-| Field | Meaning |
-|-------|---------|
-| `time` | Timestamp emitted by the JSON handler |
-| `level` | `DEBUG`, `INFO`, `WARN`, or `ERROR` |
-| `msg` | Event name |
+| フィールド | 意味 |
+|-----------|------|
+| `time` | JSON ハンドラが出力するタイムスタンプ |
+| `level` | `DEBUG`、`INFO`、`WARN`、または `ERROR` |
+| `msg` | イベント名 |
 
-### HTTP Access Logs
+### HTTP アクセスログ
 
-Every HTTP request emits one `"http request"` log after the handler returns.
+すべての HTTP リクエストはハンドラ返却後に `"http request"` ログを1件出力します。
 
-| Field | Meaning |
-|-------|---------|
-| `method` | Request method |
-| `path` | Request path without query string |
-| `status` | Final HTTP status code |
-| `latency_ms` | Request duration in milliseconds |
-| `remote_addr` | Client address after trusted proxy processing |
+| フィールド | 意味 |
+|-----------|------|
+| `method` | リクエストメソッド |
+| `path` | クエリ文字列なしのリクエストパス |
+| `status` | 最終 HTTP ステータスコード |
+| `latency_ms` | リクエスト処理時間（ミリ秒） |
+| `remote_addr` | 信頼済みプロキシ処理後のクライアントアドレス |
 
-5xx responses are logged at `ERROR`; other status ranges are logged at `INFO`.
+5xx レスポンスは `ERROR` でログ出力され、他のステータス範囲は `INFO` でログ出力されます。
 
-Example:
+例:
 
 ```json
 {"level":"INFO","msg":"http request","method":"GET","path":"/health","status":200,"latency_ms":0,"remote_addr":"127.0.0.1:53321"}
 ```
 
-### Startup And Routing Logs
+### 起動とルーティングログ
 
-Startup emits `"registered route"` for each route and `"mcp-gateway starting"`
-after the server is ready to listen.
+起動時は各ルートで `"registered route"` を出力し、サーバーがリッスン準備完了後に `"mcp-gateway starting"` を出力します。
 
-| Message | Important fields |
-|---------|------------------|
-| `registered route` | `name`, `prefix`, `upstream`, `auth_required` |
-| `mcp-gateway starting` | `bind_addr`, `public_url`, `provider`, `routes`, `trusted_proxies`, `token_audience_strict` |
+| メッセージ | 重要フィールド |
+|-----------|-------------|
+| `registered route` | `name`、`prefix`、`upstream`、`auth_required` |
+| `mcp-gateway starting` | `bind_addr`、`public_url`、`provider`、`routes`、`trusted_proxies`、`token_audience_strict` |
 | `setup wizard listening` | `bind_addr` |
 
-### Proxy Logs
+### プロキシログ
 
-Authenticated upstream requests emit:
+認証済みの upstream リクエストで以下を出力します:
 
-| Message | Important fields |
-|---------|------------------|
-| `proxy request` | `user`, `method`, `path`, `token_hash` |
-| `proxy response` | `upstream_status`, `path` |
-| `upstream rejected token; cache invalidated` | `path`, `token_hash` |
+| メッセージ | 重要フィールド |
+|-----------|-------------|
+| `proxy request` | `user`、`method`、`path`、`token_hash` |
+| `proxy response` | `upstream_status`、`path` |
+| `upstream rejected token; cache invalidated` | `path`、`token_hash` |
 
-`token_hash` is the first 8 hex characters of `SHA-256(token)`. It is only for
-correlation; raw token values are not logged.
+`token_hash` は `SHA-256(token)` の先頭 8 桁の 16 進数です。相関用であり、生トークン値はログに出力されません。
 
-### Auth And Setup Logs
+### 認証とセットアップログ
 
-Common authentication and setup messages:
+よく使われる認証とセットアップのメッセージ:
 
-| Message | Meaning |
-|---------|---------|
-| `auth failed` | Bearer token validation failed |
-| `upstream error during auth` | Provider validation returned a transient upstream error |
-| `token exchange rejected` | OAuth authorization-code exchange was invalid |
-| `refresh token rejected` | Refresh token was missing, expired, or already consumed |
-| `token without audience accepted during grace period` | Legacy token was accepted while `token_audience_strict` is disabled |
-| `mcp-gateway starting in setup mode` | Required config is missing; follow `setup_url` |
-| `setup complete; restarting to apply configuration` | Setup POST succeeded and the process is exiting with code 0 |
+| メッセージ | 意味 |
+|-----------|------|
+| `auth failed` | Bearer トークン検証失敗 |
+| `upstream error during auth` | プロバイダー検証が一時的な upstream エラーを返した |
+| `token exchange rejected` | OAuth authorization-code 交換が無効だった |
+| `refresh token rejected` | リフレッシュトークンが存在しない・期限切れ・使用済み |
+| `token without audience accepted during grace period` | `token_audience_strict` 無効中に audience なし旧トークンが受け入れられた |
+| `mcp-gateway starting in setup mode` | 必須設定が欠けている。`setup_url` に従ってください |
+| `setup complete; restarting to apply configuration` | セットアップ POST が成功しプロセスがコード 0 で終了中 |
 
-The setup-mode log includes `setup_url` and `token`. Treat the token as a
-short-lived secret.
+セットアップモードのログには `setup_url` と `token` が含まれます。トークンは短命のシークレットとして扱ってください。
 
-### Useful Log Commands
+### 便利なログコマンド
 
 ```bash
 docker compose logs mcp-gateway | jq 'select(.msg=="http request")'
@@ -176,7 +159,7 @@ docker compose logs mcp-gateway | jq 'select(.level=="ERROR" or .level=="WARN")'
 docker compose logs mcp-gateway | jq 'select(.msg=="proxy response" and .upstream_status>=500)'
 ```
 
-If `jq` is not available, follow the raw logs:
+`jq` が使えない場合は生ログを追跡します:
 
 ```bash
 docker compose logs -f mcp-gateway
@@ -184,13 +167,7 @@ docker compose logs -f mcp-gateway
 
 ### OAuth 監査ログファイル
 
-OAuth 監査イベントは stdout に加え、ローテーション付き JSON Lines ファイルへ
-保存される。既定 path は Windows では
-`%LOCALAPPDATA%\mcp-gateway\logs\auth-audit.jsonl`、Linux では
-`$XDG_STATE_HOME/mcp-gateway/logs/auth-audit.jsonl` または
-`$HOME/.local/state/mcp-gateway/logs/auth-audit.jsonl`、macOS では
-`$HOME/Library/Logs/mcp-gateway/auth-audit.jsonl` である。公式 container
-image は `/data/mcp-gateway/logs/auth-audit.jsonl` を使用する。
+OAuth 監査イベントは stdout に加え、ローテーション付き JSON Lines ファイルへ保存されます。既定パスは Windows では `%LOCALAPPDATA%\mcp-gateway\logs\auth-audit.jsonl`、Linux では `$XDG_STATE_HOME/mcp-gateway/logs/auth-audit.jsonl` または `$HOME/.local/state/mcp-gateway/logs/auth-audit.jsonl`、macOS では `$HOME/Library/Logs/mcp-gateway/auth-audit.jsonl` です。公式コンテナイメージでは `/data/mcp-gateway/logs/auth-audit.jsonl` を使用します。
 
 PowerShell:
 
@@ -202,7 +179,7 @@ Get-Content -LiteralPath $path |
   Select-Object timestamp, phase, provider, error_class, oauth_error, http_status
 ```
 
-Linux / macOS / container:
+Linux / macOS / コンテナ:
 
 ```bash
 jq 'select(.result == "failure") |
@@ -210,8 +187,7 @@ jq 'select(.result == "failure") |
   /data/mcp-gateway/logs/auth-audit.jsonl
 ```
 
-直近の失敗は internal API が有効な場合に取得できる。endpoint は既存の
-loopback + shared secret 境界を共有する。
+internal API が有効な場合は直近の失敗をAPIで取得できます。エンドポイントは既存のループバック + 共有シークレット境界を共有します。
 
 ```bash
 curl -fsS \
@@ -219,160 +195,140 @@ curl -fsS \
   "http://127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}/internal/v1/auth/failures?limit=20"
 ```
 
-応答は最新順で最大100件である。永続的な事後解析の正本は JSON Lines
-ファイルであり、internal API の履歴は process 再起動時に消失する。
+レスポンスは最新順で最大 100 件です。永続的な事後解析の正本は JSON Lines ファイルであり、internal API の履歴はプロセス再起動時に消失します。
 
-## Common Problems
+## よくある問題
 
 ### `setup_required`
 
-Symptoms:
+症状:
 
-- Non-`/setup` paths return `503 {"error":"setup_required","setup_url":"..."}`
-- Logs contain `mcp-gateway starting in setup mode`
+- `/setup` 以外のパスが `503 {"error":"setup_required","setup_url":"..."}` を返す
+- ログに `mcp-gateway starting in setup mode` がある
 
-Cause:
+原因:
 
-- One or more required values are missing: GitHub client ID, GitHub client
-  secret, or at least one route.
+- 必須値（GitHub クライアント ID・クライアントシークレット・少なくとも1つのルート）のいずれかが欠けている
 
-Fix:
+対処:
 
-1. Open the `setup_url` from logs, or run `GET /setup?token=<TOKEN>`.
-2. POST the missing `client_id`, `client_secret`, and/or `routes`.
-3. Let the supervisor restart the gateway after it exits with code 0.
+1. ログの `setup_url` を開くか、`GET /setup?token=<TOKEN>` を実行する。
+2. 欠けている `client_id`・`client_secret`・`routes` を POST する。
+3. コード 0 で終了後にスーパーバイザーがゲートウェイを再起動するのを待つ。
 
-### Setup Token Expired
+### セットアップトークンの有効期限切れ
 
-Symptoms:
+症状:
 
-- `GET /setup?token=<TOKEN>` or `POST /setup?token=<TOKEN>` returns `408`.
+- `GET /setup?token=<TOKEN>` または `POST /setup?token=<TOKEN>` が `408` を返す
 
-Cause:
+原因:
 
-- Setup tokens are valid for 15 minutes.
+- セットアップトークンの有効期間は 15 分です。
 
-Fix:
+対処:
 
-1. Restart the gateway while it is still missing required config.
-2. Read the new `setup_url` and `token` from stdout.
-3. Repeat the setup request.
+1. 必須設定が欠けたままゲートウェイを再起動する。
+2. stdout から新しい `setup_url` と `token` を読む。
+3. セットアップリクエストを繰り返す。
 
-### `gateway.key` Is Corrupt Or Unreadable
+### `gateway.key` が破損または読み取り不可
 
-Symptoms:
+症状:
 
-- Startup exits before serving traffic.
-- Logs contain `failed to load gateway encryption key`.
+- トラフィックを処理する前に起動が終了する。
+- ログに `failed to load gateway encryption key` がある。
 
-Cause:
+原因:
 
-- `gateway.key` exists but is empty, malformed, or unreadable. The gateway
-  refuses to regenerate it automatically because doing so could permanently
-  orphan encrypted secrets in `config.yaml`.
+- `gateway.key` が存在するが空・不正形式・読み取り不可。ゲートウェイは自動再生成を拒否します（`config.yaml` の暗号化シークレットが永久にアクセス不能になるリスクがあるため）。
 
-Fix:
+対処:
 
-1. Restore `gateway.key` from backup.
-2. If the key was originally derived from `MCP_GATEWAY_MASTER_KEY`, remove the
-   bad key file and restart with the same master key so the same identity is
-   regenerated.
-3. If no backup or master key exists, remove or replace the encrypted
-   `auth.github_client_secret` in `config.yaml`, provide
-   `OAUTH_CLIENT_SECRET` again (legacy `GITHUB_MCP_CLIENT_SECRET` also accepted
-   with a deprecation warning), and let the gateway write a new encrypted
-   value with a new key.
+1. バックアップから `gateway.key` を復元する。
+2. キーが元々 `MCP_GATEWAY_MASTER_KEY` から導出されていた場合、破損したキーファイルを削除し同じマスターキーで再起動すると同一 identity が再生成されます。
+3. バックアップもマスターキーも存在しない場合、`config.yaml` の暗号化 `auth.github_client_secret` を削除または置換し、`OAUTH_CLIENT_SECRET` を再度提供してゲートウェイに新しいキーで新しい暗号化値を書き込ませます（旧 `GITHUB_MCP_CLIENT_SECRET` も非推奨警告付きで受け入れられます）。
 
-Do not delete `gateway.key` as a first response unless you know how the current
-encrypted `config.yaml` can be recovered.
+現在の暗号化 `config.yaml` を回復できる確信がない限り、`gateway.key` を最初の対処として削除しないでください。
 
 ### `github_client_secret is unavailable`
 
-Symptoms:
+症状:
 
-- Startup logs `github_client_secret is unavailable`.
+- 起動ログに `github_client_secret is unavailable` がある。
 
-Cause:
+原因:
 
-- Neither `auth.github_client_secret` in `config.yaml` nor
-  `OAUTH_CLIENT_SECRET` (or legacy `GITHUB_MCP_CLIENT_SECRET`) is available.
+- `config.yaml` の `auth.github_client_secret` も `OAUTH_CLIENT_SECRET`（または旧 `GITHUB_MCP_CLIENT_SECRET`）も設定されていない。
 
-Fix:
+対処:
 
-- Provide `OAUTH_CLIENT_SECRET` once so the gateway can encrypt and persist
-  it, or restore a valid encrypted `auth.github_client_secret` and matching
-  `gateway.key`. The deprecated `GITHUB_MCP_CLIENT_SECRET` is still accepted
-  for backward compatibility but emits a startup warning.
+- `OAUTH_CLIENT_SECRET` を一度提供してゲートウェイが暗号化・永続化できるようにするか、有効な暗号化 `auth.github_client_secret` と対応する `gateway.key` を復元してください。非推奨の `GITHUB_MCP_CLIENT_SECRET` は後方互換性のため引き続き受け入れられますが、起動時警告が出力されます。
 
-### No Routes Configured
+### ルートが設定されていない
 
-Symptoms:
+症状:
 
-- Startup logs `no routes configured: set ROUTE_<NAME>=<prefix>|<upstream_url>`.
+- 起動ログに `no routes configured: set ROUTE_<NAME>=<prefix>|<upstream_url>` がある。
 
-Fix:
+対処:
 
-- Set at least one `ROUTE_<NAME>` environment variable, or add a `routes:` entry
-  to `config.yaml`.
+- `ROUTE_<NAME>` 環境変数を少なくとも1つ設定するか、`config.yaml` に `routes:` エントリを追加してください。
 
-Example:
+例:
 
 ```bash
 ROUTE_GITHUB=/mcp/github|http://github-mcp:8082
 ```
 
-### Docker Port Is Published But The Gateway Is Unreachable
+### Docker ポートが公開されているがゲートウェイに到達できない
 
-Symptoms:
+症状:
 
-- `docker compose ps` shows a published port, but host requests fail.
+- `docker compose ps` で公開ポートが表示されるが、ホストからのリクエストが失敗する。
 
-Cause:
+原因:
 
-- The gateway is bound to the loopback default (`127.0.0.1:8080`) inside the
-  container.
+- ゲートウェイがコンテナ内のループバックデフォルト（`127.0.0.1:8080`）にバインドされている。
 
-Fix:
+対処:
 
 ```bash
 MCP_GATEWAY_BIND_ADDR=0.0.0.0:8080
 ```
 
-Keep `MCP_GATEWAY_PUBLIC_URL` set to the browser-visible URL, for example
-`http://127.0.0.1:8080`.
+`MCP_GATEWAY_PUBLIC_URL` はブラウザから見える URL（例: `http://127.0.0.1:8080`）に設定したままにしてください。
 
-### GitHub OAuth Callback Mismatch
+### GitHub OAuth コールバック不一致
 
-Symptoms:
+症状:
 
-- GitHub rejects the OAuth callback URL.
-- Browser auth flow fails before returning to `/callback`.
+- GitHub が OAuth コールバック URL を拒否する。
+- `/callback` に戻る前にブラウザ認証フローが失敗する。
 
-Fix:
+対処:
 
-Update the GitHub OAuth App callback URL to exactly match:
+GitHub OAuth App のコールバック URL を以下と完全一致するよう更新します:
 
 ```text
 <MCP_GATEWAY_PUBLIC_URL>/callback
 ```
 
-For the local default this is:
+ローカルデフォルトの場合:
 
 ```text
 http://127.0.0.1:8080/callback
 ```
 
-### State Directory Cannot Be Created
+### 状態ディレクトリを作成できない
 
-Symptoms:
+症状:
 
-- Local `go run ./cmd/server` or a bare binary fails while creating or opening
-  the state directory / token store (e.g. `permission denied`).
+- `go run ./cmd/server` またはベアバイナリで、状態ディレクトリ/トークンストアの作成または開放に失敗する（例: `permission denied`）。
 
-Fix:
+対処:
 
-The gateway creates the OS default state directory on startup. If the directory
-cannot be created (e.g. due to permissions), pin paths to a writable location:
+ゲートウェイは起動時に OS デフォルトの状態ディレクトリを自動作成します。権限の問題などでディレクトリを作成できない場合は、書き込み可能な場所にパスを固定してください:
 
 ```bash
 export MCP_GATEWAY_TOKEN_STORE_PATH=/your/writable/path/tokens.json
@@ -380,99 +336,87 @@ export MCP_CONFIG_FILE=/your/writable/path/config.yaml
 export MCP_GATEWAY_KEY_PATH=/your/writable/path/gateway.key
 ```
 
-### Invalid Trusted Proxy CIDR
+### 無効な信頼済みプロキシ CIDR
 
-Symptoms:
+症状:
 
-- Startup logs `invalid trusted proxy configuration`.
+- 起動ログに `invalid trusted proxy configuration` がある。
 
-Fix:
+対処:
 
-- Ensure every `MCP_GATEWAY_TRUSTED_PROXIES` entry or
-  `gateway.trusted_proxies` item is a valid CIDR such as `127.0.0.1/32` or
-  `10.0.0.0/8`.
+- `MCP_GATEWAY_TRUSTED_PROXIES` のすべてのエントリまたは `gateway.trusted_proxies` の各項目が `127.0.0.1/32` や `10.0.0.0/8` などの有効な CIDR 形式であることを確認してください。
 
-### Token Audience Mismatch
+### トークン audience 不一致
 
-Symptoms:
+症状:
 
-- Authenticated route requests return 401 with `invalid_token`.
-- Logs mention an audience mismatch or legacy audience grace-period acceptance.
+- 認証済みルートリクエストが `invalid_token` で 401 を返す。
+- ログに audience 不一致またはレガシー audience 猶予期間受け入れの記録がある。
 
-Fix:
+対処:
 
-1. Make sure the client follows the `WWW-Authenticate.resource_metadata` URL.
-2. Re-authenticate the client so it obtains a token for the route resource.
-3. Keep `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=false` until legacy no-audience
-   tokens have disappeared from logs.
+1. クライアントが `WWW-Authenticate.resource_metadata` URL に従っていることを確認する。
+2. クライアントを再認証してルートリソース用のトークンを取得させる。
+3. レガシー audience なしトークンがログから消えるまで `MCP_GATEWAY_TOKEN_AUDIENCE_STRICT=false` を維持する。
 
-## bind_addr vs public_url
+## bind_addr と public_url
 
-mcp-gateway separates the listen address from the public URL:
+mcp-gateway はリッスンアドレスと公開 URL を分離しています:
 
-| Config | Env var | YAML key | Default | Purpose |
-|--------|---------|----------|---------|---------|
-| Bind address | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | Network interface and port the HTTP server listens on |
-| Public URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | Canonical URL used in OAuth callbacks, discovery metadata, and PRM |
+| 設定 | 環境変数 | YAML キー | デフォルト | 用途 |
+|------|---------|---------|---------|------|
+| バインドアドレス | `MCP_GATEWAY_BIND_ADDR` | `gateway.bind_addr` | `127.0.0.1:8080` | HTTP サーバーがリッスンするネットワークインターフェースとポート |
+| 公開 URL | `MCP_GATEWAY_PUBLIC_URL` | `gateway.public_url` | `http://127.0.0.1:8080` | OAuth コールバック・ディスカバリメタデータ・PRM で使用する正規 URL |
 
-Before v0.3.0, `MCP_GATEWAY_BASE_URL` / `gateway.base_url` controlled only the
-public URL. The server always listened on all interfaces (`:<port>`) regardless
-of that setting. The old setting is deprecated and will be removed in a future
-release.
+v0.3.0 以前は `MCP_GATEWAY_BASE_URL` / `gateway.base_url` が公開 URL のみを制御していました。サーバーはその設定に関わらず常にすべてのインターフェース（`:<port>`）でリッスンしていました。旧設定は非推奨になり将来のリリースで削除されます。
 
-### Why The Split Matters
+### 分離が重要な理由
 
-In Docker deployments the gateway binds to `0.0.0.0:8080` so the host can reach
-it via port forwarding, but the OAuth callback URL registered with GitHub must
-be an address that the user's browser can reach. For local development that is
-usually `http://127.0.0.1:8080`.
+Docker デプロイではゲートウェイが `0.0.0.0:8080` にバインドしてホストがポートフォワーディング経由で到達できるようにしますが、GitHub に登録する OAuth コールバック URL はユーザーのブラウザが到達できるアドレスである必要があります。ローカル開発では通常 `http://127.0.0.1:8080` です。
 
-### Migrating From MCP_GATEWAY_BASE_URL
+### MCP_GATEWAY_BASE_URL からの移行
 
-Update environment variables:
+環境変数を更新します:
 
-| Old | New |
-|-----|-----|
+| 旧 | 新 |
+|----|-----|
 | `MCP_GATEWAY_BASE_URL=http://localhost:<port>` | `MCP_GATEWAY_PUBLIC_URL=http://127.0.0.1:<port>` |
-| implicit bind on all interfaces `:<port>` | `MCP_GATEWAY_BIND_ADDR=127.0.0.1:<port>` for local runs or `0.0.0.0:<port>` for Docker |
+| すべてのインターフェースへの暗黙的バインド `:<port>` | ローカル実行: `MCP_GATEWAY_BIND_ADDR=127.0.0.1:<port>`、Docker: `0.0.0.0:<port>` |
 
-Update `config.yaml` if used:
+`config.yaml` を使用している場合は更新します:
 
 ```yaml
-# Before
+# 変更前
 gateway:
   base_url: "http://localhost:<port>"
 
-# After
+# 変更後
 gateway:
   public_url: "http://127.0.0.1:<port>"
   bind_addr: "127.0.0.1:<port>"
 ```
 
-Update the GitHub OAuth App callback URL:
+GitHub OAuth App のコールバック URL を更新します:
 
-| Field | Old value | New value |
-|-------|-----------|-----------|
+| フィールド | 旧値 | 新値 |
+|-----------|------|------|
 | Authorization callback URL | `http://localhost:<port>/callback` | `http://127.0.0.1:<port>/callback` |
 
-GitHub validates the exact callback URL, so the registered value must match the
-URL sent by the gateway.
+GitHub はコールバック URL を完全一致で検証するため、登録値はゲートウェイが送信する URL と一致する必要があります。
 
-### Cutover Procedure
+### 切り替え手順
 
-1. Deploy the updated gateway binary or image.
-2. Update the GitHub OAuth App callback URL.
-3. Update `docker-compose.yml`, a systemd unit, or `.env` with the new variables.
-4. Restart the gateway.
-5. Confirm `/health` returns `{"status":"ok"}`.
+1. 更新したゲートウェイのバイナリまたはイメージをデプロイする。
+2. GitHub OAuth App のコールバック URL を更新する。
+3. `docker-compose.yml`・systemd ユニット・`.env` を新しい変数に更新する。
+4. ゲートウェイを再起動する。
+5. `/health` が `{"status":"ok"}` を返すことを確認する。
 
-Existing access and refresh tokens remain valid unless the token store was
-deleted or the provider has revoked the upstream token.
+トークンストアが削除されていないか、プロバイダーが upstream トークンを失効させていない限り、既存のアクセストークンとリフレッシュトークンは引き続き有効です。
 
-## Reverse Proxy Deployments
+## リバースプロキシデプロイ
 
-If TLS terminates in front of mcp-gateway, set the public URL to the external
-origin and trust only the immediate proxy CIDRs:
+mcp-gateway の前で TLS を終端する場合は、公開 URL を外部オリジンに設定し、直前のプロキシ CIDR のみを信頼します:
 
 ```bash
 MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com
@@ -480,7 +424,7 @@ MCP_GATEWAY_BIND_ADDR=127.0.0.1:8080
 MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 ```
 
-Equivalent `config.yaml`:
+同等の `config.yaml`:
 
 ```yaml
 gateway:
@@ -491,23 +435,19 @@ gateway:
     - "10.0.0.0/8"
 ```
 
-When the immediate peer IP matches `trusted_proxies`, mcp-gateway reflects:
+直前のピア IP が `trusted_proxies` に一致する場合、mcp-gateway は以下を反映します:
 
-| Header | Reflected request field |
-|--------|-------------------------|
-| `X-Forwarded-Proto` | `r.URL.Scheme`, only when the value is `http` or `https` |
-| `X-Forwarded-Host` | `r.Host` after basic host validation |
-| `X-Forwarded-For` | `r.RemoteAddr`, using the rightmost valid IP supplied by the trusted proxy |
+| ヘッダー | 反映されるリクエストフィールド |
+|---------|---------------------------|
+| `X-Forwarded-Proto` | `r.URL.Scheme`（値が `http` または `https` の場合のみ） |
+| `X-Forwarded-Host` | 基本的なホスト検証後の `r.Host` |
+| `X-Forwarded-For` | 信頼済みプロキシが提供する最右端の有効 IP を使用した `r.RemoteAddr` |
 
-When the peer is not trusted, `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` are
-stripped before later middleware and handlers run.
+ピアが信頼されていない場合、`Forwarded`・`X-Forwarded-*`・`X-Real-IP` は後続のミドルウェアとハンドラの実行前にすべて除去されます。
 
-Configure the reverse proxy to overwrite or sanitize `X-Forwarded-For` instead
-of passing client-provided values through unchanged. The gateway reads the
-header from the right as a defense against appended spoofed entries, but the
-proxy should still own this header.
+クライアントが提供した値をそのまま渡すのではなく、リバースプロキシが `X-Forwarded-For` を上書きまたはサニタイズするよう設定してください。ゲートウェイは追記されたスプーフィングエントリへの防御として右端からヘッダーを読みますが、プロキシ側でこのヘッダーを管理すべきです。
 
-Example nginx location:
+nginx の location 設定例:
 
 ```nginx
 location / {
@@ -519,5 +459,4 @@ location / {
 }
 ```
 
-`MCP_GATEWAY_PUBLIC_URL` remains the canonical OAuth, discovery, and PRM URL.
-Keep it set to the same external origin that clients use.
+`MCP_GATEWAY_PUBLIC_URL` は OAuth・ディスカバリ・PRM の正規 URL のままです。クライアントが使用する外部オリジンと同じ値に保つようにしてください。


### PR DESCRIPTION
## Summary

`docs/operations.md` を全面日本語化しました。

- 起動と停止（Docker Compose・ベアバイナリ）
- ヘルスチェック
- ログの読み方（HTTP アクセスログ・起動/ルーティング/プロキシ/認証/セットアップ）
- OAuth 監査ログファイル
- よくある問題（10 項目）
- `bind_addr` vs `public_url` の解説・移行手順
- リバースプロキシデプロイ設定

技術的固有名詞・コマンド・設定キー名・ログメッセージは英語のまま維持しています。

Part of #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)