### PR TITLE
feat(auth): OIDC nonce claim 対応（OIDC Core §3.1.3.7）

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -384,6 +384,7 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	codeChallenge := q.Get("code_challenge")
 	responseType := q.Get("response_type")
 	codeChallengeMethod := q.Get("code_challenge_method")
+	nonce := q.Get("nonce")
 	audience, audErr := h.resolveRequestedAudience(q["resource"])
 	if audErr != nil {
 		h.auditFailure("authorize", "invalid_target", "authorization target rejected", audErr, http.StatusBadRequest, "")
@@ -429,7 +430,7 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h.store.SaveSession(state, redirectURI, codeChallenge, audience)
+	h.store.SaveSession(state, redirectURI, codeChallenge, audience, nonce)
 	h.auditSuccess("authorize", "authorization redirect created", http.StatusFound)
 
 	http.Redirect(w, r, h.provider.AuthorizeURL(state, codeChallenge), http.StatusFound)
@@ -592,7 +593,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
-		h.writeTokenResponse(w, gatewayToken, result.Scope, refreshToken, result.Subject)
+		h.writeTokenResponse(w, gatewayToken, result.Scope, refreshToken, result.Subject, result.Nonce)
 		h.auditSuccess("token_exchange", "authorization code exchange completed (builtin)", http.StatusOK)
 		return
 	}
@@ -608,7 +609,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 	if rtErr != nil {
 		slog.Warn("failed to create refresh token", "err", rtErr)
 	}
-	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject)
+	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject, result.Nonce)
 	h.auditSuccess("token_exchange", "authorization code exchange completed", http.StatusOK)
 }
 
@@ -680,7 +681,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token (device)", "err", rtErr)
 		}
-		h.writeTokenResponse(w, token, completed.Scope, refreshToken, completed.Subject)
+		h.writeTokenResponse(w, token, completed.Scope, refreshToken, completed.Subject, "")
 		h.auditSuccess("token_exchange", "device token exchange completed", http.StatusOK)
 	default: // devicePending
 		// Enforce minimum polling interval (RFC 8628 §3.5).
@@ -698,7 +699,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refreshToken string, subject string) {
+func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refreshToken, subject, nonce string) {
 	expiresIn := max(int64(h.cfg.ExpiresIn/time.Second), 1)
 	resp := map[string]any{
 		"access_token": token,
@@ -712,7 +713,7 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token, scope, refres
 		resp["refresh_token"] = refreshToken
 	}
 	if subject != "" && (strings.Contains(scope, "openid") || h.provider.Name() == "oidc" || h.isBuiltinMode()) {
-		idToken, err := h.generateIDToken(h.cfg.BaseURL, subject, h.provider.ClientID())
+		idToken, err := h.generateIDToken(h.cfg.BaseURL, subject, h.provider.ClientID(), nonce)
 		if err == nil {
 			resp["id_token"] = idToken
 		} else {
@@ -811,7 +812,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 			return
 		}
-		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub)
+		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub, "")
 		h.auditSuccess("refresh", "refresh token exchange completed (builtin)", http.StatusOK)
 		return
 	}
@@ -851,7 +852,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject)
+	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject, "")
 	h.auditSuccess("refresh", "refresh token exchange completed", http.StatusOK)
 }
 
@@ -956,7 +957,7 @@ func (h *Handler) ActivateSubmit(w http.ResponseWriter, r *http.Request) {
 
 	state := generateDeviceState(sess.InternalCode)
 	deviceCallbackURI := h.cfg.BaseURL + "/device_callback"
-	h.store.SaveSession(state, deviceCallbackURI, "", sess.Audience)
+	h.store.SaveSession(state, deviceCallbackURI, "", sess.Audience, "")
 
 	authorizeURL := h.cfg.BaseURL + "/authorize?response_type=code" +
 		"&client_id=" + url.QueryEscape(h.provider.ClientID()) +
@@ -1838,7 +1839,7 @@ func (h *Handler) verifyGatewayJWT(token string) (subject, audience string, err 
 }
 
 // generateIDToken creates a signed RS256 JWT for the given subject.
-func (h *Handler) generateIDToken(issuer, subject, clientID string) (string, error) {
+func (h *Handler) generateIDToken(issuer, subject, clientID, nonce string) (string, error) {
 	if h.privateKey == nil {
 		return "", fmt.Errorf("private key is nil")
 	}
@@ -1863,6 +1864,9 @@ func (h *Handler) generateIDToken(issuer, subject, clientID string) (string, err
 		"aud": clientID,
 		"iat": now,
 		"exp": now + 3600, // 1 hour
+	}
+	if nonce != "" {
+		payload["nonce"] = nonce
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2396,7 +2396,7 @@ func TestOIDCProviderEndpoints(t *testing.T) {
 	}
 
 	// 5. Test ID Token generation during code exchange
-	h.store.SaveSession("state-oidc", "http://localhost/cb", "", "http://localhost:8080")
+	h.store.SaveSession("state-oidc", "http://localhost/cb", "", "http://localhost:8080", "")
 	code, err := h.store.CompleteCallback("state-oidc", "provider-tok", "openid", "", time.Time{}, "alice")
 	if err != nil {
 		t.Fatalf("CompleteCallback: %v", err)
@@ -2454,6 +2454,72 @@ func TestOIDCProviderEndpoints(t *testing.T) {
 	pubKey := h.privateKey.Public().(*rsa.PublicKey)
 	if err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed, sig); err != nil {
 		t.Errorf("signature verification failed: %v", err)
+	}
+}
+
+func TestIDTokenNonceClaim(t *testing.T) {
+	tests := []struct {
+		name          string
+		nonce         string
+		expectInToken bool
+	}{
+		{"nonce present", "test-nonce-value-abc123", true},
+		{"nonce absent", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			h.store.SaveSession("state-nonce", "http://localhost/cb", "", "http://localhost:8080", tc.nonce)
+			code, err := h.store.CompleteCallback("state-nonce", "provider-tok", "openid", "", time.Time{}, "alice")
+			if err != nil {
+				t.Fatalf("CompleteCallback: %v", err)
+			}
+
+			body := fmt.Sprintf("grant_type=authorization_code&code=%s&redirect_uri=http://localhost/cb", code)
+			r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			h.Token(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("token exchange: got status %d; body: %s", w.Code, w.Body.String())
+			}
+
+			var tokenResp map[string]any
+			if err := json.NewDecoder(w.Body).Decode(&tokenResp); err != nil {
+				t.Fatalf("decoding token response: %v", err)
+			}
+			idToken, ok := tokenResp["id_token"].(string)
+			if !ok || idToken == "" {
+				t.Fatal("expected id_token in response")
+			}
+
+			parts := strings.Split(idToken, ".")
+			if len(parts) != 3 {
+				t.Fatalf("invalid JWT format: got %d parts", len(parts))
+			}
+			payloadDecoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+			if err != nil {
+				t.Fatalf("decoding payload: %v", err)
+			}
+			var claims map[string]any
+			if err := json.Unmarshal(payloadDecoded, &claims); err != nil {
+				t.Fatalf("unmarshaling payload: %v", err)
+			}
+
+			nonceClaim, hasClaim := claims["nonce"]
+			if tc.expectInToken {
+				if !hasClaim {
+					t.Error("expected nonce claim in id_token, but not found")
+				} else if nonceClaim != tc.nonce {
+					t.Errorf("nonce claim: got %v, want %v", nonceClaim, tc.nonce)
+				}
+			} else {
+				if hasClaim {
+					t.Errorf("expected no nonce claim in id_token, but got %v", nonceClaim)
+				}
+			}
+		})
 	}
 }
 
@@ -3363,7 +3429,7 @@ func TestDeviceCallbackBadStateFormat(t *testing.T) {
 	h := newTestHandler(t)
 
 	// A state that passes HasSession but has no "device:" prefix.
-	h.store.SaveSession("plain-state-no-prefix", "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession("plain-state-no-prefix", "http://localhost:8080/device_callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/device_callback?code=abc&state=plain-state-no-prefix", nil)
 	w := httptest.NewRecorder()
@@ -3397,7 +3463,7 @@ func TestDeviceCallbackExchangeCodeError(t *testing.T) {
 	expiresAt := time.Now().Add(15 * time.Minute)
 	internalCode, _ := h.store.CreateDevice("XCBG-1234", expiresAt, "mcp")
 	state := generateDeviceState(internalCode)
-	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/device_callback?code=abc&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
@@ -3431,7 +3497,7 @@ func TestDeviceCallbackValidateTokenError(t *testing.T) {
 	expiresAt := time.Now().Add(15 * time.Minute)
 	internalCode, _ := h.store.CreateDevice("XCBG-5678", expiresAt, "mcp")
 	state := generateDeviceState(internalCode)
-	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/device_callback?code=abc&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
@@ -3475,7 +3541,7 @@ func TestCallbackDeviceFlowFallback(t *testing.T) {
 		t.Fatalf("CreateDevice: %v", err)
 	}
 	state := generateDeviceState(deviceCode)
-	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp", "")
 
 	// Simulate GitHub redirecting to /callback with a device state (not /device_callback).
 	r := httptest.NewRequest(http.MethodGet, "/callback?code=github-code-abc&state="+url.QueryEscape(state), nil)
@@ -3530,7 +3596,7 @@ func TestCallbackDeviceStateNoMatchFallsToNormalFlow(t *testing.T) {
 
 	// State looks like a device state but has no matching device session in the store.
 	state := "device:no-such-device-code"
-	h.store.SaveSession(state, "http://localhost:8080/callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
@@ -3579,7 +3645,7 @@ func TestCallbackDeviceFlowFallbackPersistsProviderRefresh(t *testing.T) {
 		t.Fatalf("CreateDevice: %v", err)
 	}
 	state := generateDeviceState(deviceCode)
-	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()
@@ -3676,7 +3742,7 @@ func TestDeviceCallbackApproveDeviceFails(t *testing.T) {
 
 	// State encodes a device internalCode that does not exist in the store.
 	state := generateDeviceState("nonexistent-device-code")
-	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp")
+	h.store.SaveSession(state, "http://localhost:8080/device_callback", "", "mcp", "")
 
 	r := httptest.NewRequest(http.MethodGet, "/device_callback?code=abc&state="+url.QueryEscape(state), nil)
 	w := httptest.NewRecorder()

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -25,6 +25,7 @@ type Session struct {
 	RedirectURI           string
 	CodeChallenge         string
 	Audience              string
+	Nonce                 string    // OIDC Core §3.1.3.7: forwarded to id_token if provided
 	InternalCode          string
 	AccessToken           string
 	Scope                 string
@@ -152,7 +153,7 @@ func (s *Store) Stop() {
 }
 
 // SaveSession stores a new OAuth session keyed by state.
-func (s *Store) SaveSession(state, redirectURI, codeChallenge, audience string) {
+func (s *Store) SaveSession(state, redirectURI, codeChallenge, audience, nonce string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions[state] = &Session{
@@ -160,6 +161,7 @@ func (s *Store) SaveSession(state, redirectURI, codeChallenge, audience string) 
 		RedirectURI:   redirectURI,
 		CodeChallenge: codeChallenge,
 		Audience:      audience,
+		Nonce:         nonce,
 		ExpiresAt:     time.Now().Add(s.ttl),
 	}
 }
@@ -214,6 +216,7 @@ type ExchangeCodeResult struct {
 	AccessToken          string
 	Scope                string
 	Audience             string
+	Nonce                string    // OIDC Core §3.1.3.7: forwarded to id_token if provided
 	ProviderRefreshToken string
 	ProviderAccessExpiry time.Time
 	Subject              string    // resolved subject
@@ -244,6 +247,7 @@ func (s *Store) ExchangeCode(code, redirectURI, codeVerifier string) (ExchangeCo
 		AccessToken:          sess.AccessToken,
 		Scope:                sess.Scope,
 		Audience:             sess.Audience,
+		Nonce:                sess.Nonce,
 		ProviderRefreshToken: sess.ProviderRefreshToken,
 		ProviderAccessExpiry: sess.ProviderAccessExpiry,
 		Subject:              sess.Subject,

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -10,7 +10,7 @@ import (
 func TestStoreSessionLifecycle(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
 
-	s.SaveSession("state1", "http://localhost/cb", "", "https://gw.example/mcp")
+	s.SaveSession("state1", "http://localhost/cb", "", "https://gw.example/mcp", "")
 	if !s.HasSession("state1") {
 		t.Fatal("expected session to exist")
 	}
@@ -21,7 +21,7 @@ func TestStoreSessionLifecycle(t *testing.T) {
 
 func TestStoreCompleteCallback(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state2", "http://localhost/cb", "", "https://gw.example/mcp")
+	s.SaveSession("state2", "http://localhost/cb", "", "https://gw.example/mcp", "")
 
 	code, err := s.CompleteCallback("state2", "token123", "repo,user", "", time.Time{}, "user123")
 	if err != nil {
@@ -64,7 +64,7 @@ func TestStoreCompleteCallbackUnknownState(t *testing.T) {
 
 func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state3", "http://localhost/cb", "", "https://gw.example/mcp")
+	s.SaveSession("state3", "http://localhost/cb", "", "https://gw.example/mcp", "")
 
 	code, _ := s.CompleteCallback("state3", "tok", "", "", time.Time{}, "user123")
 	result, err := s.ExchangeCode(code, "http://localhost/cb", "")
@@ -88,7 +88,7 @@ func TestStoreExchangeCodeOneTimeUse(t *testing.T) {
 
 func TestStoreExchangeCodeRedirectURIMismatch(t *testing.T) {
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state4", "http://localhost/cb", "", "https://gw.example/mcp")
+	s.SaveSession("state4", "http://localhost/cb", "", "https://gw.example/mcp", "")
 
 	code, _ := s.CompleteCallback("state4", "tok", "", "", time.Time{}, "user123")
 	if _, err := s.ExchangeCode(code, "http://localhost/other", ""); err == nil {
@@ -102,7 +102,7 @@ func TestStorePKCE(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state5", "http://localhost/cb", challenge, "https://gw.example/mcp")
+	s.SaveSession("state5", "http://localhost/cb", challenge, "https://gw.example/mcp", "")
 	code, _ := s.CompleteCallback("state5", "tok", "", "", time.Time{}, "user123")
 
 	// Wrong verifier: code is NOT consumed on PKCE failure so we can retry.
@@ -121,7 +121,7 @@ func TestStorePKCEInvalidVerifierLength(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 	s := NewStore(10*time.Minute, 5*time.Minute, NewMemTokenStore())
-	s.SaveSession("state6", "http://localhost/cb", challenge, "https://gw.example/mcp")
+	s.SaveSession("state6", "http://localhost/cb", challenge, "https://gw.example/mcp", "")
 	code, _ := s.CompleteCallback("state6", "tok", "", "", time.Time{}, "user123")
 
 	if _, err := s.ExchangeCode(code, "http://localhost/cb", "tooshort"); err == nil {


### PR DESCRIPTION
## Summary

- `Session.Nonce` フィールドを追加し、`SaveSession` のシグネチャに `nonce string` を追加
- `/authorize` エンドポイントで `nonce` パラメータを読み取り、セッションに保存
- `ExchangeCodeResult` に `Nonce` フィールドを追加し、コード交換時に伝播
- `tokenAuthCode` → `writeTokenResponse` → `generateIDToken` の呼び出し連鎖に nonce を伝播
- `generateIDToken` で `nonce != ""` の場合にのみ `id_token` payload へ追加（OIDC Core §3.1.3.7 準拠）
- device flow / refresh flow は nonce なし（`""`）で呼び出し（OIDC 仕様通り）

## Test plan

- [x] `TestIDTokenNonceClaim` 追加：nonce あり/なし の両ケースでトークン payload を検証
- [x] 既存テスト全件 PASS（pre-push フック）
- [x] lint 0 issues

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)