### PR TITLE
feat(router): upstream OAuth ルートオプションのパースとバリデーション

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
   - `Route` struct gains `UpstreamOAuth` ("auto" or absolute issuer URL) and `UpstreamOAuthScope` (space-separated scopes) fields
   - `ROUTE_*` env-var parser accepts `upstream_oauth=auto|<issuer-url>` and `upstream_oauth_scope=<scopes>`
   - `config.yaml` `RouteConfig` gains `upstream_oauth` and `upstream_oauth_scope` fields parsed by `ParseFromConfig`
-  - Validation: empty value, non-http/https scheme, and invalid URL rejected (fail-closed); issuer URL trailing slash is trimmed; comma-separated scopes normalised to space-separated; `upstream_oauth` + `upstream_bearer_token_env` combination rejected
+  - Validation: empty value (`""`), non-http/https scheme, and invalid URL rejected (fail-closed); issuer URL trailing slash is trimmed; comma-separated scopes normalised to space-separated; `upstream_oauth` + `upstream_bearer_token_env` combination rejected; `upstream_oauth_scope` without `upstream_oauth` rejected
+  - YAML `null` and blank (`upstream_oauth:` with no value) both decode to `nil` via `yaml.v3`, which is treated as absent (disabled) — identical to omitting the field. Only an explicit quoted empty string (`upstream_oauth: ""`) triggers the fail-closed rejection.
   - No runtime behaviour changes; discovery/DCR/token injection handled in subsequent issues
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Upstream OAuth route option parsing and validation ([#113](https://github.com/scottlz0310/mcp-gateway/issues/113))
+  - `Route` struct gains `UpstreamOAuth` ("auto" or absolute issuer URL) and `UpstreamOAuthScope` (space-separated scopes) fields
+  - `ROUTE_*` env-var parser accepts `upstream_oauth=auto|<issuer-url>` and `upstream_oauth_scope=<scopes>`
+  - `config.yaml` `RouteConfig` gains `upstream_oauth` and `upstream_oauth_scope` fields parsed by `ParseFromConfig`
+  - Validation: empty value, non-http/https scheme, and invalid URL rejected (fail-closed); issuer URL trailing slash is trimmed; comma-separated scopes normalised to space-separated; `upstream_oauth` + `upstream_bearer_token_env` combination rejected
+  - No runtime behaviour changes; discovery/DCR/token injection handled in subsequent issues
+
 ### Fixed
 
 - Add PKCE, grant type, registration, and device authorization metadata to OIDC Discovery (`/.well-known/openid-configuration`) so OIDC clients can detect supported authorization flows ([#122](https://github.com/scottlz0310/mcp-gateway/issues/122)).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,14 @@ type RouteConfig struct {
 	// empty. Clients obtain a token with this audience by passing resource=<route-name>
 	// to the /token endpoint.
 	RequiredAudience string `yaml:"required_audience,omitempty" json:"required_audience,omitempty"`
+	// UpstreamOAuth enables upstream OAuth delegation. Value is "auto" or an
+	// absolute issuer URL (http/https). Discovery and token exchange are handled by
+	// subsequent issues; this field is parsed and validated only at startup.
+	UpstreamOAuth string `yaml:"upstream_oauth,omitempty"       json:"upstream_oauth,omitempty"`
+	// UpstreamOAuthScope is the space-separated OAuth scope string requested from
+	// the upstream authorization server. Comma-separated values are normalised to
+	// space-separated internally.
+	UpstreamOAuthScope string `yaml:"upstream_oauth_scope,omitempty" json:"upstream_oauth_scope,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,11 +31,14 @@ type RouteConfig struct {
 	// UpstreamOAuth enables upstream OAuth delegation. Value is "auto" or an
 	// absolute issuer URL (http/https). Discovery and token exchange are handled by
 	// subsequent issues; this field is parsed and validated only at startup.
-	UpstreamOAuth string `yaml:"upstream_oauth,omitempty"       json:"upstream_oauth,omitempty"`
+	// Use *string so that an explicit empty value ("") is distinguishable from
+	// the field being absent (nil), enabling fail-closed validation for empty strings.
+	UpstreamOAuth *string `yaml:"upstream_oauth,omitempty"       json:"upstream_oauth,omitempty"`
 	// UpstreamOAuthScope is the space-separated OAuth scope string requested from
 	// the upstream authorization server. Comma-separated values are normalised to
 	// space-separated internally.
-	UpstreamOAuthScope string `yaml:"upstream_oauth_scope,omitempty" json:"upstream_oauth_scope,omitempty"`
+	// Use *string for the same presence-vs-empty reason as UpstreamOAuth.
+	UpstreamOAuthScope *string `yaml:"upstream_oauth_scope,omitempty" json:"upstream_oauth_scope,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestMigrateSecret_EncryptedValue decrypts an ENC[age:] value from config.
@@ -343,6 +345,40 @@ func TestMigrateOIDCPrivateKey(t *testing.T) {
 	// Keys should be identical (same N and D for RSA key)
 	if privKey1.N.Cmp(privKey2.N) != 0 || privKey1.D.Cmp(privKey2.D) != 0 {
 		t.Error("expected loaded private key to match generated private key")
+	}
+}
+
+// TestRouteConfig_UpstreamOAuthNullAndBlankDecodedAsNil documents that yaml.v3
+// decodes both `null` and a blank value (key present with no value) to nil for
+// *string fields. nil is indistinguishable from a missing field — ParseFromConfig
+// treats it as "absent" (upstream OAuth disabled), with no validation error.
+// Only an explicit quoted empty string (`upstream_oauth: ""`) yields ptr("") and
+// is rejected as a fail-closed violation.
+func TestRouteConfig_UpstreamOAuthNullAndBlankDecodedAsNil(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		checkOAuth bool
+		checkScope bool
+	}{
+		{"oauth_null", "name: r\nprefix: /mcp\nupstream: https://up.example.com/mcp\nupstream_oauth: null\n", true, false},
+		{"oauth_blank", "name: r\nprefix: /mcp\nupstream: https://up.example.com/mcp\nupstream_oauth:\n", true, false},
+		{"scope_null", "name: r\nprefix: /mcp\nupstream: https://up.example.com/mcp\nupstream_oauth_scope: null\n", false, true},
+		{"scope_blank", "name: r\nprefix: /mcp\nupstream: https://up.example.com/mcp\nupstream_oauth_scope:\n", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var r RouteConfig
+			if err := yaml.Unmarshal([]byte(tc.input), &r); err != nil {
+				t.Fatalf("yaml.Unmarshal: %v", err)
+			}
+			if tc.checkOAuth && r.UpstreamOAuth != nil {
+				t.Errorf("UpstreamOAuth: expected nil (blank/null decodes to nil), got ptr(%q)", *r.UpstreamOAuth)
+			}
+			if tc.checkScope && r.UpstreamOAuthScope != nil {
+				t.Errorf("UpstreamOAuthScope: expected nil (blank/null decodes to nil), got ptr(%q)", *r.UpstreamOAuthScope)
+			}
+		})
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -159,8 +159,12 @@ func parseRoutes(env []string) ([]Route, error) {
 
 		// upstream_oauth_scope: space-separated OAuth scope string.
 		// Comma-separated values are normalised to space-separated.
+		// upstream_oauth must be set when upstream_oauth_scope is specified.
 		var upstreamOAuthScope string
 		if scopeVal, ok := options["upstream_oauth_scope"]; ok {
+			if upstreamOAuth == "" {
+				return nil, fmt.Errorf("%s: upstream_oauth_scope requires upstream_oauth to be set", key)
+			}
 			scopeVal = strings.TrimSpace(scopeVal)
 			if scopeVal == "" {
 				return nil, fmt.Errorf("%s: upstream_oauth_scope value must not be empty or whitespace-only", key)
@@ -306,8 +310,12 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			}
 		}
 		// upstream_oauth_scope: normalise comma-separated to space-separated.
+		// upstream_oauth must be set when upstream_oauth_scope is specified.
 		upstreamOAuthScope := strings.TrimSpace(r.UpstreamOAuthScope)
 		if r.UpstreamOAuthScope != "" {
+			if upstreamOAuth == "" {
+				return nil, fmt.Errorf("route %q: upstream_oauth_scope requires upstream_oauth to be set", name)
+			}
 			if upstreamOAuthScope == "" {
 				return nil, fmt.Errorf("route %q: upstream_oauth_scope value must not be empty or whitespace-only", name)
 			}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -290,8 +290,11 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			requiredAudience = DefaultRequiredAudience
 		}
 		// upstream_oauth: same validation as parseRoutes.
-		upstreamOAuth := strings.TrimSpace(r.UpstreamOAuth)
-		if r.UpstreamOAuth != "" {
+		// RouteConfig.UpstreamOAuth is *string so that explicit empty values are
+		// distinguishable from absent fields (nil = absent, ptr("") = empty → error).
+		var upstreamOAuth string
+		if r.UpstreamOAuth != nil {
+			upstreamOAuth = strings.TrimSpace(*r.UpstreamOAuth)
 			if upstreamOAuth == "" {
 				return nil, fmt.Errorf("route %q: upstream_oauth value must not be empty", name)
 			}
@@ -311,11 +314,13 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 		}
 		// upstream_oauth_scope: normalise comma-separated to space-separated.
 		// upstream_oauth must be set when upstream_oauth_scope is specified.
-		upstreamOAuthScope := strings.TrimSpace(r.UpstreamOAuthScope)
-		if r.UpstreamOAuthScope != "" {
+		// RouteConfig.UpstreamOAuthScope is *string for the same presence-vs-empty reason.
+		var upstreamOAuthScope string
+		if r.UpstreamOAuthScope != nil {
 			if upstreamOAuth == "" {
 				return nil, fmt.Errorf("route %q: upstream_oauth_scope requires upstream_oauth to be set", name)
 			}
+			upstreamOAuthScope = strings.TrimSpace(*r.UpstreamOAuthScope)
 			if upstreamOAuthScope == "" {
 				return nil, fmt.Errorf("route %q: upstream_oauth_scope value must not be empty or whitespace-only", name)
 			}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -35,6 +35,13 @@ type Route struct {
 	// access this route. Clients request a token with this audience by passing
 	// resource=<route-name> to the /token endpoint. Defaults to "mcp-gateway".
 	RequiredAudience string
+	// UpstreamOAuth is "auto" or an absolute issuer URL (http/https) for upstream
+	// OAuth delegation. Empty means disabled. Discovery and token exchange are
+	// handled by subsequent issues; this field is parsed and validated only.
+	UpstreamOAuth string
+	// UpstreamOAuthScope is the space-separated OAuth scope string requested from
+	// the upstream authorization server.
+	UpstreamOAuthScope string
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
@@ -124,6 +131,48 @@ func parseRoutes(env []string) ([]Route, error) {
 			delete(options, "required_audience")
 		}
 
+		// upstream_oauth: enables upstream OAuth delegation.
+		// Value must be "auto" or an absolute http/https issuer URL.
+		// Mutually exclusive with upstream_bearer_token_env (fail-closed).
+		var upstreamOAuth string
+		if oauthVal, ok := options["upstream_oauth"]; ok {
+			oauthVal = strings.TrimSpace(oauthVal)
+			if oauthVal == "" {
+				return nil, fmt.Errorf("%s: upstream_oauth value must not be empty", key)
+			}
+			if upstreamBearerTokenEnv != "" {
+				return nil, fmt.Errorf("%s: upstream_oauth and upstream_bearer_token_env are mutually exclusive", key)
+			}
+			if oauthVal != "auto" {
+				u, err := url.Parse(oauthVal)
+				if err != nil || u.Scheme == "" || u.Host == "" {
+					return nil, fmt.Errorf("%s: upstream_oauth must be \"auto\" or an absolute http/https URL (got %q)", key, oauthVal)
+				}
+				if u.Scheme != "http" && u.Scheme != "https" {
+					return nil, fmt.Errorf("%s: upstream_oauth URL scheme must be http or https (got %q)", key, u.Scheme)
+				}
+				oauthVal = strings.TrimRight(oauthVal, "/")
+			}
+			upstreamOAuth = oauthVal
+			delete(options, "upstream_oauth")
+		}
+
+		// upstream_oauth_scope: space-separated OAuth scope string.
+		// Comma-separated values are normalised to space-separated.
+		var upstreamOAuthScope string
+		if scopeVal, ok := options["upstream_oauth_scope"]; ok {
+			scopeVal = strings.TrimSpace(scopeVal)
+			if scopeVal == "" {
+				return nil, fmt.Errorf("%s: upstream_oauth_scope value must not be empty or whitespace-only", key)
+			}
+			// Normalise comma-separated to space-separated.
+			scopeVal = strings.ReplaceAll(scopeVal, ",", " ")
+			// Collapse multiple spaces.
+			fields := strings.Fields(scopeVal)
+			upstreamOAuthScope = strings.Join(fields, " ")
+			delete(options, "upstream_oauth_scope")
+		}
+
 		// Reject any unrecognised option keys.
 		if len(options) > 0 {
 			unknown := make([]string, 0, len(options))
@@ -168,6 +217,8 @@ func parseRoutes(env []string) ([]Route, error) {
 			NoAuth:                 noAuth,
 			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
 			RequiredAudience:       requiredAudience,
+			UpstreamOAuth:          upstreamOAuth,
+			UpstreamOAuthScope:     upstreamOAuthScope,
 		})
 	}
 	// Longest prefix first for correct matching order.
@@ -234,6 +285,35 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 		if requiredAudience == "" {
 			requiredAudience = DefaultRequiredAudience
 		}
+		// upstream_oauth: same validation as parseRoutes.
+		upstreamOAuth := strings.TrimSpace(r.UpstreamOAuth)
+		if r.UpstreamOAuth != "" {
+			if upstreamOAuth == "" {
+				return nil, fmt.Errorf("route %q: upstream_oauth value must not be empty", name)
+			}
+			if upstreamBearerTokenEnv != "" {
+				return nil, fmt.Errorf("route %q: upstream_oauth and upstream_bearer_token_env are mutually exclusive", name)
+			}
+			if upstreamOAuth != "auto" {
+				pu, err := url.Parse(upstreamOAuth)
+				if err != nil || pu.Scheme == "" || pu.Host == "" {
+					return nil, fmt.Errorf("route %q: upstream_oauth must be \"auto\" or an absolute http/https URL (got %q)", name, upstreamOAuth)
+				}
+				if pu.Scheme != "http" && pu.Scheme != "https" {
+					return nil, fmt.Errorf("route %q: upstream_oauth URL scheme must be http or https (got %q)", name, pu.Scheme)
+				}
+				upstreamOAuth = strings.TrimRight(upstreamOAuth, "/")
+			}
+		}
+		// upstream_oauth_scope: normalise comma-separated to space-separated.
+		upstreamOAuthScope := strings.TrimSpace(r.UpstreamOAuthScope)
+		if r.UpstreamOAuthScope != "" {
+			if upstreamOAuthScope == "" {
+				return nil, fmt.Errorf("route %q: upstream_oauth_scope value must not be empty or whitespace-only", name)
+			}
+			upstreamOAuthScope = strings.ReplaceAll(upstreamOAuthScope, ",", " ")
+			upstreamOAuthScope = strings.Join(strings.Fields(upstreamOAuthScope), " ")
+		}
 		seen[prefix] = struct{}{}
 		routes = append(routes, Route{
 			Name:                   name,
@@ -242,6 +322,8 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			NoAuth:                 r.NoAuth,
 			UpstreamBearerTokenEnv: upstreamBearerTokenEnv,
 			RequiredAudience:       requiredAudience,
+			UpstreamOAuth:          upstreamOAuth,
+			UpstreamOAuthScope:     upstreamOAuthScope,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -712,3 +712,40 @@ func TestParseFromConfig_UpstreamOAuthScopeWithoutOAuthRejected(t *testing.T) {
 		t.Fatal("expected error for upstream_oauth_scope without upstream_oauth")
 	}
 }
+
+// yaml.v3 decodes `null` and blank (key with no value) to nil for *string fields.
+// nil is treated as absent (disabled); these tests pin that specification so that
+// any future UnmarshalYAML change that alters this behaviour is caught immediately.
+
+func TestParseFromConfig_UpstreamOAuthNilTreatedAsAbsent(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: nil},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error for nil upstream_oauth: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].UpstreamOAuth != "" {
+		t.Errorf("UpstreamOAuth should be empty for nil input, got %q", routes[0].UpstreamOAuth)
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthScopeNilTreatedAsAbsent(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthScope: nil},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error for nil upstream_oauth_scope: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].UpstreamOAuthScope != "" {
+		t.Errorf("UpstreamOAuthScope should be empty for nil input, got %q", routes[0].UpstreamOAuthScope)
+	}
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -7,6 +7,8 @@ import (
 	appconfig "github.com/scottlz0310/mcp-gateway/internal/config"
 )
 
+func strPtr(s string) *string { return &s }
+
 func TestParseRoutesEmpty(t *testing.T) {
 	routes, err := parseRoutes(nil)
 	if err != nil {
@@ -556,7 +558,7 @@ func TestParseRoutesUnknownOptionStillRejected(t *testing.T) {
 
 func TestParseFromConfig_UpstreamOAuthAuto(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
-		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "auto"},
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("auto")},
 	}
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
@@ -572,7 +574,7 @@ func TestParseFromConfig_UpstreamOAuthAuto(t *testing.T) {
 
 func TestParseFromConfig_UpstreamOAuthExplicitIssuer(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
-		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "https://mcp.cloudflare.com"},
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("https://mcp.cloudflare.com")},
 	}
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
@@ -588,7 +590,7 @@ func TestParseFromConfig_UpstreamOAuthExplicitIssuer(t *testing.T) {
 
 func TestParseFromConfig_UpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
-		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "https://mcp.cloudflare.com/"},
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("https://mcp.cloudflare.com/")},
 	}
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
@@ -605,7 +607,7 @@ func TestParseFromConfig_UpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
 func TestParseFromConfig_UpstreamOAuthWithScope(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
 		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
-			UpstreamOAuth: "auto", UpstreamOAuthScope: "account:read offline_access d1:write workers:edit"},
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthScope: strPtr("account:read offline_access d1:write workers:edit")},
 	}
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
@@ -622,7 +624,7 @@ func TestParseFromConfig_UpstreamOAuthWithScope(t *testing.T) {
 func TestParseFromConfig_UpstreamOAuthScopeCommaNormalized(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
 		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
-			UpstreamOAuth: "auto", UpstreamOAuthScope: "account:read,offline_access"},
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthScope: strPtr("account:read,offline_access")},
 	}
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
@@ -638,7 +640,7 @@ func TestParseFromConfig_UpstreamOAuthScopeCommaNormalized(t *testing.T) {
 
 func TestParseFromConfig_UpstreamOAuthInvalidURL(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
-		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "not-a-url"},
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("not-a-url")},
 	}
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
@@ -648,7 +650,7 @@ func TestParseFromConfig_UpstreamOAuthInvalidURL(t *testing.T) {
 
 func TestParseFromConfig_UpstreamOAuthNonHTTPScheme(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
-		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "ftp://issuer.example.com"},
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("ftp://issuer.example.com")},
 	}
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
@@ -660,7 +662,7 @@ func TestParseFromConfig_UpstreamOAuthAndBearerTokenMutuallyExclusive(t *testing
 	t.Setenv("CF_TOKEN", "my-token")
 	cfgRoutes := []appconfig.RouteConfig{
 		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
-			UpstreamOAuth: "auto", UpstreamBearerTokenEnv: "CF_TOKEN"},
+			UpstreamOAuth: strPtr("auto"), UpstreamBearerTokenEnv: "CF_TOKEN"},
 	}
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
@@ -671,7 +673,7 @@ func TestParseFromConfig_UpstreamOAuthAndBearerTokenMutuallyExclusive(t *testing
 func TestParseFromConfig_UpstreamOAuthScopeWhitespaceOnlyRejected(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
 		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
-			UpstreamOAuth: "auto", UpstreamOAuthScope: "   "},
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthScope: strPtr("   ")},
 	}
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
@@ -679,10 +681,31 @@ func TestParseFromConfig_UpstreamOAuthScopeWhitespaceOnlyRejected(t *testing.T) 
 	}
 }
 
+func TestParseFromConfig_UpstreamOAuthEmptyStringRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for explicit empty upstream_oauth value in config")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthScopeEmptyStringRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthScope: strPtr("")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for explicit empty upstream_oauth_scope value in config")
+	}
+}
+
 func TestParseFromConfig_UpstreamOAuthScopeWithoutOAuthRejected(t *testing.T) {
 	cfgRoutes := []appconfig.RouteConfig{
 		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
-			UpstreamOAuthScope: "account:read"},
+			UpstreamOAuthScope: strPtr("account:read")},
 	}
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -422,3 +422,221 @@ func TestParseRoutesEmptyValueSkipped(t *testing.T) {
 		t.Errorf("expected route name %q, got %q", "github", routes[0].Name)
 	}
 }
+
+// upstream_oauth テスト群
+
+func TestParseRoutesUpstreamOAuthAuto(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "auto" {
+		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "auto")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthExplicitIssuer(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=https://mcp.cloudflare.com"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
+		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "https://mcp.cloudflare.com")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=https://mcp.cloudflare.com/"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
+		t.Errorf("UpstreamOAuth trailing slash not trimmed: got %q", routes[0].UpstreamOAuth)
+	}
+}
+
+func TestParseRoutesUpstreamOAuthWithScope(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_scope=account:read offline_access"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthScope != "account:read offline_access" {
+		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthScopeCommaNormalized(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_scope=account:read,offline_access,d1:write"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthScope != "account:read offline_access d1:write" {
+		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access d1:write")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthEmpty(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth="}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for empty upstream_oauth value")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthInvalidURL(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=not-a-url"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for invalid upstream_oauth URL")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthNonHTTPScheme(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=ftp://issuer.example.com"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for non-http/https upstream_oauth scheme")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthAndBearerTokenMutuallyExclusive(t *testing.T) {
+	t.Setenv("CF_TOKEN", "my-token")
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_bearer_token_env=CF_TOKEN"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth + upstream_bearer_token_env combination")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthScopeEmptyRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_scope="}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for empty upstream_oauth_scope value")
+	}
+}
+
+func TestParseRoutesUnknownOptionStillRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|some_future_opt=value"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for unknown option alongside upstream_oauth")
+	}
+}
+
+// ParseFromConfig upstream_oauth テスト群
+
+func TestParseFromConfig_UpstreamOAuthAuto(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "auto"},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "auto" {
+		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "auto")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthExplicitIssuer(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "https://mcp.cloudflare.com"},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
+		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "https://mcp.cloudflare.com")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "https://mcp.cloudflare.com/"},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
+		t.Errorf("UpstreamOAuth trailing slash not trimmed: got %q", routes[0].UpstreamOAuth)
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthWithScope(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: "auto", UpstreamOAuthScope: "account:read offline_access d1:write workers:edit"},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthScope != "account:read offline_access d1:write workers:edit" {
+		t.Errorf("UpstreamOAuthScope: got %q", routes[0].UpstreamOAuthScope)
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthScopeCommaNormalized(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: "auto", UpstreamOAuthScope: "account:read,offline_access"},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthScope != "account:read offline_access" {
+		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthInvalidURL(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "not-a-url"},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for invalid upstream_oauth URL")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthNonHTTPScheme(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: "ftp://issuer.example.com"},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for non-http/https upstream_oauth scheme")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthAndBearerTokenMutuallyExclusive(t *testing.T) {
+	t.Setenv("CF_TOKEN", "my-token")
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: "auto", UpstreamBearerTokenEnv: "CF_TOKEN"},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth + upstream_bearer_token_env combination")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthScopeWhitespaceOnlyRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: "auto", UpstreamOAuthScope: "   "},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for whitespace-only upstream_oauth_scope")
+	}
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -431,6 +431,9 @@ func TestParseRoutesUpstreamOAuthAuto(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuth != "auto" {
 		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "auto")
 	}
@@ -441,6 +444,9 @@ func TestParseRoutesUpstreamOAuthExplicitIssuer(t *testing.T) {
 	routes, err := parseRoutes(env)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
 		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "https://mcp.cloudflare.com")
@@ -453,6 +459,9 @@ func TestParseRoutesUpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
 		t.Errorf("UpstreamOAuth trailing slash not trimmed: got %q", routes[0].UpstreamOAuth)
 	}
@@ -464,6 +473,9 @@ func TestParseRoutesUpstreamOAuthWithScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuthScope != "account:read offline_access" {
 		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access")
 	}
@@ -474,6 +486,9 @@ func TestParseRoutesUpstreamOAuthScopeCommaNormalized(t *testing.T) {
 	routes, err := parseRoutes(env)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 	if routes[0].UpstreamOAuthScope != "account:read offline_access d1:write" {
 		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access d1:write")
@@ -521,6 +536,14 @@ func TestParseRoutesUpstreamOAuthScopeEmptyRejected(t *testing.T) {
 	}
 }
 
+func TestParseRoutesUpstreamOAuthScopeWithoutOAuthRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth_scope=account:read"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth_scope without upstream_oauth")
+	}
+}
+
 func TestParseRoutesUnknownOptionStillRejected(t *testing.T) {
 	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|some_future_opt=value"}
 	_, err := parseRoutes(env)
@@ -539,6 +562,9 @@ func TestParseFromConfig_UpstreamOAuthAuto(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuth != "auto" {
 		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "auto")
 	}
@@ -552,6 +578,9 @@ func TestParseFromConfig_UpstreamOAuthExplicitIssuer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
 		t.Errorf("UpstreamOAuth: got %q, want %q", routes[0].UpstreamOAuth, "https://mcp.cloudflare.com")
 	}
@@ -564,6 +593,9 @@ func TestParseFromConfig_UpstreamOAuthTrailingSlashTrimmed(t *testing.T) {
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 	if routes[0].UpstreamOAuth != "https://mcp.cloudflare.com" {
 		t.Errorf("UpstreamOAuth trailing slash not trimmed: got %q", routes[0].UpstreamOAuth)
@@ -579,6 +611,9 @@ func TestParseFromConfig_UpstreamOAuthWithScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
 	if routes[0].UpstreamOAuthScope != "account:read offline_access d1:write workers:edit" {
 		t.Errorf("UpstreamOAuthScope: got %q", routes[0].UpstreamOAuthScope)
 	}
@@ -592,6 +627,9 @@ func TestParseFromConfig_UpstreamOAuthScopeCommaNormalized(t *testing.T) {
 	routes, err := ParseFromConfig(cfgRoutes)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 	if routes[0].UpstreamOAuthScope != "account:read offline_access" {
 		t.Errorf("UpstreamOAuthScope: got %q, want %q", routes[0].UpstreamOAuthScope, "account:read offline_access")
@@ -638,5 +676,16 @@ func TestParseFromConfig_UpstreamOAuthScopeWhitespaceOnlyRejected(t *testing.T) 
 	_, err := ParseFromConfig(cfgRoutes)
 	if err == nil {
 		t.Fatal("expected error for whitespace-only upstream_oauth_scope")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthScopeWithoutOAuthRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuthScope: "account:read"},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth_scope without upstream_oauth")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #113

- `Route` 構造体に `UpstreamOAuth`（`"auto"` または絶対 issuer URL）と `UpstreamOAuthScope`（スペース区切りスコープ）フィールドを追加
- `ROUTE_*` 環境変数パーサで `upstream_oauth` / `upstream_oauth_scope` オプションをサポート
- `config.yaml` の `RouteConfig` に同フィールドを追加し、`ParseFromConfig` で同等バリデーションを適用
- ランタイム動作の変更なし（discovery / DCR / トークン注入は後続 Issue で実装）

## バリデーションルール

| 条件 | 結果 |
|------|------|
| `upstream_oauth` が空文字 | fail-closed エラー |
| 無効な URL（非 absolute） | エラー |
| `http`/`https` 以外のスキーム | エラー |
| `upstream_oauth` + `upstream_bearer_token_env` 同時指定 | fail-closed エラー |
| issuer URL の末尾スラッシュ | trim して保存 |
| `upstream_oauth_scope` が空またはホワイトスペースのみ | エラー |
| カンマ区切りスコープ | スペース区切りに正規化 |

## Test plan

- [x] `upstream_oauth=auto` での環境変数ルートパース
- [x] 明示的 issuer URL でのパース
- [x] `upstream_oauth_scope` 指定でのパース
- [x] 無効値（空文字・不正 URL・非 http/https スキーム）の拒否
- [x] `upstream_oauth` + `upstream_bearer_token_env` 同時指定の拒否
- [x] 末尾スラッシュが trim されて保存されること
- [x] カンマ区切りスコープのスペース正規化
- [x] `config.yaml` ルートパースの同等テスト（計 10 ケース追加）
- [x] 未知オプションが引き続き fail-closed で拒否されることの確認
- [x] 全既存テストが引き続き PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)