### PR TITLE
fix(auth): builtin モードのコールバック時 identity resolution 502 を修正

### DIFF
--- a/internal/auth/provider/builtin.go
+++ b/internal/auth/provider/builtin.go
@@ -2,13 +2,7 @@ package provider
 
 import (
 	"context"
-	"errors"
 )
-
-// ErrBuiltinValidateNotSupported is returned when ValidateToken is called on the
-// builtin provider. In builtin mode, gateway-issued JWTs are validated directly
-// by the handler (which holds the RSA signing key), not via the upstream provider.
-var ErrBuiltinValidateNotSupported = errors.New("builtin provider: ValidateToken must be handled by the gateway JWT verifier")
 
 // builtinProvider wraps the GitHub OAuth flow so that the gateway can use
 // GitHub as a social login source while issuing its own RS256 JWTs as
@@ -51,8 +45,12 @@ func (p *builtinProvider) RefreshToken(_ context.Context, _ string) (TokenRespon
 	return TokenResponse{}, ErrRefreshNotSupported
 }
 
-// ValidateToken must not be called in builtin mode. The handler validates
-// gateway-issued JWTs directly using its RSA private key.
-func (p *builtinProvider) ValidateToken(_ context.Context, _ string) (Identity, error) {
-	return Identity{}, ErrBuiltinValidateNotSupported
+// ValidateToken resolves the caller's identity from the GitHub API using the
+// GitHub access token obtained via ExchangeCode. This is called during the
+// OAuth callback and device callback flows to populate the Subject claim.
+//
+// Note: in builtin mode, handler.ValidateToken (proxy-auth path) bypasses this
+// method and validates gateway-issued JWTs directly via verifyGatewayJWT.
+func (p *builtinProvider) ValidateToken(ctx context.Context, token string) (Identity, error) {
+	return p.github.ValidateToken(ctx, token)
 }

--- a/internal/auth/provider/builtin_test.go
+++ b/internal/auth/provider/builtin_test.go
@@ -92,6 +92,16 @@ func TestBuiltinRefreshTokenNotSupported(t *testing.T) {
 
 func TestBuiltinValidateTokenDelegatesToGitHub(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-access-token" {
+			t.Errorf("Authorization: got %q, want %q", got, "Bearer gh-access-token")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"login":"testuser","id":42,"email":"test@example.com","name":"Test User"}`))
 	}))
@@ -101,8 +111,8 @@ func TestBuiltinValidateTokenDelegatesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateToken: %v", err)
 	}
-	if id.Subject == "" {
-		t.Error("ValidateToken: expected non-empty Subject")
+	if id.Subject != "testuser" {
+		t.Errorf("ValidateToken: Subject = %q, want %q", id.Subject, "testuser")
 	}
 }
 

--- a/internal/auth/provider/builtin_test.go
+++ b/internal/auth/provider/builtin_test.go
@@ -90,13 +90,19 @@ func TestBuiltinRefreshTokenNotSupported(t *testing.T) {
 	}
 }
 
-func TestBuiltinValidateTokenNotSupported(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+func TestBuiltinValidateTokenDelegatesToGitHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"login":"testuser","id":42,"email":"test@example.com","name":"Test User"}`))
+	}))
 	defer srv.Close()
 	p := newBuiltinFromServer(t, srv)
-	_, err := p.ValidateToken(context.Background(), "some-token")
-	if !errors.Is(err, ErrBuiltinValidateNotSupported) {
-		t.Errorf("ValidateToken: expected ErrBuiltinValidateNotSupported, got %v", err)
+	id, err := p.ValidateToken(context.Background(), "gh-access-token")
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if id.Subject == "" {
+		t.Error("ValidateToken: expected non-empty Subject")
 	}
 }
 


### PR DESCRIPTION
## 概要

`OAUTH_PROVIDER=builtin` モードで `/callback`・`/device_callback` エンドポイントが `provider.ValidateToken` を直接呼び出す際、`builtinProvider.ValidateToken` が `ErrBuiltinValidateNotSupported` を返すため identity resolution が 502 で失敗していた。

ISSUE #6 のライブ検証中に発見したバグ。

## 原因

`Callback` ハンドラー（`handler.go:490`）と `DeviceCallback` ハンドラー（`handler.go:1007`）は builtin モード判定なしに `h.provider.ValidateToken(tokens.AccessToken)` を呼び出す。

コールバックフローにおける `tokens.AccessToken` は GitHub access token であり、ユーザー identity（Subject）の解決に GitHub API（`GET /user`）が必要。しかし `builtinProvider.ValidateToken` は常にエラーを返していた。

なお `handler.ValidateToken`（プロキシ認証パス）はすでに `isBuiltinMode()` チェックで gateway JWT を直接検証する分岐を持つため、この修正の影響を受けない。

## 修正内容

`builtinProvider.ValidateToken` を削除していたエラー返却から GitHub プロバイダーへの委譲に変更。

```go
// Before
func (p *builtinProvider) ValidateToken(_ context.Context, _ string) (Identity, error) {
    return Identity{}, ErrBuiltinValidateNotSupported
}

// After
func (p *builtinProvider) ValidateToken(ctx context.Context, token string) (Identity, error) {
    return p.github.ValidateToken(ctx, token)
}
```

## ライブ検証結果（ISSUE #6）

Device Authorization Grant flow（builtin モード）で以下を確認：

| 検証項目 | 結果 |
|---------|------|
| POST /device_authorization → device_code, user_code | ✅ |
| /activate → GitHub 認証 → デバイス承認 | ✅ |
| POST /token → access_token, id_token, refresh_token 取得 | ✅ |
| access_token が gateway 自身の RS256 JWT | ✅ (`iss=http://127.0.0.1:8090`) |
| GitHub access_token がクライアントに渡らない | ✅ |
| id_token に iss / sub / aud / exp / iat | ✅ |
| id_token alg=RS256, kid=gateway-key-1 | ✅ |
| /userinfo に sub, name, preferred_username | ✅ |
| refresh_token ローテーション（新 access_token + id_token 発行） | ✅ |

## テスト

- `TestBuiltinValidateTokenDelegatesToGitHub`：ValidateToken が GitHub API 経由で identity を解決することを確認（従来の `TestBuiltinValidateTokenNotSupported` を置き換え）

🤖 Generated with [Claude Code](https://claude.com/claude-code)