### PR TITLE
feat(auth): RFC 8252 §7.1 opaque-form カスタムスキーム URI のサポート

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -409,20 +409,30 @@ func (h *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsedRedirect, err := url.Parse(redirectURI)
-	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Host == "" || parsedRedirect.Fragment != "" {
+	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Fragment != "" {
 		h.auditFailure("authorize", "invalid_request", "authorization redirect URI rejected", err, http.StatusBadRequest, "")
 		oauthError(w, "invalid_request", "invalid redirect_uri: must be an absolute URI without fragment", http.StatusBadRequest)
 		return
 	}
 	switch parsedRedirect.Scheme {
 	case "http", "https":
+		if parsedRedirect.Host == "" {
+			h.auditFailure("authorize", "invalid_request", "authorization redirect URI rejected", nil, http.StatusBadRequest, "")
+			oauthError(w, "invalid_request", "invalid redirect_uri: must be an absolute URI without fragment", http.StatusBadRequest)
+			return
+		}
 		if !isAllowedRedirectHost(parsedRedirect.Hostname(), h.cfg.AllowedRedirectHosts) {
 			h.auditFailure("authorize", "invalid_request", "authorization redirect host rejected", nil, http.StatusBadRequest, "")
 			oauthError(w, "invalid_request", "redirect_uri host not permitted", http.StatusBadRequest)
 			return
 		}
 	default:
-		// RFC 8252: custom URL scheme for native apps (e.g. antigravity://oauth-callback)
+		// RFC 8252 §7.1: custom scheme — authority (host != ""), path-only (/path), or opaque form
+		if parsedRedirect.Host == "" && parsedRedirect.Path == "" && parsedRedirect.Opaque == "" {
+			h.auditFailure("authorize", "invalid_request", "authorization redirect URI rejected", nil, http.StatusBadRequest, "")
+			oauthError(w, "invalid_request", "invalid redirect_uri: must be an absolute URI without fragment", http.StatusBadRequest)
+			return
+		}
 		if !isAllowedRedirectScheme(parsedRedirect.Scheme, h.cfg.AllowedRedirectSchemes) {
 			h.auditFailure("authorize", "invalid_request", "authorization redirect scheme rejected", nil, http.StatusBadRequest, "")
 			oauthError(w, "invalid_request", "redirect_uri scheme not permitted", http.StatusBadRequest)

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2635,6 +2635,29 @@ func TestAuthorizeCustomSchemeRedirectURI(t *testing.T) {
 			schemes:     []string{"com.example.app"},
 			wantStatus:  http.StatusFound,
 		},
+		// true opaque form (scheme:opaque, no leading slash — exercises the Opaque branch)
+		{
+			name:        "true opaque form accepted when scheme is allowed",
+			redirectURI: "antigravity:callback",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "true opaque form rejected when scheme not allowed",
+			redirectURI: "myapp:callback",
+			wantStatus:  http.StatusBadRequest,
+		},
+		// scheme-only URI (host == "" && path == "" && opaque == "") must be rejected
+		{
+			name:        "custom scheme URI with no path or opaque rejected",
+			redirectURI: "antigravity:",
+			wantStatus:  http.StatusBadRequest,
+		},
+		// http/https without host must be rejected
+		{
+			name:        "http scheme without host rejected",
+			redirectURI: "http:/no-authority-path",
+			wantStatus:  http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2619,6 +2619,22 @@ func TestAuthorizeCustomSchemeRedirectURI(t *testing.T) {
 			schemes:     []string{"other"},
 			wantStatus:  http.StatusBadRequest,
 		},
+		{
+			name:        "opaque-form custom scheme accepted when scheme is allowed",
+			redirectURI: "antigravity:/oauth2redirect/provider",
+			wantStatus:  http.StatusFound,
+		},
+		{
+			name:        "opaque-form custom scheme rejected when scheme not allowed",
+			redirectURI: "myapp:/oauth2redirect/provider",
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "opaque-form custom scheme accepted when scheme explicitly configured",
+			redirectURI: "com.example.app:/oauth2redirect/provider",
+			schemes:     []string{"com.example.app"},
+			wantStatus:  http.StatusFound,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Go の `url.Parse("com.example.app:/oauth2redirect/provider")` は `Host=""` / `Path="/oauth2redirect/provider"` を返すため、旧来の `Host == ""` 一律チェックが opaque-form URI を誤拒否していた
- 初期バリデーションから `Host == ""` の一律チェックを除去
- `http`/`https`: switch 内で明示的に `Host != ""` を要求（挙動変更なし）
- `default`（カスタムスキーム）: `Host == "" && Path == "" && Opaque == ""` の場合のみ拒否し、authority 形式（`://`）/ path-only 形式（`:/path`）/ opaque 形式の3形式すべてを許容

## Test plan

- [x] `TestAuthorizeCustomSchemeRedirectURI` に opaque-form 3ケース追加（許可スキーム・未許可スキーム・明示設定）
- [x] 既存テスト全件 PASS（pre-push フック: build / test / lint）

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)