### PR TITLE
[codex] add OIDC discovery metadata

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -45,6 +45,7 @@
 
 ### 修正
 
+- OIDC Discovery（`/.well-known/openid-configuration`）に PKCE、grant type、registration、device authorization の metadata を追加し、OIDC クライアントが対応フローを検出できるよう修正（[#122](https://github.com/scottlz0310/mcp-gateway/issues/122)）
 - exact-prefix リクエストで upstream のベースパスに末尾スラッシュを付与せず、そのまま転送するよう修正（[#111](https://github.com/scottlz0310/mcp-gateway/issues/111)）
 - upstream 転送時にルーティングプレフィックスをストリップする機能を追加（[#108](https://github.com/scottlz0310/mcp-gateway/issues/108)）
   - `github-mcp-server` や `playwright-mcp` などパスを厳格に検証する MCP サーバーで発生していた `405 Method Not Allowed` を解消するため、プロキシ転送前にルーティングプレフィックス（例: `/mcp/github`）をリクエストパスから除去するよう修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add PKCE, grant type, registration, and device authorization metadata to OIDC Discovery (`/.well-known/openid-configuration`) so OIDC clients can detect supported authorization flows ([#122](https://github.com/scottlz0310/mcp-gateway/issues/122)).
+
 ## [0.6.0] - 2026-06-17
 
 ### Added

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -893,12 +893,12 @@ func (h *Handler) DeviceAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	verificationURI := h.cfg.BaseURL + "/activate"
 	resp := map[string]any{
-		"device_code":              internalCode,
-		"user_code":                userCode,
-		"verification_uri":         verificationURI,
+		"device_code":               internalCode,
+		"user_code":                 userCode,
+		"verification_uri":          verificationURI,
 		"verification_uri_complete": verificationURI + "?user_code=" + userCode,
-		"expires_in":               int(deviceCodeTTL / time.Second),
-		"interval":                 5,
+		"expires_in":                int(deviceCodeTTL / time.Second),
+		"interval":                  5,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
@@ -1560,7 +1560,6 @@ func (h *Handler) validateAudience(token string, record TokenRecord, audience st
 	return audienceCheckError{ErrTokenAudienceMismatch}
 }
 
-
 func normalizeAudience(audience string) string {
 	return strings.TrimRight(strings.TrimSpace(audience), "/")
 }
@@ -1639,7 +1638,11 @@ func (h *Handler) OIDCDiscovery(w http.ResponseWriter, r *http.Request) {
 		"token_endpoint":                        h.cfg.BaseURL + "/token",
 		"userinfo_endpoint":                     h.cfg.BaseURL + "/userinfo",
 		"jwks_uri":                              h.cfg.BaseURL + "/jwks",
+		"registration_endpoint":                 h.cfg.BaseURL + "/register",
+		"device_authorization_endpoint":         h.cfg.BaseURL + "/device_authorization",
 		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
 		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": []string{"RS256"},
 		"scopes_supported":                      []string{"openid", "profile", "email"},

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1,4 +1,4 @@
-﻿package auth
+package auth
 
 import (
 	"context"
@@ -2334,6 +2334,16 @@ func TestOIDCProviderEndpoints(t *testing.T) {
 	if discDoc["jwks_uri"] != "http://localhost:8080/jwks" {
 		t.Errorf("jwks_uri: got %v", discDoc["jwks_uri"])
 	}
+	if discDoc["registration_endpoint"] != "http://localhost:8080/register" {
+		t.Errorf("registration_endpoint: got %v", discDoc["registration_endpoint"])
+	}
+	if discDoc["device_authorization_endpoint"] != "http://localhost:8080/device_authorization" {
+		t.Errorf("device_authorization_endpoint: got %v", discDoc["device_authorization_endpoint"])
+	}
+	assertJSONStringsContain(t, discDoc, "code_challenge_methods_supported", "S256")
+	assertJSONStringsContain(t, discDoc, "grant_types_supported", "authorization_code")
+	assertJSONStringsContain(t, discDoc, "grant_types_supported", "refresh_token")
+	assertJSONStringsContain(t, discDoc, "grant_types_supported", "urn:ietf:params:oauth:grant-type:device_code")
 
 	// 2. Test JWKS
 	rJWKS := httptest.NewRequest(http.MethodGet, "/jwks", nil)
@@ -2445,6 +2455,21 @@ func TestOIDCProviderEndpoints(t *testing.T) {
 	if err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed, sig); err != nil {
 		t.Errorf("signature verification failed: %v", err)
 	}
+}
+
+func assertJSONStringsContain(t *testing.T, doc map[string]any, key, want string) {
+	t.Helper()
+
+	values, ok := doc[key].([]any)
+	if !ok {
+		t.Fatalf("%s: got %T, want JSON string array", key, doc[key])
+	}
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("%s: got %v, want value %q", key, values, want)
 }
 
 func TestNewHandler_OIDCPrivateKey(t *testing.T) {
@@ -3098,12 +3123,12 @@ func TestBuiltinValidateTokenAudienceStrict(t *testing.T) {
 		},
 	}
 	h, err := NewHandler(Config{
-		BaseURL:              "http://localhost:8080",
-		SessionTTL:           10 * time.Minute,
-		CacheTTL:             5 * time.Minute,
-		ExpiresIn:            90 * 24 * time.Hour,
-		OIDCPrivateKey:       key,
-		TokenAudienceStrict:  true,
+		BaseURL:             "http://localhost:8080",
+		SessionTTL:          10 * time.Minute,
+		CacheTTL:            5 * time.Minute,
+		ExpiresIn:           90 * 24 * time.Hour,
+		OIDCPrivateKey:      key,
+		TokenAudienceStrict: true,
 	}, p)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)

--- a/tasks.md
+++ b/tasks.md
@@ -30,7 +30,7 @@
 
 | 優先 | Issue | 状態 | 依存 | 次のアクション |
 |---|---|---|---|---|
-| P0 | [#122](https://github.com/scottlz0310/mcp-gateway/issues/122) OIDC Discovery metadata 補完 | [ ] | なし | `/.well-known/openid-configuration` に PKCE / grant / registration / device metadata を追加 |
+| P0 | [#122](https://github.com/scottlz0310/mcp-gateway/issues/122) OIDC Discovery metadata 補完 | [x] | なし | `/.well-known/openid-configuration` に PKCE / grant / registration / device metadata を追加 |
 | P0 | [#123](https://github.com/scottlz0310/mcp-gateway/issues/123) OIDC `nonce` claim 対応 | [ ] | なし | `nonce` を authorize session から `id_token` まで伝播 |
 | P1 | [#125](https://github.com/scottlz0310/mcp-gateway/issues/125) RFC 8252 opaque-form redirect URI | [ ] | なし | custom scheme の `Opaque` 形式を許可し、HTTP(S) とは別に validation |
 | P1 | [#6](https://github.com/scottlz0310/mcp-gateway/issues/6) gateway OIDC Provider 完成 / agy 完走 | [ ] | `#122` / `#123` / `#125` 推奨先行、`#127` / `#128` / `#130` 完了済み | #126 前提の AC で agy / device flow / gateway-issued JWT を E2E 確認 |
@@ -51,10 +51,10 @@
 
 ### [#122](https://github.com/scottlz0310/mcp-gateway/issues/122) OIDC Discovery に `code_challenge_methods_supported` を追加
 
-- [ ] `OIDCDiscovery` に `code_challenge_methods_supported: ["S256"]` を追加
-- [ ] `grant_types_supported` に `authorization_code` / `refresh_token` / `urn:ietf:params:oauth:grant-type:device_code` を追加
-- [ ] `registration_endpoint` と `device_authorization_endpoint` を追加
-- [ ] `internal/auth/handler_test.go` に OIDC Discovery の regression test を追加
+- [x] `OIDCDiscovery` に `code_challenge_methods_supported: ["S256"]` を追加
+- [x] `grant_types_supported` に `authorization_code` / `refresh_token` / `urn:ietf:params:oauth:grant-type:device_code` を追加
+- [x] `registration_endpoint` と `device_authorization_endpoint` を追加
+- [x] `internal/auth/handler_test.go` に OIDC Discovery の regression test を追加
 
 ### [#123](https://github.com/scottlz0310/mcp-gateway/issues/123) OIDC Provider の `nonce` claim 対応
 


### PR DESCRIPTION
## Summary

- Add missing OIDC Discovery metadata for PKCE, supported grant types, dynamic registration, and device authorization.
- Extend the OIDC provider endpoint regression test to assert the discovery document exposes those fields.
- Mark #122 complete in `tasks.md` and document the change in both changelogs.

## Why

OIDC clients depend on `/.well-known/openid-configuration` to determine which authorization flows and PKCE methods are supported. The gateway already implements the related endpoints and flows, but the OIDC Discovery document did not advertise all of them.

## Impact

OIDC clients can now discover authorization code + PKCE, device authorization, refresh token support, and registration/device authorization endpoints from the standard discovery document.

## Validation

- `go test ./...`
- `go vet ./...`
- pre-push hook: test / build / lint

Closes #122
