### PR TITLE
docs(ja): translate auth-error-contract.md and spike-72 to Japanese (#150)

### DIFF
--- a/docs/auth-error-contract.md
+++ b/docs/auth-error-contract.md
@@ -1,315 +1,254 @@
-# Auth Error Contract
+# 認証エラーコントラクト
 
-> **Phase C — Structured Error Contract** (Issue #73)
+> **Phase C — 構造化エラーコントラクト** (Issue #73)
 >
-> This document is the authoritative reference for the error code contract between mcp-gateway
-> and its consumers: MCP clients (public API), upstream MCP servers (internal API), and
-> operator tooling. It covers trigger conditions, wire representation, and the mapping to
-> copilot-review-mcp's internal error taxonomy.
+> このドキュメントは、mcp-gateway とその利用者（MCP クライアント（公開 API）・upstream MCP サーバー（内部 API）・オペレーターツール）間のエラーコードコントラクトの権威的なリファレンスです。トリガー条件・ワイヤー表現・copilot-review-mcp の内部エラー分類へのマッピングを扱います。
 
 ---
 
-## 1. Public Client Contract
+## 1. 公開クライアントコントラクト
 
-MCP clients authenticate against gateway-protected routes via RFC 6750 Bearer tokens. All
-error responses carry a JSON body `{"error": "<code>", "error_description": "..."}` and the
-headers below.
+MCP クライアントは RFC 6750 Bearer トークンを使用してゲートウェイ保護ルートに対して認証します。すべてのエラーレスポンスは JSON ボディ `{"error": "<code>", "error_description": "..."}` と以下のヘッダーを含みます。
 
-### 1.1 Error Codes
+### 1.1 エラーコード
 
-| Error code | HTTP status | `WWW-Authenticate error=` | Trigger | Recommended client action |
+| エラーコード | HTTP ステータス | `WWW-Authenticate error=` | トリガー | 推奨クライアントアクション |
 |---|---|---|---|---|
-| `invalid_request` | 401 | **omitted** (intentional — see §1.2) | No `Authorization` header, or header is not in `Bearer <token>` form | Start the gateway OAuth flow (follow the `resource_metadata` URL in the `WWW-Authenticate` header) |
-| `invalid_token` | 401 | `error="invalid_token"` | Token is expired, cryptographically invalid, or addressed to the wrong audience | Re-authenticate via the gateway OAuth flow |
-| `upstream_error` | 503 | *(no `WWW-Authenticate` header)* | The upstream OAuth provider (GitHub) returned 5xx or was unreachable during token validation | Retry with exponential backoff; no credential change required |
+| `invalid_request` | 401 | **省略**（意図的 — §1.2 参照） | `Authorization` ヘッダーなし、またはヘッダーが `Bearer <token>` 形式でない | ゲートウェイ OAuth フローを開始する（`WWW-Authenticate` ヘッダーの `resource_metadata` URL に従う） |
+| `invalid_token` | 401 | `error="invalid_token"` | トークンが期限切れ・暗号的に無効・または誤った audience 宛て | ゲートウェイ OAuth フローで再認証する |
+| `upstream_error` | 503 | *（`WWW-Authenticate` ヘッダーなし）* | upstream OAuth プロバイダー（GitHub）がトークン検証中に 5xx を返したか、到達不能だった | 指数バックオフで再試行する。認証情報の変更は不要 |
 
-### 1.2 `error=` Omission for `invalid_request` — Security Design
+### 1.2 `invalid_request` での `error=` 省略 — セキュリティ設計
 
-RFC 6750 §3.1 permits omitting `error=` when the request lacked credentials entirely. The
-gateway applies the same omission when the `Authorization` header is malformed (not in
-`Bearer <token>` form) — `extractBearer()` returns `""` in both cases, and both result in
-`invalid_request`:
+RFC 6750 §3.1 は、リクエストに認証情報がまったくない場合に `error=` を省略することを許可しています。ゲートウェイは `Authorization` ヘッダーが不正形式（`Bearer <token>` 形式でない）の場合にも同じ省略を適用します。`extractBearer()` はどちらの場合も `""` を返し、どちらも `invalid_request` になります:
 
 ```
-# invalid_request — no error= attribute
+# invalid_request — error= 属性なし
 WWW-Authenticate: Bearer realm="mcp-gateway", resource_metadata="<url>"
 
-# invalid_token — error= is present
+# invalid_token — error= あり
 WWW-Authenticate: Bearer realm="mcp-gateway", error="invalid_token", error_description="...", resource_metadata="<url>"
 ```
 
-**Rationale:** Omitting `error="invalid_request"` avoids revealing whether the request was malformed
-versus simply unauthenticated. The response still advertises the Bearer challenge and the
-`resource_metadata` URL needed by legitimate MCP clients — the Bearer scheme itself is not hidden.
+**理由:** `error="invalid_request"` を省略することで、リクエストが不正形式なのか単に未認証なのかを明かさないようにしています。レスポンスは引き続き Bearer チャレンジと正規の MCP クライアントが必要とする `resource_metadata` URL を広告しています。Bearer スキーム自体は隠されていません。
 
-Implementation reference: `internal/middleware/auth.go:writeUnauthorized()` — the condition
-`if errCode == "invalid_token"` gates the `error=` attribute.
+実装参照: `internal/middleware/auth.go:writeUnauthorized()` — 条件 `if errCode == "invalid_token"` が `error=` 属性の出力を制御します。
 
-### 1.3 Backward Compatibility Guarantee
+### 1.3 後方互換性保証
 
-The three codes above (`invalid_request`, `invalid_token`, `upstream_error`) are covered by tests
-in `internal/middleware/auth_test.go` (`TestAuthMissingToken`, `TestAuthInvalidToken`,
-`TestAuthUpstreamError`). Any change to their wire shape requires updating those tests and
-incrementing the semver minor version.
+上記の 3 つのコード（`invalid_request`、`invalid_token`、`upstream_error`）は `internal/middleware/auth_test.go` のテスト（`TestAuthMissingToken`、`TestAuthInvalidToken`、`TestAuthUpstreamError`）でカバーされています。それらのワイヤー形状を変更する場合は、これらのテストを更新し semver マイナーバージョンをインクリメントする必要があります。
 
 ---
 
-## 2. Internal Delegated Access Contract
+## 2. 内部委任アクセスコントラクト
 
-Upstream MCP servers (e.g. copilot-review-mcp) obtain a fresh gateway-managed access token by
-calling `POST /internal/v1/whoami` on the internal listener. This endpoint is **loopback-only**
-and authenticates via a pre-shared secret.
+upstream MCP サーバー（例: copilot-review-mcp）は、内部リスナーで `POST /internal/v1/whoami` を呼び出すことで、ゲートウェイが管理する新鮮なアクセストークンを取得します。このエンドポイントは**ループバックのみ**で、事前共有シークレットで認証します。
 
-Error responses carry `{"error": "<code>"}` (no `error_description` field) to reduce the
-information surface on this trust boundary.
+エラーレスポンスはこのトラスト境界での情報露出を抑えるため `{"error": "<code>"}` のみ（`error_description` フィールドなし）です。
 
-### 2.1 Error Codes
+### 2.1 エラーコード
 
-| Error code | HTTP status | Trigger | Caller action |
+| エラーコード | HTTP ステータス | トリガー | 呼び出し元アクション |
 |---|---|---|---|
-| `method_not_allowed` | 405 | Non-`POST` method | Fix the HTTP method; this is a caller bug |
-| `loopback_required` | 403 | Request originated from a non-loopback address | Ensure the caller connects to the internal API on loopback — the listener always binds to `127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}` |
-| `invalid_authorization` | 401 | `Authorization: Bearer` secret missing or does not match `MCP_GATEWAY_INTERNAL_SECRET` | Fix the shared secret configuration |
-| `invalid_body` | 400 | Malformed JSON, body exceeds 4 KiB, unknown fields, or trailing bytes after the JSON object | Fix the request body |
-| `missing_subject` | 400 | `subject` field is omitted or empty (including whitespace-only) | Supply a non-empty subject |
-| `subject_not_found` | 404 | No entry in the in-memory subject index for the requested subject — the user has never authenticated on this instance, the session was purged, or the process was recently restarted (the in-memory index starts empty after restart and re-seeds as bearer tokens are validated on protected routes) | Trigger the user to re-authenticate; after a process restart the error may be transient — the index rebuilds as users access protected routes |
-| `rotation_failed` | 502 | Token is near expiry, rotation was attempted but did not yield a fresh token (covers both transient provider/network errors and explicit rejection by GitHub's token endpoint) | Retry after a brief delay; if the error persists, trigger the user to re-authenticate — the refresh token may have been revoked |
-| `upstream_failure` | 502 | Any other resolver error, or the resolver returned an empty access token | Retry after a brief delay; if persistent, treat as `subject_not_found` and prompt re-auth |
+| `method_not_allowed` | 405 | `POST` 以外のメソッド | HTTP メソッドを修正する。呼び出し元のバグ |
+| `loopback_required` | 403 | ループバック以外のアドレスからのリクエスト | 呼び出し元が内部 API にループバック経由で接続していることを確認する。リスナーは常に `127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}` にバインド |
+| `invalid_authorization` | 401 | `Authorization: Bearer` シークレットが欠けているか `MCP_GATEWAY_INTERNAL_SECRET` と一致しない | 共有シークレットの設定を修正する |
+| `invalid_body` | 400 | 不正な JSON・ボディが 4 KiB を超える・未知のフィールド・JSON オブジェクト後の余分なバイト | リクエストボディを修正する |
+| `missing_subject` | 400 | `subject` フィールドが省略または空（ホワイトスペースのみを含む） | 空でない subject を提供する |
+| `subject_not_found` | 404 | 要求された subject のインメモリ subject インデックスにエントリーがない。ユーザーがこのインスタンスで一度も認証していない・セッションがパージされた・プロセスが最近再起動した（インメモリインデックスは再起動後に空から始まり、保護ルートで Bearer トークンが検証されるたびに再シードされる） | ユーザーに再認証を促す。プロセス再起動後はエラーが一時的な場合がある。ユーザーが保護ルートにアクセスするとインデックスが再構築される |
+| `rotation_failed` | 502 | トークンが有効期限間近でローテーションを試みたが新鮮なトークンが得られなかった（一時的なプロバイダー/ネットワークエラーと GitHub トークンエンドポイントによる明示的な拒否を含む） | 短時間後に再試行する。エラーが続く場合はユーザーに再認証を促す。リフレッシュトークンが失効している可能性がある |
+| `upstream_failure` | 502 | その他のリゾルバーエラー、またはリゾルバーが空のアクセストークンを返した | 短時間後に再試行する。継続する場合は `subject_not_found` として扱い再認証を促す |
 
-### 2.2 Naming Note: `upstream_error` vs `upstream_failure`
+### 2.2 命名の注記: `upstream_error` vs `upstream_failure`
 
-These are **two distinct codes at two different layers**, not aliases:
+これらは**異なるレイヤーの 2 つの別コード**であり、エイリアスではありません:
 
-| Code | Layer | HTTP status | Meaning |
+| コード | レイヤー | HTTP ステータス | 意味 |
 |---|---|---|---|
-| `upstream_error` | Public API (`middleware/auth.go`) | 503 | The *OAuth provider* (GitHub) is unreachable when validating the incoming Bearer token |
-| `upstream_failure` | Internal API (`internalapi/handler.go`) | 502 | The *gateway resolver* failed to produce a usable access token for the requested subject |
+| `upstream_error` | 公開 API（`middleware/auth.go`） | 503 | 受信 Bearer トークン検証時に *OAuth プロバイダー*（GitHub）に到達できない |
+| `upstream_failure` | 内部 API（`internalapi/handler.go`） | 502 | *ゲートウェイリゾルバー* が要求された subject に使用可能なアクセストークンを生成できなかった |
 
-The asymmetry in naming is deliberate: the two codes appear in separate subsystems, serve
-different audiences, and have different retry semantics. They should not be merged.
+命名の非対称性は意図的です。2 つのコードは別々のサブシステムに存在し、異なる対象者に向けられ、異なる再試行セマンティクスを持っています。統合すべきではありません。
 
-### 2.3 Conceptual Category: AUTH_CONTEXT_UNAVAILABLE
+### 2.3 概念カテゴリー: AUTH_CONTEXT_UNAVAILABLE
 
-Issue #72 (Phase B) considered introducing a single error code `auth_context_unavailable` to
-cover the condition "the gateway has no usable auth context for this subject." After the Phase B
-go/no-go verdict this was **decided against** — no new error code was added to the codebase.
+Issue #72（Phase B）では、「ゲートウェイがこの subject に使用可能な認証コンテキストを持っていない」という状態をカバーする単一のエラーコード `auth_context_unavailable` の導入が検討されました。Phase B の go/no-go 決定後、これは**却下**されました。コードベースに新しいエラーコードは追加されていません。
 
-Instead, the two existing codes cover the concept:
+代わりに、既存の 2 つのコードがその概念をカバーしています:
 
-| Code | Why the context is unavailable |
+| コード | コンテキストが利用不可な理由 |
 |---|---|
-| `subject_not_found` | No token has ever been cached for this subject (user never authenticated on this gateway instance, or cache was purged) |
-| `rotation_failed` | A token exists but rotation did not yield a fresh token — may be a transient provider/network error or permanent refresh-token rejection |
+| `subject_not_found` | この subject のトークンがキャッシュされていない（ユーザーがこのゲートウェイインスタンスで認証したことがない、またはキャッシュがパージされた） |
+| `rotation_failed` | トークンは存在するがローテーションが新鮮なトークンを生成できなかった。一時的なプロバイダー/ネットワークエラーまたはリフレッシュトークンの永続的な拒否の可能性がある |
 
-`subject_not_found` always requires re-authentication. `rotation_failed` should be retried first;
-if the error persists, trigger the end-user to re-authenticate via the gateway's public OAuth flow.
-Callers **SHOULD** treat persistent `rotation_failed` as "prompt re-authentication," but a single
-transient occurrence warrants a retry before escalating.
+`subject_not_found` は常に再認証が必要です。`rotation_failed` はまず再試行すべきです。エラーが続く場合はエンドユーザーにゲートウェイの公開 OAuth フローで再認証を促してください。呼び出し元は継続的な `rotation_failed` を「再認証を促す」として扱う**べき**ですが、単発の一時的な発生は昇格前に再試行を保証します。
 
-Implementation reference: `internal/auth/handler.go:EnsureFreshAccessTokenForSubject()` —
-returns `auth.ErrSubjectNotFound` and `auth.ErrRotationFailed` as distinct typed errors;
-`internalapi/handler.go` maps them to the codes above.
+実装参照: `internal/auth/handler.go:EnsureFreshAccessTokenForSubject()` — 別個の型付きエラーとして `auth.ErrSubjectNotFound` と `auth.ErrRotationFailed` を返します。`internalapi/handler.go` がそれらを上記のコードにマッピングします。
 
 ---
 
-### 2.4 OAuth 失敗診断 endpoint
+### 2.4 OAuth 失敗診断エンドポイント
 
-`GET /internal/v1/auth/failures` は、既存の loopback + shared secret 境界で
-直近100件の OAuth 失敗を最新順に返す。`limit=1..100` で件数を縮小できる。
+`GET /internal/v1/auth/failures` は、既存のループバック + 共有シークレット境界で直近 100 件の OAuth 失敗を最新順に返します。`limit=1..100` で件数を縮小できます。
 
-| Error code | HTTP status | Trigger |
+| エラーコード | HTTP ステータス | トリガー |
 |---|---|---|
 | `method_not_allowed` | 405 | `GET` 以外 |
-| `loopback_required` | 403 | loopback 以外からの接続 |
-| `invalid_authorization` | 401 | shared secret 不一致 |
-| `invalid_limit` | 400 | `limit` が1から100の整数ではない |
+| `loopback_required` | 403 | ループバック以外からの接続 |
+| `invalid_authorization` | 401 | 共有シークレット不一致 |
+| `invalid_limit` | 400 | `limit` が 1 から 100 の整数でない |
 | `diagnostics_unavailable` | 503 | failure reader が設定されていない |
 
-応答イベントには token、authorization code、OAuth `state`、secret、provider
-response body を含めない。永続的な解析の正本は OAuth 監査 JSON Lines
-ファイルであり、この endpoint のメモリ履歴は process 再起動時に消失する。
+レスポンスイベントにはトークン・authorization code・OAuth `state`・シークレット・プロバイダーレスポンスボディを含みません。永続的な解析の正本は OAuth 監査 JSON Lines ファイルであり、このエンドポイントのメモリ履歴はプロセス再起動時に消失します。
 
 ---
 
-## 3. copilot-review-mcp Mapping Contract
+## 3. copilot-review-mcp マッピングコントラクト
 
-This section documents how gateway error codes propagate through copilot-review-mcp's internal
-error taxonomy. It is primarily useful for maintainers of both services.
+このセクションはゲートウェイのエラーコードが copilot-review-mcp の内部エラー分類を通じてどのように伝播するかを説明します。両サービスのメンテナーに主に有用です。
 
-### 3.1 Gateway Internal API → Sentinel Errors
+### 3.1 ゲートウェイ内部 API → センチネルエラー
 
-`copilot-review-mcp/internal/github/gateway_token_source.go` maps the HTTP status codes of
-`/internal/v1/whoami` responses to Go sentinel errors:
+`copilot-review-mcp/internal/github/gateway_token_source.go` は `/internal/v1/whoami` レスポンスの HTTP ステータスコードを Go センチネルエラーにマッピングします:
 
-| `/whoami` HTTP status | Gateway error code | Sentinel error |
+| `/whoami` HTTP ステータス | ゲートウェイエラーコード | センチネルエラー |
 |---|---|---|
-| 200 | *(success)* | — |
-| 200 (malformed body) | `expires_at` missing or unparseable | `ErrGatewayInvalidExpiry` |
+| 200 | *（成功）* | — |
+| 200（不正なボディ） | `expires_at` が欠けているか解析不能 | `ErrGatewayInvalidExpiry` |
 | 401 | `invalid_authorization` | `ErrGatewayUnauthorized` |
 | 403 | `loopback_required` | `ErrGatewayLoopbackRequired` |
 | 404 | `subject_not_found` | `ErrGatewaySubjectGone` |
 | 502 | `rotation_failed` | `ErrGatewayRotationFailed` |
-| 502 | `upstream_failure` (or unrecognised body) | `ErrGatewayUpstreamFailure` |
-| other 4xx | `method_not_allowed` / `invalid_body` / `missing_subject` | `ErrGatewayBadRequest` |
+| 502 | `upstream_failure`（または認識不能なボディ） | `ErrGatewayUpstreamFailure` |
+| その他 4xx | `method_not_allowed` / `invalid_body` / `missing_subject` | `ErrGatewayBadRequest` |
 
-`ErrGatewayUnauthorized`, `ErrGatewayLoopbackRequired`, and `ErrGatewayBadRequest` always
-indicate configuration errors; they should never occur in a correctly configured deployment.
+`ErrGatewayUnauthorized`・`ErrGatewayLoopbackRequired`・`ErrGatewayBadRequest` は常に設定エラーを示します。正しく設定されたデプロイでは発生しないはずです。
 
-`ErrGatewayRotationFailed` and `ErrGatewayUpstreamFailure` are distinct sentinels since
-copilot-review-mcp PR #34 (Issue #33): `gatewayTokenSource.Token()` now parses the JSON `error`
-body of HTTP 502 responses to emit the appropriate sentinel.
+`ErrGatewayRotationFailed` と `ErrGatewayUpstreamFailure` は copilot-review-mcp PR #34（Issue #33）以降の別々のセンチネルです。`gatewayTokenSource.Token()` が HTTP 502 レスポンスの JSON `error` ボディを解析して適切なセンチネルを発行するようになりました。
 
-### 3.2 Watch Manager: Sentinel Errors → `FailureReason`
+### 3.2 ウォッチマネージャー: センチネルエラー → `FailureReason`
 
-`copilot-review-mcp/internal/watch/manager.go` classifies polling failures into three
-`FailureReason` values:
+`copilot-review-mcp/internal/watch/manager.go` はポーリング失敗を 3 つの `FailureReason` 値に分類します:
 
-| `FailureReason` | Meaning |
+| `FailureReason` | 意味 |
 |---|---|
-| `AUTH_EXPIRED` | The auth context expired; the watch cannot continue until the user re-authenticates |
-| `GITHUB_ERROR` | A GitHub API error that is not an auth expiry (may be transient) |
-| `INTERNAL_ERROR` | Watch setup or database failure |
+| `AUTH_EXPIRED` | 認証コンテキストが期限切れ。ユーザーが再認証するまでウォッチを継続できない |
+| `GITHUB_ERROR` | 認証期限切れでない GitHub API エラー（一時的な可能性あり） |
+| `INTERNAL_ERROR` | ウォッチのセットアップまたはデータベース障害 |
 
-The manager uses `ghclient.IsAuthError(err)` and `ghclient.IsGatewayAuthError(err)` to
-distinguish `AUTH_EXPIRED` from `GITHUB_ERROR`. `IsAuthError` detects HTTP 401 errors from
-the **GitHub API**. `IsGatewayAuthError` recognises the gateway sentinels that require
-re-authentication. `ErrGatewayUpstreamFailure` is handled separately by a consecutive-failure
-budget: after `N` consecutive failures the watch escalates to `AUTH_EXPIRED`.
+マネージャーは `ghclient.IsAuthError(err)` と `ghclient.IsGatewayAuthError(err)` を使用して `AUTH_EXPIRED` と `GITHUB_ERROR` を区別します。`IsAuthError` は **GitHub API** からの HTTP 401 エラーを検出します。`IsGatewayAuthError` は再認証が必要なゲートウェイセンチネルを認識します。`ErrGatewayUpstreamFailure` は連続障害予算によって別途処理されます。`N` 回の連続障害後にウォッチは `AUTH_EXPIRED` に昇格します。
 
-**Current (actual) mapping:**
+**現在の（実際の）マッピング:**
 
-| Sentinel error | `IsGatewayAuthError(err)` | `FailureReason` (current) | Semantically correct? |
+| センチネルエラー | `IsGatewayAuthError(err)` | `FailureReason`（現在） | 意味的に正確か |
 |---|---|---|---|
-| `ErrGatewaySubjectGone` | `true` | `AUTH_EXPIRED` | ✅ Fixed ([scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36)) |
-| `ErrGatewayRotationFailed` | `true` | `AUTH_EXPIRED` | ✅ Fixed ([scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36)) |
-| `ErrGatewayUpstreamFailure` (transient, below threshold) | `false` | `GITHUB_ERROR` (continues watch) | ✅ Fixed ([scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)) |
-| `ErrGatewayUpstreamFailure` (persistent, above threshold) | `false` → escalated | `AUTH_EXPIRED` | ✅ Fixed ([scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)) |
-| GitHub API 401 | *(IsAuthError)* `true` | `AUTH_EXPIRED` | ✅ |
-| GitHub API 5xx / other | `false` | `GITHUB_ERROR` | ✅ |
+| `ErrGatewaySubjectGone` | `true` | `AUTH_EXPIRED` | ✅ 修正済み ([scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36)) |
+| `ErrGatewayRotationFailed` | `true` | `AUTH_EXPIRED` | ✅ 修正済み ([scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36)) |
+| `ErrGatewayUpstreamFailure`（一時的、閾値未満） | `false` | `GITHUB_ERROR`（ウォッチ継続） | ✅ 修正済み ([scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)) |
+| `ErrGatewayUpstreamFailure`（継続的、閾値超過） | `false` → 昇格 | `AUTH_EXPIRED` | ✅ 修正済み ([scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)) |
+| GitHub API 401 | *（IsAuthError）* `true` | `AUTH_EXPIRED` | ✅ |
+| GitHub API 5xx / その他 | `false` | `GITHUB_ERROR` | ✅ |
 
-### 3.3 Tool Call Path: `AuthErrorType`
+### 3.3 ツール呼び出しパス: `AuthErrorType`
 
-When a copilot-review-mcp **tool call** fails (not a background watch), errors are classified by
-`ClassifyGitHubError()` into `autherr.AuthErrorType`:
+copilot-review-mcp の**ツール呼び出し**が失敗した場合（バックグラウンドウォッチではなく）、エラーは `ClassifyGitHubError()` によって `autherr.AuthErrorType` に分類されます:
 
-| `AuthErrorType` | Meaning |
+| `AuthErrorType` | 意味 |
 |---|---|
-| `AUTH_REQUIRED` | No credentials present at all |
-| `REAUTH_REQUIRED` | Credentials expired (GitHub 401) |
-| `TOKEN_REFRESH_FAILED` | Refresh token was explicitly rejected |
+| `AUTH_REQUIRED` | 認証情報がまったく存在しない |
+| `REAUTH_REQUIRED` | 認証情報が期限切れ（GitHub 401） |
+| `TOKEN_REFRESH_FAILED` | リフレッシュトークンが明示的に拒否された |
 | `PERMISSION_DENIED` | GitHub 403 |
-| `RATE_LIMITED` | GitHub rate limit (primary or secondary) |
+| `RATE_LIMITED` | GitHub レート制限（プライマリまたはセカンダリ） |
 | `NOT_FOUND` | GitHub 404 |
 | `VALIDATION_ERROR` | GitHub 400 / 422 |
-| `TRANSIENT_UPSTREAM_ERROR` | GitHub 5xx (retryable) |
+| `TRANSIENT_UPSTREAM_ERROR` | GitHub 5xx（再試行可能） |
 
-`ClassifyGitHubError` is built around both GitHub API HTTP status codes and gateway sentinel
-errors. Gateway sentinels are checked first (before generic HTTP-status checks) because they
-carry more precise semantics.
+`ClassifyGitHubError` は GitHub API HTTP ステータスコードとゲートウェイセンチネルエラーの両方に基づいて構築されています。ゲートウェイセンチネルはより正確なセマンティクスを持つため、汎用的な HTTP ステータスチェックより先にチェックされます。
 
-**Gateway sentinel → `AuthErrorType` mapping (as of PR #32):**
+**ゲートウェイセンチネル → `AuthErrorType` マッピング（PR #32 時点）:**
 
-| Sentinel | `AuthErrorType` | Rationale |
+| センチネル | `AuthErrorType` | 理由 |
 |---|---|---|
-| `ErrGatewayRotationFailed` | `TOKEN_REFRESH_FAILED` | Gateway reported `rotation_failed` (may indicate token rejection, transient provider failure, or malformed provider response); re-auth recommended if persistent |
-| `ErrGatewaySubjectGone` | `REAUTH_REQUIRED` | Subject removed or revoked; re-auth required |
-| `ErrGatewayUpstreamFailure` | `TRANSIENT_UPSTREAM_ERROR` | Transient resolver failure; retry may succeed |
-| `ErrGatewayUnauthorized` | `AUTH_REQUIRED` | Shared-secret misconfiguration; no usable token |
-| `ErrGatewayLoopbackRequired` | `AUTH_REQUIRED` | Endpoint not on loopback; configuration error |
-| `ErrGatewayBadRequest` | `VALIDATION_ERROR` | Request arguments rejected; do not retry |
-| `ErrGatewayInvalidExpiry` | `TRANSIENT_UPSTREAM_ERROR` | Malformed whoami response (missing/invalid `expires_at`); retry may succeed |
+| `ErrGatewayRotationFailed` | `TOKEN_REFRESH_FAILED` | ゲートウェイが `rotation_failed` を報告（トークン拒否・一時的なプロバイダー障害・不正なプロバイダーレスポンスを示す可能性あり）。継続する場合は再認証を推奨 |
+| `ErrGatewaySubjectGone` | `REAUTH_REQUIRED` | Subject が削除または失効。再認証が必要 |
+| `ErrGatewayUpstreamFailure` | `TRANSIENT_UPSTREAM_ERROR` | 一時的なリゾルバー障害。再試行で成功する可能性あり |
+| `ErrGatewayUnauthorized` | `AUTH_REQUIRED` | 共有シークレットの設定ミス。使用可能なトークンなし |
+| `ErrGatewayLoopbackRequired` | `AUTH_REQUIRED` | エンドポイントがループバック上にない。設定エラー |
+| `ErrGatewayBadRequest` | `VALIDATION_ERROR` | リクエスト引数が拒否された。再試行しないこと |
+| `ErrGatewayInvalidExpiry` | `TRANSIENT_UPSTREAM_ERROR` | 不正な whoami レスポンス（`expires_at` が欠けているか無効）。再試行で成功する可能性あり |
 
 ---
 
-## 4. Known Gaps — All Resolved
+## 4. 既知のギャップ — すべて解決済み
 
-All three gaps identified at Phase C document creation have been resolved in
-copilot-review-mcp. The sections below are preserved for historical reference and
-cross-linked to the relevant PRs.
+Phase C ドキュメント作成時に特定された 3 つのギャップはすべて copilot-review-mcp で解決されました。以下のセクションは歴史的参照として保存されており、関連する PR にクロスリンクされています。
 
-### Gap 1 — ✅ Resolved (scottlz0310/copilot-review-mcp PR #36)
+### ギャップ 1 — ✅ 解決済み (scottlz0310/copilot-review-mcp PR #36)
 
-**`ErrGatewaySubjectGone` was classified as `GITHUB_ERROR` not `AUTH_EXPIRED`**
+**`ErrGatewaySubjectGone` が `AUTH_EXPIRED` ではなく `GITHUB_ERROR` に分類されていた**
 
-**Location:** `copilot-review-mcp/internal/watch/manager.go`
+**場所:** `copilot-review-mcp/internal/watch/manager.go`
 
-When a watch's `gatewayTokenSource.Token()` call returned `ErrGatewaySubjectGone` (HTTP 404
-from gateway), `IsAuthError` returned `false` because it only recognised GitHub API 401
-patterns. The watch therefore set `FailureReason = GITHUB_ERROR`.
+ウォッチの `gatewayTokenSource.Token()` 呼び出しが `ErrGatewaySubjectGone`（ゲートウェイからの HTTP 404）を返した場合、`IsAuthError` が GitHub API 401 パターンのみを認識するため `false` を返していました。ウォッチはそのため `FailureReason = GITHUB_ERROR` を設定していました。
 
-**Resolution:** `ghclient.IsGatewayAuthError` was introduced and wired into the watch manager.
-It returns `true` for `ErrGatewaySubjectGone` and `ErrGatewayRotationFailed`, causing the watch
-to set `FailureReason = AUTH_EXPIRED` for both.
-Fixed by [scottlz0310/copilot-review-mcp#31](https://github.com/scottlz0310/copilot-review-mcp/issues/31),
-landed in [scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36).
+**解決:** `ghclient.IsGatewayAuthError` が導入されウォッチマネージャーに組み込まれました。`ErrGatewaySubjectGone` と `ErrGatewayRotationFailed` に対して `true` を返し、ウォッチが両方に対して `FailureReason = AUTH_EXPIRED` を設定するようになりました。
+[scottlz0310/copilot-review-mcp#31](https://github.com/scottlz0310/copilot-review-mcp/issues/31) で修正され、[scottlz0310/copilot-review-mcp PR #36](https://github.com/scottlz0310/copilot-review-mcp/pull/36) でリリースされました。
 
-### Gap 2 — ✅ Resolved (scottlz0310/copilot-review-mcp PR #32)
+### ギャップ 2 — ✅ 解決済み (scottlz0310/copilot-review-mcp PR #32)
 
-**Gateway sentinel errors had no `AuthErrorType` mapping**
+**ゲートウェイセンチネルエラーに `AuthErrorType` マッピングがなかった**
 
-**Location:** `copilot-review-mcp/internal/github/classify.go`
+**場所:** `copilot-review-mcp/internal/github/classify.go`
 
-When a tool call failed due to a gateway sentinel error, `ClassifyGitHubError` did not produce
-an `AuthErrorType`.
+ツール呼び出しがゲートウェイセンチネルエラーで失敗した場合、`ClassifyGitHubError` が `AuthErrorType` を生成しませんでした。
 
-**Resolution:** Explicit cases for all gateway sentinel errors were added to
-`ClassifyGitHubError`. See §3.3 for the current mapping table.
-Fixed by [scottlz0310/copilot-review-mcp#32](https://github.com/scottlz0310/copilot-review-mcp/issues/32).
+**解決:** すべてのゲートウェイセンチネルエラーの明示的なケースが `ClassifyGitHubError` に追加されました。現在のマッピングテーブルは §3.3 を参照してください。
+[scottlz0310/copilot-review-mcp#32](https://github.com/scottlz0310/copilot-review-mcp/issues/32) で修正されました。
 
-### Gap 3 — ✅ Resolved (scottlz0310/copilot-review-mcp PR #34, Issue #33)
+### ギャップ 3 — ✅ 解決済み (scottlz0310/copilot-review-mcp PR #34, Issue #33)
 
-**`ErrGatewayUpstreamFailure` conflated `rotation_failed` and `upstream_failure`**
+**`ErrGatewayUpstreamFailure` が `rotation_failed` と `upstream_failure` を混在させていた**
 
-**Location:** `copilot-review-mcp/internal/github/gateway_token_source.go`
+**場所:** `copilot-review-mcp/internal/github/gateway_token_source.go`
 
-`gatewayTokenSource.Token()` mapped **all** HTTP 502 responses from the gateway to the same
-sentinel `ErrGatewayUpstreamFailure`, without reading the JSON `error` body.
+`gatewayTokenSource.Token()` がゲートウェイからのすべての HTTP 502 レスポンスを、JSON `error` ボディを読まずに同じセンチネル `ErrGatewayUpstreamFailure` にマッピングしていました。
 
-**Resolution:** `gatewayTokenSource.Token()` now parses the JSON `error` field of HTTP 502
-responses and emits `ErrGatewayRotationFailed` for `{"error":"rotation_failed"}` and
-`ErrGatewayUpstreamFailure` for `{"error":"upstream_failure"}` (or any unrecognised body).
-The persistent `ErrGatewayUpstreamFailure` escalation to `AUTH_EXPIRED` after `N` consecutive
-failures was also added ([scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)).
-Fixed by [scottlz0310/copilot-review-mcp#33](https://github.com/scottlz0310/copilot-review-mcp/issues/33),
-landed in [scottlz0310/copilot-review-mcp PR #34](https://github.com/scottlz0310/copilot-review-mcp/pull/34).
+**解決:** `gatewayTokenSource.Token()` が HTTP 502 レスポンスの JSON `error` フィールドを解析し、`{"error":"rotation_failed"}` に対して `ErrGatewayRotationFailed` を、`{"error":"upstream_failure"}`（または認識不能なボディ）に対して `ErrGatewayUpstreamFailure` を発行するようになりました。`N` 回の連続障害後の `ErrGatewayUpstreamFailure` の `AUTH_EXPIRED` への昇格も追加されました（[scottlz0310/copilot-review-mcp PR #38](https://github.com/scottlz0310/copilot-review-mcp/pull/38)）。
+[scottlz0310/copilot-review-mcp#33](https://github.com/scottlz0310/copilot-review-mcp/issues/33) で修正され、[scottlz0310/copilot-review-mcp PR #34](https://github.com/scottlz0310/copilot-review-mcp/pull/34) でリリースされました。
 
 ---
 
-## 5. Operator Notes
+## 5. オペレーターノート
 
-### 5.1 Log Fields
+### 5.1 ログフィールド
 
-Structured logs in this repo use the field key `"err"` (not `"error"`) for error values. All
-log entries below are emitted with `slog.Error` or `slog.Warn`.
+このリポジトリの構造化ログはエラー値に `"error"` ではなく `"err"` フィールドキーを使用します。以下のすべてのログエントリは `slog.Error` または `slog.Warn` で出力されます。
 
-| Log message | Level | Key fields | Meaning |
+| ログメッセージ | レベル | キーフィールド | 意味 |
 |---|---|---|---|
-| `"upstream error during auth"` | Error | `err`, `path` | GitHub OAuth provider returned 5xx or network failure during token validation; maps to `upstream_error` (503) |
-| `"auth failed"` | Warn | `err`, `path` | Token validation failed; maps to `invalid_token` (401) |
-| `"internalapi: whoami rotation failed"` | Warn | `subject`, `err` | Refresh rotation failed; maps to `rotation_failed` (502) |
-| `"internalapi: whoami lookup failed"` | Warn | `subject`, `err` | Other resolver failure; maps to `upstream_failure` (502) |
-| `"internalapi: whoami returned empty access token despite no error"` | Warn | `subject` | Defensive path; maps to `upstream_failure` (502) |
+| `"upstream error during auth"` | Error | `err`、`path` | GitHub OAuth プロバイダーがトークン検証中に 5xx を返すかネットワーク障害。`upstream_error`（503）にマッピング |
+| `"auth failed"` | Warn | `err`、`path` | トークン検証失敗。`invalid_token`（401）にマッピング |
+| `"internalapi: whoami rotation failed"` | Warn | `subject`、`err` | リフレッシュローテーション失敗。`rotation_failed`（502）にマッピング |
+| `"internalapi: whoami lookup failed"` | Warn | `subject`、`err` | その他のリゾルバー障害。`upstream_failure`（502）にマッピング |
+| `"internalapi: whoami returned empty access token despite no error"` | Warn | `subject` | 防御的パス。`upstream_failure`（502）にマッピング |
 
-### 5.2 Re-authentication Triggers
+### 5.2 再認証トリガー
 
-A user must complete a fresh OAuth flow when either of the following is observed:
+以下のいずれかが観測された場合、ユーザーは新鮮な OAuth フローを完了する必要があります:
 
-1. The public API returns `invalid_token` — the gateway Bearer token is expired, invalid, or
-   not valid for the requested resource (e.g., audience mismatch). Any `invalid_token` response
-   requires re-authentication regardless of the specific `error_description`.
-2. The internal API returns `subject_not_found` — the user has no cached session on this gateway
-   instance (new deployment, cache purge, or the user never authenticated here).
-3. The internal API returns `rotation_failed` — token rotation did not yield a fresh access token (may be transient; retry before triggering re-authentication).
+1. 公開 API が `invalid_token` を返す — ゲートウェイ Bearer トークンが期限切れ・無効・または要求されたリソースに対して有効でない（audience 不一致など）。`error_description` に関わらず `invalid_token` レスポンスはすべて再認証が必要です。
+2. 内部 API が `subject_not_found` を返す — ユーザーがこのゲートウェイインスタンスでキャッシュされたセッションを持っていない（新しいデプロイ・キャッシュのパージ・またはユーザーがここで認証したことがない）。
+3. 内部 API が `rotation_failed` を返す — トークンローテーションが新鮮なアクセストークンを生成できなかった（一時的な可能性あり。再認証を促す前に再試行してください）。
 
-Operators can surface the re-authentication URL from the `resource_metadata` parameter in the
-`WWW-Authenticate` header of any `401` response.
+オペレーターは `401` レスポンスの `WWW-Authenticate` ヘッダーの `resource_metadata` パラメーターから再認証 URL を取得できます。
 
-### 5.3 Configuration Hints
+### 5.3 設定ヒント
 
-| Symptom | Likely cause | Check |
+| 症状 | 原因の可能性 | 確認事項 |
 |---|---|---|
-| `loopback_required` (403) on internal API | Caller is not connecting via loopback | Ensure upstream MCP server calls `127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}`; the listener always binds to `127.0.0.1` only (IPv6 loopback `[::1]` is not supported) |
-| `invalid_authorization` (401) on internal API | Mismatched shared secret | `MCP_GATEWAY_INTERNAL_SECRET` in both gateway and upstream server env |
-| Persistent `upstream_failure` (502) | Transient resolver or GitHub API failure; or the resolver returned an empty access token | Check GitHub status and retry; inspect gateway logs for resolver errors (`"err"` field) |
-| `subject_not_found` (404) after process restart | In-memory subject index starts empty after restart and re-seeds as bearer tokens are validated | Set `MCP_GATEWAY_TOKEN_STORE_PATH` for durable storage so sessions survive restart; the index rebuilds on the first bearer token validation per subject |
-| `upstream_error` (503) on every request | GitHub OAuth provider unreachable | Check GitHub status and outbound network access to the OAuth provider (configured via `OAUTH_PROVIDER`, default `github`) |
+| 内部 API で `loopback_required`（403） | 呼び出し元がループバック経由で接続していない | upstream MCP サーバーが `127.0.0.1:${MCP_GATEWAY_INTERNAL_PORT}` を呼び出していることを確認する。リスナーは常に `127.0.0.1` のみにバインドされる（IPv6 ループバック `[::1]` は非対応） |
+| 内部 API で `invalid_authorization`（401） | 共有シークレットが一致しない | ゲートウェイと upstream サーバーの両方の env で `MCP_GATEWAY_INTERNAL_SECRET` を確認する |
+| `upstream_failure`（502）が継続する | 一時的なリゾルバーまたは GitHub API 障害、またはリゾルバーが空のアクセストークンを返した | GitHub のステータスを確認して再試行する。リゾルバーエラーのゲートウェイログ（`"err"` フィールド）を確認する |
+| プロセス再起動後に `subject_not_found`（404） | インメモリ subject インデックスは再起動後に空から始まり Bearer トークン検証のたびに再シードされる | セッションが再起動後も維持されるように `MCP_GATEWAY_TOKEN_STORE_PATH` を永続ストレージに設定する。インデックスは subject ごとの最初の Bearer トークン検証で再構築される |
+| すべてのリクエストで `upstream_error`（503） | GitHub OAuth プロバイダーに到達できない | GitHub のステータスと OAuth プロバイダー（`OAUTH_PROVIDER` で設定、デフォルト `github`）への外部ネットワークアクセスを確認する |

--- a/docs/spike-72-delegated-background-access.md
+++ b/docs/spike-72-delegated-background-access.md
@@ -1,64 +1,43 @@
-# Spike #72: Delegated Background Access (Phase B PoC)
+# Spike #72: 委任バックグラウンドアクセス（Phase B PoC）
 
-**Status**: PoC / spike. Not for production use.
-**Refs**: #70 (overall plan), #71 (Phase A: rotation in request path), #72 (this PoC)
+**ステータス**: PoC / スパイク。本番環境での使用不可。
+**参照**: #70（全体計画）、#71（Phase A: リクエストパスでのローテーション）、#72（この PoC）
 
-## Problem
+## 問題
 
-Phase A (#71) introduced transparent GitHub access-token rotation on the
-**client request path** through the gateway. Each inbound proxied request
-calls `tryGitHubRotation`, so the bearer presented by an MCP client is
-swapped for a fresh one inside the leeway window before it is forwarded.
+Phase A（#71）はゲートウェイの**クライアントリクエストパス**での透過的な GitHub アクセストークンローテーションを導入しました。各インバウンドのプロキシされたリクエストが `tryGitHubRotation` を呼び出すため、MCP クライアントが提示する Bearer はリードウィンドウ内で upstream に転送される前に新鮮なものに交換されます。
 
-However, upstream MCP servers (notably `copilot-review-mcp`) run
-**background workflows** (a `watch` goroutine for the Copilot review
-poller) that bypass the per-request path entirely. They snapshot a
-bearer into an `oauth2.StaticTokenSource` at watch-start time and keep
-using it for the entire watch lifetime — even after rotation has issued
-a new access token.
+しかし、upstream MCP サーバー（特に `copilot-review-mcp`）はリクエストごとのパスを完全にバイパスする**バックグラウンドワークフロー**（Copilot レビューポーラーの `watch` goroutine）を実行しています。これらはウォッチ開始時に Bearer を `oauth2.StaticTokenSource` にスナップショットし、ローテーションで新しいアクセストークンが発行された後もウォッチ全体の存続期間中それを使い続けます。
 
-The Phase A rotation does cache *both* the old and new bearer for the
-gateway's own cache TTL (so MCP requests presenting either bearer continue
-to validate inside the gateway), but the underlying **GitHub-side access
-token validity** is independent of that cache: once the original GitHub
-access token actually expires, the old bearer presented by the background
-goroutine starts returning `401` from GitHub and the watch dies.
+Phase A のローテーションはゲートウェイ独自のキャッシュ TTL の間、古い Bearer と新しい Bearer の*両方*をキャッシュします（どちらの Bearer を提示する MCP リクエストもゲートウェイ内で引き続き検証されます）が、基盤となる **GitHub 側のアクセストークン有効性**はそのキャッシュとは独立しています。元の GitHub アクセストークンが実際に期限切れになると、バックグラウンド goroutine が提示する古い Bearer は GitHub から `401` を返し始め、ウォッチが終了します。
 
-## Goal
+## ゴール
 
-Provide a **gateway-internal API** that upstream MCP servers can call from
-their background goroutines to fetch the **current valid access token for a
-known subject**, with the gateway transparently rotating if the token is
-close to expiry. The upstream stores no tokens.
+upstream MCP サーバーがバックグラウンド goroutine から呼び出せる**ゲートウェイ内部 API** を提供し、トークンが有効期限間近の場合にゲートウェイが透過的にローテーションしながら**既知の subject の現在の有効なアクセストークン**を取得できるようにします。upstream はトークンを保存しません。
 
-This is the Option C ("gateway-managed delegated access") candidate from
-#70. The PoC validates the shape; production decisions remain open.
+これは #70 のオプション C（「ゲートウェイ管理の委任アクセス」）候補です。PoC は形状を検証します。本番環境向けの決定は未解決のままです。
 
-## Non-goals (for this spike)
+## 非ゴール（このスパイクの範囲外）
 
-- Persistent subject→token index across gateway restarts.
-- Hardened multi-tenant authorization between multiple upstreams.
-- UNIX domain socket / mTLS trust boundary (compared but deferred).
-- `copilot-review-mcp` production client implementation (drafted separately).
+- ゲートウェイ再起動をまたいだ subject→token インデックスの永続化。
+- 複数 upstream 間のハードニングされたマルチテナント認可。
+- UNIX ドメインソケット / mTLS トラスト境界（比較したが延期）。
+- `copilot-review-mcp` 本番クライアント実装（別途ドラフト済み）。
 
-## Trust boundary: comparison
+## トラスト境界: 比較
 
-| Option | Pros | Cons |
+| オプション | 長所 | 短所 |
 |---|---|---|
-| **A. UNIX domain socket** | OS-level permission isolation. No secret distribution. No network exposure. | Awkward on Windows; needs sidecar bind-mount in Docker. Two code paths to maintain. |
-| **B. loopback + shared secret** (chosen) | Trivial implementation. Cross-platform. Aligns with existing `gateway.key` / env-var patterns. | Secret distribution, rotation, and constant-time comparison must be handled. |
-| **C. mTLS** | Strong mutual authentication. Clean cert rotation. | Heavy for a PoC. CA/cert distribution design cost. |
-| **D. Hybrid (A + B fallback)** | Platform-optimal. | Doubles the test matrix. Out of PoC scope. |
+| **A. UNIX ドメインソケット** | OS レベルの権限分離。シークレット配布不要。ネットワーク露出なし。 | Windows では不便。Docker でサイドカーバインドマウントが必要。2 つのコードパスを保守する必要がある。 |
+| **B. ループバック + 共有シークレット**（選択） | 実装が簡単。クロスプラットフォーム。既存の `gateway.key` / env 変数パターンに合致。 | シークレットの配布・ローテーション・定数時間比較を処理する必要がある。 |
+| **C. mTLS** | 強力な相互認証。クリーンな証明書ローテーション。 | PoC には重すぎる。CA/証明書配布の設計コストがある。 |
+| **D. ハイブリッド（A + B フォールバック）** | プラットフォーム最適。 | テストマトリックスが倍増する。PoC のスコープ外。 |
 
-**Chosen: B**. Rationale: smallest PoC surface that still answers the
-"is delegated access useful?" question. Migration to A (Unix socket) is
-mostly straightforward later: the listener wiring changes, and the
-handler's loopback re-validation needs to become socket-aware (peer
-credential / `SO_PEERCRED`-style check instead of `r.RemoteAddr`).
+**選択: B**。理由: 「委任アクセスは有用か？」という問いに答えられる最小の PoC サーフェス。A（Unix ソケット）への移行は後から比較的容易です。リスナーの配線が変わり、ハンドラーのループバック再検証が `r.RemoteAddr` の代わりにソケットを認識する必要があります（`SO_PEERCRED` スタイルのチェック）。
 
 ## API
 
-### Endpoint
+### エンドポイント
 
 ```
 POST /internal/v1/whoami
@@ -69,12 +48,9 @@ Content-Type: application/json
 { "subject": "alice" }
 ```
 
-The endpoint is named `whoami` (rather than `token/refresh`) so the
-upstream semantics stay "give me the latest valid token", with rotation
-policy hidden inside the gateway. This avoids upstream-side
-over-rotation and keeps the upstream stateless.
+エンドポイントは `token/refresh` ではなく `whoami` と命名されているため、upstream のセマンティクスは「最新の有効なトークンをください」となり、ローテーションポリシーはゲートウェイ内部に隠蔽されます。これにより upstream 側の過剰なローテーションを避け、upstream をステートレスに保ちます。
 
-### Response (200)
+### レスポンス (200)
 
 ```json
 {
@@ -85,212 +61,105 @@ over-rotation and keeps the upstream stateless.
 }
 ```
 
-`refresh_token` is intentionally absent: the upstream MUST NOT persist
-refresh tokens. The `scopes` field is the gateway's configured scope
-list (best-effort identifier for what the access token can do).
+`refresh_token` は意図的に省略されています。upstream はリフレッシュトークンを永続化しては**なりません**。`scopes` フィールドはゲートウェイで設定されたスコープリストです（アクセストークンで実行できることのベストエフォート識別子）。
 
-### Error responses
+### エラーレスポンス
 
-| Status | Reason |
+| ステータス | 理由 |
 |---|---|
-| 400 | malformed body, missing `subject`, or trailing data after JSON object |
-| 401 | missing/invalid `Authorization` (constant-time compared) |
-| 403 | request did not originate from a loopback address |
-| 404 | no cached token record for this subject |
-| 405 | non-POST method (response includes `Allow: POST`) |
-| 502 | provider rotation was required (cached token inside the leeway window) but did not produce a fresh token (`error: "rotation_failed"`) |
-| 502 | upstream resolver failed for a non-rotation reason, or returned an empty access token despite reporting success (`error: "upstream_failure"`) |
+| 400 | 不正なボディ・`subject` が欠けている・JSON オブジェクト後の余分なデータ |
+| 401 | `Authorization` が欠けているか無効（定数時間比較） |
+| 403 | リクエストがループバックアドレスから発生していない |
+| 404 | この subject のキャッシュされたトークンレコードがない |
+| 405 | POST 以外のメソッド（レスポンスに `Allow: POST` を含む） |
+| 502 | プロバイダーローテーションが必要だった（キャッシュされたトークンがリードウィンドウ内）が新鮮なトークンを生成できなかった（`error: "rotation_failed"`） |
+| 502 | ローテーション以外の理由で upstream リゾルバーが失敗した、またはリゾルバーが成功を報告したにもかかわらず空のアクセストークンを返した（`error: "upstream_failure"`） |
 
-## Security model
+## セキュリティモデル
 
-1. **Listener bind**: 127.0.0.1 (IPv4 loopback) only in the current PoC. Binding 0.0.0.0 / a non-loopback interface is a startup error. IPv6 loopback (`::1`) is not bound today; adding it is straightforward (`net.Listen` on `[::1]:<port>`) but out of PoC scope.
-2. **Defense in depth**: handler re-validates `r.RemoteAddr` is a loopback IP.
-3. **Shared secret**:
-   - Env var `MCP_GATEWAY_INTERNAL_SECRET`. Must be ≥ 32 chars; shorter is a startup error.
-   - Compared with `crypto/subtle.ConstantTimeCompare`.
-   - Internal listener is **not started** unless both the secret and port are set (fail-closed).
-4. **Body cap**: `http.MaxBytesReader` at 4 KiB.
-5. **Logging**: access tokens never appear in logs. Subject is logged in clear (it is the GitHub login, which is already non-sensitive in the gateway's threat model); the upstream listener emits the same structured fields as the public HTTP server.
-6. **Limited enumeration resistance**: 404 is returned for "subject not present in the cache". An attacker who has already obtained the shared secret can use timing or status to probe which subjects currently have an active session — this PoC does not attempt to flatten that signal. The mitigation is the shared-secret + loopback boundary, not response-shape obfuscation.
+1. **リスナーバインド**: 現在の PoC では 127.0.0.1（IPv4 ループバック）のみ。0.0.0.0 / ループバック以外のインターフェースへのバインドは起動エラーです。IPv6 ループバック（`::1`）は現在バインドされていません。追加は容易（`[::1]:<port>` での `net.Listen`）ですが PoC のスコープ外です。
+2. **多層防御**: ハンドラーが `r.RemoteAddr` がループバック IP であることを再検証します。
+3. **共有シークレット**:
+   - env 変数 `MCP_GATEWAY_INTERNAL_SECRET`。32 文字以上必須。それより短い場合は起動エラー。
+   - `crypto/subtle.ConstantTimeCompare` で比較。
+   - シークレットとポートの両方が設定されていない限り内部リスナーは**起動しない**（フェイルクローズド）。
+4. **ボディキャップ**: `http.MaxBytesReader` で 4 KiB。
+5. **ログ**: アクセストークンはログに出力されません。Subject は平文でログされます（GitHub ログインであり、ゲートウェイの脅威モデルでは既に非機密）。upstream リスナーは公開 HTTP サーバーと同じ構造化フィールドを出力します。
+6. **限定的な列挙耐性**: `subject` がキャッシュに存在しない場合 404 を返します。既に共有シークレットを取得した攻撃者はタイミングまたはステータスを使用してどの subject が現在アクティブなセッションを持っているかを探索できます。この PoC はそのシグナルをフラット化しようとしません。緩和策はレスポンス形状の難読化ではなく共有シークレット + ループバック境界です。
 
-## Subject → token index
+## Subject → トークンインデックス
 
-Internal lookup design: `auth.Store` gains an **in-memory** secondary
-index `subject → []indexEntry{rawToken, expiresAt}`. The
-authoritative `ProviderAccessExpiry` is read from the underlying
-`TokenRecord` at lookup time so the index stays minimal.
+内部ルックアップ設計: `auth.Store` に**インメモリ**のセカンダリインデックス `subject → []indexEntry{rawToken, expiresAt}` を追加します。権威ある `ProviderAccessExpiry` はルックアップ時に基盤の `TokenRecord` から読み取られるため、インデックスは最小限に保たれます。
 
-- Updated whenever `CacheToken` is called (sign-up, rotation).
-- Pruned lazily on read: expired entries removed.
-- **Not persisted to disk** by design — the existing `fileTokenStore`
-  hashes tokens precisely so raw tokens never reach disk; we preserve
-  that invariant. A gateway restart forces upstream MCP servers to wait
-  for the next client request to re-seed the cache.
+- `CacheToken` が呼び出されるたびに更新（サインアップ・ローテーション）。
+- 読み取り時に遅延プルーニング: 期限切れエントリーを削除。
+- **設計上ディスクには永続化しない** — 既存の `fileTokenStore` がトークンをハッシュ化することで生のトークンがディスクに到達しないようにしています。この不変条件を維持します。ゲートウェイの再起動により upstream MCP サーバーは次のクライアントリクエストがキャッシュを再シードするまで待機する必要があります。
 
-Trade-off: this is a PoC compromise. A production implementation might
-add an encrypted persistent index, or migrate to a model where the
-upstream presents its current (possibly stale) token plus subject and
-the gateway returns the rotated successor. Documented for follow-up.
+トレードオフ: これは PoC 上の妥協です。本番実装では暗号化された永続的なインデックスを追加するか、upstream が現在の（古い可能性のある）トークンと subject を提示しゲートウェイがローテーション後継を返すモデルに移行する可能性があります。フォローアップのために文書化済みです。
 
-## Configuration
+## 設定
 
-| Env var | Required for internal API | Default | Purpose |
+| env 変数 | 内部 API に必須 | デフォルト | 用途 |
 |---|---|---|---|
-| `MCP_GATEWAY_INTERNAL_SECRET` | Yes | (unset → disabled) | Bearer secret. ≥ 32 chars. |
-| `MCP_GATEWAY_INTERNAL_PORT` | Yes | (unset → disabled) | TCP port for the loopback listener. |
+| `MCP_GATEWAY_INTERNAL_SECRET` | 必須 | （未設定 → 無効） | Bearer シークレット。32 文字以上必須。 |
+| `MCP_GATEWAY_INTERNAL_PORT` | 必須 | （未設定 → 無効） | ループバックリスナーの TCP ポート。 |
 
-Both must be set to enable the API. Either missing → internal listener
-is silently not started, with one `slog.Info` line documenting why.
+両方を設定すると API が有効になります。どちらかが欠けている → 内部リスナーは起動しない（なぜ起動しないかを文書化する 1 行の `slog.Info`）。
 
-### Prerequisite for rotating GitHub tokens
+### GitHub トークンローテーションの前提条件
 
-The internal API only triggers transparent rotation when the existing
-GitHub refresh flag is on. Set it together with the internal API env
-vars when you expect expiring GitHub OAuth tokens:
+内部 API は既存の GitHub リフレッシュフラグが有効な場合のみ透過的なローテーションをトリガーします。期限切れ GitHub OAuth トークンを期待する場合は内部 API env 変数と一緒に設定してください:
 
-| Setting | Required for rotation | Effect |
+| 設定 | ローテーションに必須 | 効果 |
 |---|---|---|
-| `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` / `gateway.github_refresh_enabled` | Yes (for rotating tokens) | Persists provider refresh metadata and lets `tryGitHubRotation` actually call the GitHub refresh endpoint. Defaults to **false**. |
+| `MCP_GATEWAY_GITHUB_REFRESH_ENABLED` / `gateway.github_refresh_enabled` | 必須（ローテーションするトークンの場合） | プロバイダーリフレッシュメタデータを永続化し、`tryGitHubRotation` が実際に GitHub リフレッシュエンドポイントを呼び出せるようにします。デフォルトは **false**。 |
 
-If the flag is off, `/internal/v1/whoami` still works but only ever
-returns the cached access token — useful for classic non-expiring PATs,
-but **not** for expiring OAuth tokens, where the gateway will keep
-handing back the same (eventually dead) bearer.
+フラグがオフの場合、`/internal/v1/whoami` は引き続き動作しますが、キャッシュされたアクセストークンを返すだけです。クラシックな非期限切れ PAT には便利ですが、**期限切れ OAuth トークンには不適切**です。ゲートウェイは同じ（やがて無効になる）Bearer を返し続けます。
 
-## Rotation policy
+## ローテーションポリシー
 
-On `POST /internal/v1/whoami`:
+`POST /internal/v1/whoami` 時:
 
-1. Look up subject. If absent → 404.
-2. Pick the entry with the latest `ProviderAccessExpiry`.
-3. Delegate to the existing `tryGitHubRotation` code path, which itself
-   compares `time.Until(expiry)` against `Handler.githubRefreshLeeway()`
-   (the same Phase A policy used on the client request path). If the
-   token is still outside the leeway window, the current raw token is
-   returned unchanged; otherwise rotation is attempted.
-4. If rotation was required (cached token inside the leeway window) but
-   did not produce a fresh token — whether the provider returned a
-   transient error or a permanent one that cleared the refresh metadata —
-   the response is **502 `rotation_failed`**. The gateway never hands
-   back a cached bearer that is at or past the rotation threshold; the
-   caller is expected to surface the failure to the user.
+1. subject を検索。存在しない場合 → 404。
+2. `ProviderAccessExpiry` が最も新しいエントリーを選択。
+3. 既存の `tryGitHubRotation` コードパスに委任。このコードパス自体が `time.Until(expiry)` を `Handler.githubRefreshLeeway()`（Phase A クライアントリクエストパスで使用されるのと同じポリシー）と比較します。トークンがまだリードウィンドウの外にある場合、現在の生のトークンをそのまま返します。それ以外の場合はローテーションを試みます。
+4. ローテーションが必要だった（キャッシュされたトークンがリードウィンドウ内）が新鮮なトークンを生成できなかった場合（プロバイダーが一時的なエラーを返したかリフレッシュメタデータをクリアした永続的なエラーの場合）、レスポンスは **502 `rotation_failed`**。ゲートウェイはローテーション閾値に達した・または超えたキャッシュされた Bearer を返しません。呼び出し元は障害をユーザーに伝えることが期待されます。
 
-The Phase B PoC deliberately does **not** introduce a dedicated leeway
-constant for delegated background access. It reuses the same GitHub
-refresh leeway policy as Phase A (default 5 minutes, overridable via
-`Handler.githubRefreshLeeway()`), so a single tunable governs rotation
-behaviour across both the client request path and the internal API.
-Splitting the leeway out per code path — e.g. a tighter window for
-long-running watch goroutines — is intentionally deferred (see Future
-work).
+Phase B PoC は委任バックグラウンドアクセス専用のリードウィンドウ定数を意図的に導入していません。Phase A と同じ GitHub リフレッシュリードウィンドウポリシー（デフォルト 5 分、`Handler.githubRefreshLeeway()` でオーバーライド可能）を再利用するため、クライアントリクエストパスと内部 API の両方でローテーション動作を 1 つの設定値で制御できます。コードパスごとにリードウィンドウを分割すること（長時間実行の watch goroutine にはより厳しいウィンドウなど）は意図的に延期されています（将来の作業を参照）。
 
-## Deployment and limitations
+## デプロイと制限事項
 
-- **Loopback-only by design.** The listener binds 127.0.0.1 only (IPv4
-  loopback). The request handler additionally accepts `::1` for
-  defense-in-depth, but no IPv6 listener is started in this PoC, so
-  upstream clients must connect over IPv4. The upstream must share the
-  gateway's network namespace.
-  Concretely:
-  - **Same host, bare binary**: works as-is — the upstream connects to
-    `127.0.0.1:<INTERNAL_PORT>`.
-  - **Docker bridge network**: a container running on the default bridge
-    cannot reach the gateway container's loopback. The upstream
-    container must be started with `--network=container:<gateway>` (or
-    the same compose `network_mode: "service:<gateway>"`), or be
-    co-located in the same pod / network namespace.
-  - **Reverse proxies**: do not route the internal API through any
-    public-facing reverse proxy; the loopback re-validation in the
-    handler will reject forwarded requests.
-- **No persistence across gateway restart.** The subject index is
-  in-memory; after a restart, the upstream watch goroutine will get 404
-  for that subject until the user issues a fresh client request that
-  re-seeds the cache. The upstream is expected to treat 404 as
-  "session-not-yet-ready" rather than a hard failure.
-- **Single shared secret.** All upstream consumers share one secret. A
-  compromised upstream effectively has the keys to every cached
-  subject's access token. Per-upstream identities are listed under
-  Future work.
+- **設計上ループバックのみ。** リスナーは 127.0.0.1 のみにバインドします（IPv4 ループバック）。リクエストハンドラーは多層防御として `::1` も追加で受け入れますが、この PoC では IPv6 リスナーは起動しないため、upstream クライアントは IPv4 で接続する必要があります。upstream はゲートウェイのネットワーク名前空間を共有している必要があります。
+  具体的に:
+  - **同一ホスト、ベアバイナリ**: そのまま動作します。upstream は `127.0.0.1:<INTERNAL_PORT>` に接続します。
+  - **Docker ブリッジネットワーク**: デフォルトブリッジで実行されているコンテナはゲートウェイコンテナのループバックに到達できません。upstream コンテナは `--network=container:<gateway>`（または同じ compose の `network_mode: "service:<gateway>"`）で起動するか、同じポッド / ネットワーク名前空間に配置する必要があります。
+  - **リバースプロキシ**: 内部 API を公開向けリバースプロキシ経由でルーティングしないでください。ハンドラーのループバック再検証が転送されたリクエストを拒否します。
+- **ゲートウェイ再起動をまたいで永続化しない。** Subject インデックスはインメモリです。再起動後、upstream の watch goroutine はユーザーが新しいクライアントリクエストを発行してキャッシュを再シードするまでその subject に対して 404 を受け取ります。upstream は 404 を「セッションがまだ準備できていない」ではなくハード障害として扱うことが期待されます。
+- **単一の共有シークレット。** すべての upstream コンシューマーが 1 つのシークレットを共有します。侵害された upstream はすべてのキャッシュされた subject のアクセストークンへのアクセス権を実質的に持ちます。upstream ごとの identity は将来の作業として挙げられています。
 
-## Known limitations (PoC scope)
+## 既知の制限事項（PoC のスコープ）
 
-The Copilot review on PR #76 surfaced two rotation-correctness gaps
-that are **not** addressed in this PoC because each requires a design
-change larger than the PoC envelope. They are accepted as risks because
-the loopback + shared-secret trust boundary keeps the blast radius
-inside the host, and because background watch goroutines tolerate
-transient 401s by re-issuing the delegated call. They are tracked
-under Future work and should be resolved before this API leaves PoC
-status.
+PR #76 での Copilot レビューで、この PoC では対処**しない** 2 つのローテーション正確性のギャップが明らかになりました。ループバック + 共有シークレットのトラスト境界がブラスト半径をホスト内に限定し、バックグラウンド watch goroutine が委任呼び出しを再発行することで一時的な 401 を許容するため、リスクとして受け入れられています。これらは将来の作業として追跡されており、この API が PoC ステータスを脱する前に解決すべきです。
 
-Note that the **temporal** blast radius depends on which token store is
-configured:
+なお、**時間的な**ブラスト半径は設定されているトークンストアによって異なります:
 
-- In-memory store (default for short-lived dev): bounded by
-  `cfg.CacheTTL` (a few minutes).
-- Persistent store (`auth.NewHandler` with a non-nil TokenStore):
-  bounded by `cfg.ExpiresIn` — **90 days by default** — because that
-  value drives both the issued session expiry and the cache TTL
-  applied to saved token records. A dead bearer / old-bearer
-  preference can therefore persist for days unless the operator
-  invalidates the entry manually or the user re-authenticates.
+- インメモリストア（短命の開発環境のデフォルト）: `cfg.CacheTTL`（数分）で制限される。
+- 永続ストア（非 nil の TokenStore を持つ `auth.NewHandler`）: `cfg.ExpiresIn` で制限される（デフォルトで **90 日**）。この値が発行されたセッション有効期限と保存されたトークンレコードに適用されるキャッシュ TTL の両方を決定するためです。したがって、死んだ Bearer / 古い Bearer の優先は、オペレーターが手動でエントリーを無効化するかユーザーが再認証するまで数日間継続する可能性があります。
 
-1. **Dead bearer after permanent rotation failure.** When
-   `runGitHubRotation` hits a *permanent* failure (`bad_refresh_token`
-   or an upstream response that reports success but returns an empty
-   `access_token`) it calls `ClearProviderRefresh` on the token entry.
-   The next `/internal/v1/whoami` call then finds no provider-refresh
-   metadata and falls into the lenient "no rotation contract" branch,
-   which returns the cached bearer with `200`. That bearer is almost
-   certainly already invalid on GitHub's side. Note that *transient*
-   upstream failures (5xx, network errors surfaced as
-   `auth.UpstreamError`) do **not** trigger `ClearProviderRefresh`;
-   they return `502 upstream_failure` with rotation metadata preserved
-   so the next call still takes the rotation path
-   (`action=retry_next`). The dead-bearer pitfall therefore applies
-   only to the permanent-failure subset. **Recovery does not happen
-   by simply re-issuing the delegated call on the next polling cycle**:
-   subsequent calls keep taking the same lenient branch and return the
-   same dead bearer until the underlying token-store/index TTL expires
-   (see the per-store bounds above) or the user re-authenticates.
-   Background callers will observe a `401` from GitHub on every use
-   and the gateway has no in-band recovery path. Proper fix: persist a
-   `RotationFailed` (or equivalent) flag on `TokenRecord` and surface
-   `ErrRotationFailed` on the next call.
+1. **永続的なローテーション失敗後の死んだ Bearer。** `runGitHubRotation` が*永続的な*失敗（`bad_refresh_token`、またはすべてが成功を報告したが空の `access_token` を返す upstream レスポンス）に遭遇した場合、トークンエントリーの `ClearProviderRefresh` を呼び出します。次の `/internal/v1/whoami` 呼び出しはプロバイダーリフレッシュメタデータを見つけられず、キャッシュされた Bearer を `200` で返す寛大な「ローテーションコントラクトなし」ブランチに入ります。その Bearer は GitHub 側では既にほぼ確実に無効です。*一時的な* upstream 障害（5xx、`auth.UpstreamError` として表面化したネットワークエラー）は `ClearProviderRefresh` をトリガー**しない**ことに注意してください。これらはローテーションメタデータを保持したまま `502 upstream_failure` を返すため、次の呼び出しはローテーションパスを取り続けます（`action=retry_next`）。死んだ Bearer の落とし穴は永続的な失敗のサブセットにのみ適用されます。**次のポーリングサイクルで委任呼び出しを再発行するだけでは回復は起こりません**。後続の呼び出しは同じ寛大なブランチを取り続け、基盤のトークンストア/インデックス TTL が期限切れになる（上記の各ストアの境界を参照）かユーザーが再認証するまで同じ死んだ Bearer を返し続けます。バックグラウンド呼び出し元はすべての使用で GitHub から `401` を観察し、ゲートウェイにはインバンドのリカバリパスがありません。適切な修正: `TokenRecord` に `RotationFailed`（または同等の）フラグを永続化し、次の呼び出しで `ErrRotationFailed` を表面化する。
 
-2. **Old/new bearer tie-break in `LatestBySubject`.** On successful
-   rotation, `runGitHubRotation` updates the *old* token entry's
-   `ProviderAccessExpiry` to the same value as the new entry (so a
-   client that keeps presenting the old bearer can still be rotated on
-   the next request). `LatestBySubject` walks the subject-index slice
-   in deterministic insertion order and ranks candidates by strict
-   `.After(...)`; when both entries carry an equal `ProviderAccessExpiry`
-   the strict comparison fails for the later-visited entry, so the
-   *first-inserted* (i.e. older) bearer keeps the lead and is returned
-   — even though only the *new* bearer is actually valid against
-   GitHub's original access token. The hazard is therefore the
-   insertion-order + equal-expiry combination, not map iteration
-   non-determinism. Proper fix: break ties in favour of the newest
-   index entry, or track the currently-active access token explicitly
-   on the rotation chain.
+2. **`LatestBySubject` での古い/新しい Bearer のタイブレーク。** ローテーションが成功すると、`runGitHubRotation` は*古い*トークンエントリーの `ProviderAccessExpiry` を新しいエントリーと同じ値に更新します（古い Bearer を提示し続けるクライアントが次のリクエストでローテーションされるように）。`LatestBySubject` は決定論的な挿入順序で subject インデックスのスライスを走査し、厳密な `.After(...)` で候補をランク付けします。両エントリーが等しい `ProviderAccessExpiry` を持つ場合、後から訪問されるエントリーに対して厳密な比較が失敗するため、*最初に挿入された*（すなわち古い）Bearer がトップに留まり返されます。実際に GitHub のオリジナルアクセストークンに対して有効なのは*新しい* Bearer だけであるにもかかわらずです。したがって、危険なのはマップ反復の非決定論ではなく、挿入順序 + 等しい有効期限の組み合わせです。適切な修正: 最新のインデックスエントリーを優先してタイを解決するか、ローテーションチェーン上の現在アクティブなアクセストークンを明示的に追跡する。
 
-## Future work
+## 将来の作業
 
-- Move trust boundary to Unix socket (Option A) once Linux-only
-  upstream sidecars are the canonical deployment.
-- Add a `POST /internal/v1/token/refresh` that *forces* rotation
-  regardless of expiry (separate semantics from whoami).
-- Split the refresh leeway per code path / make it configurable —
-  long-running watch goroutines may want a tighter window than the
-  Phase A client request path. Today both reuse `Handler.githubRefreshLeeway()`.
-- Persistent encrypted subject index.
-- Per-upstream secret/identity (today: one shared secret for all upstreams).
-- Telemetry / metrics for delegated-access call rate vs rotation rate.
+- Linux 専用の upstream サイドカーが標準的なデプロイになったら Unix ソケット（オプション A）にトラスト境界を移動する。
+- 有効期限に関わらずローテーションを*強制する* `POST /internal/v1/token/refresh` を追加する（whoami とは別のセマンティクス）。
+- コードパスごとにリフレッシュリードウィンドウを分割 / 設定可能にする。長時間実行の watch goroutine は Phase A クライアントリクエストパスより厳しいウィンドウを必要とする場合がある。現在は両方とも `Handler.githubRefreshLeeway()` を再利用。
+- 暗号化された永続的な subject インデックス。
+- upstream ごとのシークレット/identity（現在: すべての upstream で 1 つの共有シークレット）。
+- 委任アクセス呼び出し率 vs ローテーション率のテレメトリー / メトリクス。
 
-## Open questions
+## 未解決の質問
 
-- Should the gateway emit a structured event (audit log) per internal
-  call? Probably yes for production; out of PoC scope.
-- Should `scopes` reflect the actual GitHub-granted scopes rather than
-  the configured request scopes? Requires storing scopes on the
-  `TokenRecord`, which is a separate change.
+- ゲートウェイは内部呼び出しごとに構造化イベント（監査ログ）を出力すべきか？本番環境ではおそらく yes。PoC のスコープ外。
+- `scopes` は設定されたリクエストスコープではなく実際の GitHub が付与したスコープを反映すべきか？`TokenRecord` にスコープを保存する必要があり、これは別の変更です。


### PR DESCRIPTION
## Summary

以下のファイルを全面日本語化しました:

- `docs/auth-error-contract.md`: 公開クライアントコントラクト・内部委任アクセスコントラクト・copilot-review-mcp マッピングコントラクト・オペレーターノートを翻訳（§2.4 はすでに日本語だったため維持）
- `docs/spike-72-delegated-background-access.md`: Phase B PoC 全体を翻訳

`docs/spike-18-copilot-api-auth.md` と `docs/spike-105-auth-issue-investigation.md` はすでに日本語のため対象外。

Part of #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)