### PR TITLE
fix(auth): refresh_token フローの id_token に nonce を引き継ぐ（OIDC Core §12.2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Propagate OIDC nonce to `id_token` issued by the `refresh_token` endpoint (OIDC Core §12.2) ([#160](https://github.com/scottlz0310/mcp-gateway/issues/160))
+  - Added `Nonce` field to `TokenRecord`, `memEntry`, and `fileEntry` so the nonce from the original authorization request is persisted alongside the access token
+  - `tokenAuthCode` now calls `SaveTokenNonce` after caching the token (both builtin and non-builtin paths)
+  - `tokenRefresh` looks up the nonce via `LookupToken` before rotating and forwards it to `writeTokenResponse` (both builtin and non-builtin paths)
+
 ### Added
 
 - Upstream OAuth route option parsing and validation ([#113](https://github.com/scottlz0310/mcp-gateway/issues/113))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Propagate OIDC nonce to `id_token` issued by the `refresh_token` endpoint (OIDC Core §12.2) ([#160](https://github.com/scottlz0310/mcp-gateway/issues/160))
-  - Added `Nonce` field to `TokenRecord`, `memEntry`, and `fileEntry` so the nonce from the original authorization request is persisted alongside the access token
-  - `tokenAuthCode` now calls `SaveTokenNonce` after caching the token (both builtin and non-builtin paths)
-  - `tokenRefresh` looks up the nonce via `LookupToken` before rotating and forwards it to `writeTokenResponse` (both builtin and non-builtin paths)
+  - Added `Nonce` field to `TokenRecord`, `memEntry`, `fileEntry`, `memRTEntry`, `fileRTEntry`, and `sqliteRefreshTokenStore` so the nonce is persisted in both the access-token store and the refresh-token store
+  - `RefreshTokenStore` gains `SaveNonce` / `LookupNonce` to key nonce on the refresh token, outliving the access-token TTL (Copilot review PRRT_kwDOSNXuJs6KuAH4)
+  - `tokenAuthCode` calls `SaveTokenNonce` and `SaveRefreshTokenNonce` after caching (both builtin and non-builtin paths)
+  - `tokenRefresh` reads the nonce via `LookupRefreshTokenNonce` before `ReserveRefreshToken` so it is available even after soft-revocation, and forwards it to `writeTokenResponse` (both paths)
+  - `SaveTokenNonce` empty-string guard removed so a subsequent grant with no nonce correctly clears a previously stored value (thread-owl review PRRT_kwDOSNXuJs6KuLsC)
+  - `fileEntry` and `fileRTEntry` OIDC nonce JSON key standardised to `"n"` for consistency with existing short field names (Copilot review PRRT_kwDOSNXuJs6KuAIE)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
   - `RefreshTokenStore` gains `SaveNonce` / `LookupNonce` to key nonce on the refresh token, outliving the access-token TTL (Copilot review PRRT_kwDOSNXuJs6KuAH4)
   - `tokenAuthCode` calls `SaveTokenNonce` and `SaveRefreshTokenNonce` after caching (both builtin and non-builtin paths)
   - `tokenRefresh` reads the nonce via `LookupRefreshTokenNonce` before `ReserveRefreshToken` so it is available even after soft-revocation, and forwards it to `writeTokenResponse` (both paths)
+  - `tokenRefresh` now calls `SaveRefreshTokenNonce(newRT, nonce)` after issuing the rotated refresh token (both builtin and non-builtin), so nonce survives across consecutive refresh cycles (thread-owl PRRT_kwDOSNXuJs6KuAH4 follow-up)
   - `SaveTokenNonce` empty-string guard removed so a subsequent grant with no nonce correctly clears a previously stored value (thread-owl review PRRT_kwDOSNXuJs6KuLsC)
   - `fileEntry` and `fileRTEntry` OIDC nonce JSON key standardised to `"n"` for consistency with existing short field names (Copilot review PRRT_kwDOSNXuJs6KuAIE)
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -594,6 +594,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.CacheToken(gatewayToken, result.Subject, result.Audience)
+		h.store.SaveTokenNonce(gatewayToken, result.Nonce)
 		familyID, fidErr := generateCode()
 		if fidErr != nil {
 			slog.Warn("failed to generate refresh token family ID", "err", fidErr)
@@ -609,6 +610,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.store.CacheToken(result.AccessToken, result.Subject, result.Audience)
+	h.store.SaveTokenNonce(result.AccessToken, result.Nonce)
 	h.persistProviderRefresh(result.AccessToken, result.ProviderRefreshToken, result.ProviderAccessExpiry)
 	familyID, fidErr := generateCode()
 	if fidErr != nil {
@@ -794,6 +796,14 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		audience = resolved
 	}
 
+	// Retrieve the nonce from the existing token entry before rotating.
+	// OIDC Core §12.2: if an id_token is returned from the refresh endpoint,
+	// the nonce claim MUST be the same as in the original authentication request.
+	var nonce string
+	if rec, ok := h.store.LookupToken(accessToken); ok {
+		nonce = rec.Nonce
+	}
+
 	if h.isBuiltinMode() {
 		// builtin mode: verify the existing gateway JWT locally to extract subject,
 		// then issue a new gateway JWT. GitHub API is not consulted.
@@ -813,6 +823,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.CacheToken(newGatewayToken, sub, audience)
+		h.store.SaveTokenNonce(newGatewayToken, nonce)
 		// Propagate the same familyID so the token lineage remains traceable.
 		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
@@ -822,7 +833,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 			return
 		}
-		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub, "")
+		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub, nonce)
 		h.auditSuccess("refresh", "refresh token exchange completed (builtin)", http.StatusOK)
 		return
 	}
@@ -862,7 +873,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject, "")
+	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject, nonce)
 	h.auditSuccess("refresh", "refresh token exchange completed", http.StatusOK)
 }
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -604,6 +604,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
+		h.store.SaveRefreshTokenNonce(refreshToken, result.Nonce)
 		h.writeTokenResponse(w, gatewayToken, result.Scope, refreshToken, result.Subject, result.Nonce)
 		h.auditSuccess("token_exchange", "authorization code exchange completed (builtin)", http.StatusOK)
 		return
@@ -621,6 +622,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 	if rtErr != nil {
 		slog.Warn("failed to create refresh token", "err", rtErr)
 	}
+	h.store.SaveRefreshTokenNonce(refreshToken, result.Nonce)
 	h.writeTokenResponse(w, result.AccessToken, result.Scope, refreshToken, result.Subject, result.Nonce)
 	h.auditSuccess("token_exchange", "authorization code exchange completed", http.StatusOK)
 }
@@ -753,6 +755,13 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up the nonce before reserving (soft-revoking) the refresh token so
+	// the nonce is still readable via LookupNonce even after revocation.
+	// OIDC Core §12.2: the nonce in the refresh-issued id_token MUST match the
+	// original authentication request. We key on the refresh token (not the
+	// access token) so the nonce remains available past the access-token TTL.
+	nonce := h.store.LookupRefreshTokenNonce(rt)
+
 	// Atomically reserve (remove) the token. Concurrent callers presenting the
 	// same token will fail here, preventing double-rotation.
 	// On reuse detection (revoked token replay), ReserveRefreshToken revokes the
@@ -794,14 +803,6 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		audience = resolved
-	}
-
-	// Retrieve the nonce from the existing token entry before rotating.
-	// OIDC Core §12.2: if an id_token is returned from the refresh endpoint,
-	// the nonce claim MUST be the same as in the original authentication request.
-	var nonce string
-	if rec, ok := h.store.LookupToken(accessToken); ok {
-		nonce = rec.Nonce
 	}
 
 	if h.isBuiltinMode() {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -834,6 +834,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 			return
 		}
+		h.store.SaveRefreshTokenNonce(newRT, nonce)
 		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub, nonce)
 		h.auditSuccess("refresh", "refresh token exchange completed (builtin)", http.StatusOK)
 		return
@@ -873,6 +874,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		oauthError(w, "server_error", "internal error", http.StatusInternalServerError)
 		return
 	}
+	h.store.SaveRefreshTokenNonce(newRT, nonce)
 
 	h.writeTokenResponse(w, accessToken, "", newRT, id.Subject, nonce)
 	h.auditSuccess("refresh", "refresh token exchange completed", http.StatusOK)

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2523,6 +2523,121 @@ func TestIDTokenNonceClaim(t *testing.T) {
 	}
 }
 
+// TestTokenRefreshNoncePropagated verifies that the nonce from the original
+// authorization request is forwarded in the id_token issued by the refresh
+// endpoint (OIDC Core §12.2). Tested in builtin mode where id_token is always
+// emitted on refresh.
+func TestTokenRefreshNoncePropagated(t *testing.T) {
+	tests := []struct {
+		name          string
+		nonce         string
+		expectInToken bool
+	}{
+		{"nonce present", "original-nonce-xyz", true},
+		{"nonce absent", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newBuiltinTestHandler(t,
+				func(_ context.Context, _ string) (provider.TokenResponse, error) {
+					return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+				},
+				func(_ context.Context, _ string) (provider.Identity, error) {
+					return provider.Identity{Subject: "alice"}, nil
+				},
+			)
+
+			// Authorize → Callback → Token (authorization_code) with nonce.
+			verifier := "test-verifier-abcdefghijklmnopqrstuvwxyz01234"
+			challenge := pkceChallenge(verifier)
+			state := "nonce-test-state"
+			redirectURI := "http://localhost/cb"
+
+			authURL := "/authorize?response_type=code&state=" + state +
+				"&redirect_uri=" + url.QueryEscape(redirectURI) +
+				"&code_challenge=" + challenge +
+				"&code_challenge_method=S256"
+			if tc.nonce != "" {
+				authURL += "&nonce=" + url.QueryEscape(tc.nonce)
+			}
+			h.Authorize(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, authURL, nil))
+
+			cbRec := httptest.NewRecorder()
+			h.Callback(cbRec, httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil))
+			if cbRec.Code != http.StatusFound {
+				t.Fatalf("callback: got %d", cbRec.Code)
+			}
+			loc, _ := url.Parse(cbRec.Header().Get("Location"))
+			internalCode := loc.Query().Get("code")
+
+			tokenBody := "grant_type=authorization_code" +
+				"&redirect_uri=" + url.QueryEscape(redirectURI) +
+				"&code=" + url.QueryEscape(internalCode) +
+				"&code_verifier=" + url.QueryEscape(verifier)
+			tokenRec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			h.Token(tokenRec, req)
+			if tokenRec.Code != http.StatusOK {
+				t.Fatalf("token exchange: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+			}
+			var tokenResp map[string]any
+			if err := json.NewDecoder(tokenRec.Body).Decode(&tokenResp); err != nil {
+				t.Fatalf("decode token response: %v", err)
+			}
+			rt, _ := tokenResp["refresh_token"].(string)
+			if rt == "" {
+				t.Fatal("expected refresh_token in authorization_code response")
+			}
+
+			// Refresh — nonce must be propagated to the new id_token.
+			refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt)
+			refreshRec := httptest.NewRecorder()
+			req2 := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+			req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			h.Token(refreshRec, req2)
+			if refreshRec.Code != http.StatusOK {
+				t.Fatalf("refresh: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+			}
+			var refreshResp map[string]any
+			if err := json.NewDecoder(refreshRec.Body).Decode(&refreshResp); err != nil {
+				t.Fatalf("decode refresh response: %v", err)
+			}
+
+			idToken, _ := refreshResp["id_token"].(string)
+			if idToken == "" {
+				t.Fatal("expected id_token in refresh response (builtin mode always issues id_token)")
+			}
+			parts := strings.Split(idToken, ".")
+			if len(parts) != 3 {
+				t.Fatalf("invalid JWT: got %d parts", len(parts))
+			}
+			payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+			if err != nil {
+				t.Fatalf("decode JWT payload: %v", err)
+			}
+			var claims map[string]any
+			if err := json.Unmarshal(payload, &claims); err != nil {
+				t.Fatalf("unmarshal claims: %v", err)
+			}
+
+			nonceClaim, hasClaim := claims["nonce"]
+			if tc.expectInToken {
+				if !hasClaim {
+					t.Error("expected nonce claim in refresh id_token, but not found")
+				} else if nonceClaim != tc.nonce {
+					t.Errorf("nonce claim: got %v, want %q", nonceClaim, tc.nonce)
+				}
+			} else {
+				if hasClaim {
+					t.Errorf("expected no nonce claim in refresh id_token, but got %v", nonceClaim)
+				}
+			}
+		})
+	}
+}
+
 func assertJSONStringsContain(t *testing.T, doc map[string]any, key, want string) {
 	t.Helper()
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -2653,6 +2653,93 @@ func TestTokenRefreshNoncePropagated(t *testing.T) {
 	}
 }
 
+// TestTokenRefreshNoncePropagatedChained verifies that the nonce is correctly
+// propagated across multiple consecutive refresh operations (RT rotation).
+// PRRT_kwDOSNXuJs6KuAH4 follow-up: after the first refresh the new RT must
+// also carry the nonce so the second refresh can include it in id_token.
+func TestTokenRefreshNoncePropagatedChained(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+
+	const nonce = "chained-nonce-xyz"
+	verifier := "test-verifier-abcdefghijklmnopqrstuvwxyz01234"
+	challenge := pkceChallenge(verifier)
+	state := "chained-nonce-state"
+	redirectURI := "http://localhost/cb"
+
+	authURL := "/authorize?response_type=code&state=" + state +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code_challenge=" + challenge +
+		"&code_challenge_method=S256" +
+		"&nonce=" + url.QueryEscape(nonce)
+	h.Authorize(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, authURL, nil))
+
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil))
+	loc, _ := url.Parse(cbRec.Header().Get("Location"))
+	internalCode := loc.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenRec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.Token(tokenRec, req)
+	var tokenResp map[string]any
+	if err := json.NewDecoder(tokenRec.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	rt1, _ := tokenResp["refresh_token"].(string)
+	if rt1 == "" {
+		t.Fatal("expected refresh_token in authorization_code response")
+	}
+
+	doRefresh := func(t *testing.T, rt string) (newRT string, nonceClaim string) {
+		t.Helper()
+		refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt)
+		refreshRec := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+		req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		h.Token(refreshRec, req2)
+		if refreshRec.Code != http.StatusOK {
+			t.Fatalf("refresh: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(refreshRec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode refresh response: %v", err)
+		}
+		idToken, _ := resp["id_token"].(string)
+		if idToken == "" {
+			t.Fatal("expected id_token in refresh response (builtin mode)")
+		}
+		claims := parseJWTPayload(t, idToken)
+		nc, _ := claims["nonce"].(string)
+		nr, _ := resp["refresh_token"].(string)
+		return nr, nc
+	}
+
+	rt2, nonce1 := doRefresh(t, rt1)
+	if nonce1 != nonce {
+		t.Errorf("1st refresh: nonce claim got %q, want %q", nonce1, nonce)
+	}
+	if rt2 == "" {
+		t.Fatal("expected refresh_token in 1st refresh response")
+	}
+
+	_, nonce2 := doRefresh(t, rt2)
+	if nonce2 != nonce {
+		t.Errorf("2nd refresh: nonce claim got %q, want %q (nonce must survive RT rotation)", nonce2, nonce)
+	}
+}
+
 func assertJSONStringsContain(t *testing.T, doc map[string]any, key, want string) {
 	t.Helper()
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1399,10 +1399,12 @@ func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, string, time
 func (d *deleteFailRefreshStore) LookupAny(rt string) (string, string, string, time.Time, bool, bool) {
 	return d.inner.LookupAny(rt)
 }
-func (d *deleteFailRefreshStore) Revoke(_ string) error         { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) RevokeFamily(fid string) error { return d.inner.RevokeFamily(fid) }
-func (d *deleteFailRefreshStore) Delete(_ string) error         { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) Sweep() error                  { return d.inner.Sweep() }
+func (d *deleteFailRefreshStore) Revoke(_ string) error            { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) RevokeFamily(fid string) error    { return d.inner.RevokeFamily(fid) }
+func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error     { return d.inner.SaveNonce(rt, n) }
+func (d *deleteFailRefreshStore) LookupNonce(rt string) string     { return d.inner.LookupNonce(rt) }
+func (d *deleteFailRefreshStore) Delete(_ string) error            { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) Sweep() error                     { return d.inner.Sweep() }
 
 // TestTokenRefreshDeleteFailed503 verifies that when the refresh token store
 // fails to delete the token during rotation (ErrRefreshTokenDeleteFailed),
@@ -2529,12 +2531,16 @@ func TestIDTokenNonceClaim(t *testing.T) {
 // emitted on refresh.
 func TestTokenRefreshNoncePropagated(t *testing.T) {
 	tests := []struct {
-		name          string
-		nonce         string
-		expectInToken bool
+		name           string
+		nonce          string
+		expireATBefore bool // simulate AT TTL expiry before refresh
+		expectInToken  bool
 	}{
-		{"nonce present", "original-nonce-xyz", true},
-		{"nonce absent", "", false},
+		{"nonce present", "original-nonce-xyz", false, true},
+		{"nonce absent", "", false, false},
+		// Thread-owl PRRT_kwDOSNXuJs6KuAH4: nonce must survive past the AT TTL
+		// because the refresh token grace period exceeds the access token TTL.
+		{"nonce present, AT store expired", "original-nonce-xyz", true, true},
 	}
 
 	for _, tc := range tests {
@@ -2589,6 +2595,15 @@ func TestTokenRefreshNoncePropagated(t *testing.T) {
 			rt, _ := tokenResp["refresh_token"].(string)
 			if rt == "" {
 				t.Fatal("expected refresh_token in authorization_code response")
+			}
+
+			if tc.expireATBefore {
+				// Simulate the access-token TTL expiring before the refresh-token
+				// grace period (PRRT_kwDOSNXuJs6KuAH4): the AT record is evicted
+				// from the token store while the RT is still valid. Nonce must
+				// still be propagated via the RT-keyed entry.
+				at, _ := tokenResp["access_token"].(string)
+				h.store.InvalidateCachedToken(at)
 			}
 
 			// Refresh — nonce must be propagated to the new id_token.

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -716,6 +716,18 @@ func (s *Store) RecordProviderRefresh(token, providerRefreshToken string, provid
 	// is no separate index hint to update here.
 }
 
+// SaveTokenNonce attaches the OIDC nonce to an existing token entry so it can
+// be forwarded in the id_token on refresh (OIDC Core §12.2). No-op when the
+// nonce is empty or the entry is absent/expired.
+func (s *Store) SaveTokenNonce(token, nonce string) {
+	if nonce == "" {
+		return
+	}
+	if err := s.tokens.SaveNonce(token, nonce); err != nil {
+		slog.Warn("token store nonce save failed", "err", err)
+	}
+}
+
 // ClearProviderRefresh drops the provider refresh metadata for token (sets
 // both the refresh token and access expiry to their zero values). Used after
 // a permanent rotation failure (e.g. bad_refresh_token) so subsequent

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -717,15 +717,29 @@ func (s *Store) RecordProviderRefresh(token, providerRefreshToken string, provid
 }
 
 // SaveTokenNonce attaches the OIDC nonce to an existing token entry so it can
-// be forwarded in the id_token on refresh (OIDC Core §12.2). No-op when the
-// nonce is empty or the entry is absent/expired.
+// be forwarded in the id_token on refresh (OIDC Core §12.2). An empty nonce
+// clears any previously stored value, ensuring stale nonces from a prior grant
+// do not leak into subsequent grants that reuse the same access token.
 func (s *Store) SaveTokenNonce(token, nonce string) {
-	if nonce == "" {
-		return
-	}
 	if err := s.tokens.SaveNonce(token, nonce); err != nil {
 		slog.Warn("token store nonce save failed", "err", err)
 	}
+}
+
+// SaveRefreshTokenNonce attaches the OIDC nonce to a refresh-token entry so
+// the nonce survives past the access-token TTL and can be retrieved during
+// token refresh (OIDC Core §12.2). No-op when entry is absent or expired.
+func (s *Store) SaveRefreshTokenNonce(refreshToken, nonce string) {
+	if err := s.refreshStore.SaveNonce(refreshToken, nonce); err != nil {
+		slog.Warn("refresh token store nonce save failed", "err", err)
+	}
+}
+
+// LookupRefreshTokenNonce returns the OIDC nonce stored for refreshToken, or
+// "" when absent or expired. Reads even soft-revoked entries (already rotated
+// by ReserveRefreshToken) so the nonce remains readable during the rotation.
+func (s *Store) LookupRefreshTokenNonce(refreshToken string) string {
+	return s.refreshStore.LookupNonce(refreshToken)
 }
 
 // ClearProviderRefresh drops the provider refresh metadata for token (sets

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -234,10 +234,11 @@ func (e *errTokenStore) Save(_, _ string, _ []string, _ time.Time) error {
 func (e *errTokenStore) SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error {
 	return e.mem.SaveProviderRefresh(token, providerRefreshToken, providerAccessExpiry)
 }
-func (e *errTokenStore) Lookup(token string) (TokenRecord, bool)    { return e.mem.Lookup(token) }
-func (e *errTokenStore) MarkRotationFailed(_ string) error          { return nil }
-func (e *errTokenStore) Delete(_ string) error                      { return fmt.Errorf("injected delete error") }
-func (e *errTokenStore) Sweep() error                               { return e.mem.Sweep() }
+func (e *errTokenStore) Lookup(token string) (TokenRecord, bool)  { return e.mem.Lookup(token) }
+func (e *errTokenStore) SaveNonce(token, nonce string) error       { return e.mem.SaveNonce(token, nonce) }
+func (e *errTokenStore) MarkRotationFailed(_ string) error         { return nil }
+func (e *errTokenStore) Delete(_ string) error                     { return fmt.Errorf("injected delete error") }
+func (e *errTokenStore) Sweep() error                              { return e.mem.Sweep() }
 
 // TestNewStoreNilTokenStore verifies that a nil TokenStore defaults to memTokenStore.
 func TestNewStoreNilTokenStore(t *testing.T) {

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -25,13 +25,19 @@ import (
 // rotation for this token (e.g., bad or revoked refresh token). Once set it
 // survives gateway restarts when using a file-backed store so that
 // ValidateToken never re-seeds the subject index with a dead bearer.
+//
+// Nonce is the OIDC nonce from the original authorization request (OIDC Core
+// §3.1.3.7). It is propagated to id_token on refresh (OIDC Core §12.2) so
+// that the nonce binding survives token rotation. Empty when no nonce was
+// requested.
 type TokenRecord struct {
-	Subject                  string
-	Audiences                []string
-	ExpiresAt                time.Time
-	ProviderRefreshToken     string
-	ProviderAccessExpiry     time.Time
+	Subject                   string
+	Audiences                 []string
+	ExpiresAt                 time.Time
+	ProviderRefreshToken      string
+	ProviderAccessExpiry      time.Time
 	RotationPermanentlyFailed bool
+	Nonce                     string
 }
 
 // HasAudience reports whether the token record is scoped to audience.
@@ -59,6 +65,11 @@ type TokenStore interface {
 	SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error
 	// Lookup returns metadata for a non-expired token, or (zero, false).
 	Lookup(token string) (TokenRecord, bool)
+	// SaveNonce attaches the OIDC nonce to an existing entry so it can be
+	// forwarded in id_token on refresh (OIDC Core §12.2). The entry must
+	// already exist; if absent or expired the call is a no-op. An empty
+	// nonce clears any previously stored value.
+	SaveNonce(token, nonce string) error
 	// MarkRotationFailed marks token as having a permanent rotation failure.
 	// The entry must already exist; if it is absent or expired the call is a
 	// no-op. For file-backed stores the flag is flushed to disk immediately so
@@ -79,12 +90,13 @@ func tokenKey(token string) string {
 // ── in-memory implementation ────────────────────────────────────────────────
 
 type memEntry struct {
-	subject                  string
-	audiences                []string
-	expiresAt                time.Time
-	providerRefreshToken     string
-	providerAccessExpiry     time.Time
+	subject                   string
+	audiences                 []string
+	expiresAt                 time.Time
+	providerRefreshToken      string
+	providerAccessExpiry      time.Time
 	rotationPermanentlyFailed bool
+	nonce                     string
 }
 
 type memTokenStore struct {
@@ -146,7 +158,21 @@ func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 		ProviderRefreshToken:      e.providerRefreshToken,
 		ProviderAccessExpiry:      e.providerAccessExpiry,
 		RotationPermanentlyFailed: e.rotationPermanentlyFailed,
+		Nonce:                     e.nonce,
 	}, true
+}
+
+func (m *memTokenStore) SaveNonce(token, nonce string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := m.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+	entry.nonce = nonce
+	m.entries[key] = entry
+	return nil
 }
 
 func (m *memTokenStore) MarkRotationFailed(token string) error {
@@ -194,12 +220,13 @@ func (m *memTokenStore) Sweep() error {
 // window — months). Snapshot, backup, and access-control implications are
 // covered in docs/configuration.md under "Token Persistence".
 type fileEntry struct {
-	Subject               string    `json:"s"`
-	Audiences             []string  `json:"aud,omitempty"`
-	ExpiresAt             time.Time `json:"e"`
-	ProviderRefreshToken  string    `json:"prt,omitempty"`
-	ProviderAccessExpiry  time.Time `json:"pae,omitempty"`
-	RotationFailed        bool      `json:"rf,omitempty"`
+	Subject              string    `json:"s"`
+	Audiences            []string  `json:"aud,omitempty"`
+	ExpiresAt            time.Time `json:"e"`
+	ProviderRefreshToken string    `json:"prt,omitempty"`
+	ProviderAccessExpiry time.Time `json:"pae,omitempty"`
+	RotationFailed       bool      `json:"rf,omitempty"`
+	Nonce                string    `json:"nonce,omitempty"`
 }
 
 type fileTokenStore struct {
@@ -325,7 +352,26 @@ func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 		ProviderRefreshToken:      e.ProviderRefreshToken,
 		ProviderAccessExpiry:      e.ProviderAccessExpiry,
 		RotationPermanentlyFailed: e.RotationFailed,
+		Nonce:                     e.Nonce,
 	}, true
+}
+
+func (f *fileTokenStore) SaveNonce(token, nonce string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.Nonce = nonce
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
 }
 
 func (f *fileTokenStore) MarkRotationFailed(token string) error {

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -226,7 +226,7 @@ type fileEntry struct {
 	ProviderRefreshToken string    `json:"prt,omitempty"`
 	ProviderAccessExpiry time.Time `json:"pae,omitempty"`
 	RotationFailed       bool      `json:"rf,omitempty"`
-	Nonce                string    `json:"nonce,omitempty"`
+	Nonce                string    `json:"n,omitempty"`
 }
 
 type fileTokenStore struct {
@@ -506,6 +506,14 @@ type RefreshTokenStore interface {
 	RevokeFamily(familyID string) error
 	// Delete removes a single refresh token entry immediately.
 	Delete(refreshToken string) error
+	// SaveNonce attaches the OIDC nonce to an existing refresh-token entry so it
+	// can be forwarded in id_token on refresh (OIDC Core §12.2). No-op when
+	// entry is absent or expired. An empty nonce clears any previously stored value.
+	SaveNonce(refreshToken, nonce string) error
+	// LookupNonce returns the OIDC nonce stored for refreshToken, or "" when
+	// absent, expired, or nonce was never set. Returns the nonce even for
+	// soft-revoked (already-rotated) entries so it can be read after ReserveRefreshToken.
+	LookupNonce(refreshToken string) string
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
 	Sweep() error
 }
@@ -518,6 +526,7 @@ type memRTEntry struct {
 	familyID    string
 	expiresAt   time.Time
 	revoked     bool
+	nonce       string
 }
 
 type memRefreshTokenStore struct {
@@ -588,6 +597,29 @@ func (m *memRefreshTokenStore) RevokeFamily(familyID string) error {
 	return nil
 }
 
+func (m *memRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(refreshToken)
+	e, ok := m.entries[key]
+	if !ok || time.Now().After(e.expiresAt) {
+		return nil
+	}
+	e.nonce = nonce
+	m.entries[key] = e
+	return nil
+}
+
+func (m *memRefreshTokenStore) LookupNonce(refreshToken string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.expiresAt) {
+		return ""
+	}
+	return e.nonce
+}
+
 func (m *memRefreshTokenStore) Delete(refreshToken string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -619,6 +651,7 @@ type fileRTEntry struct {
 	FamilyID    string    `json:"fid,omitempty"`
 	ExpiresAt   time.Time `json:"e"`
 	Revoked     bool      `json:"rv,omitempty"`
+	Nonce       string    `json:"n,omitempty"`
 }
 
 type fileRefreshTokenStore struct {
@@ -750,6 +783,34 @@ func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
 		return nil
 	}
 	return f.flush()
+}
+
+func (f *fileRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(refreshToken)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.Nonce = nonce
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
+}
+
+func (f *fileRefreshTokenStore) LookupNonce(refreshToken string) string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	e, ok := f.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.ExpiresAt) {
+		return ""
+	}
+	return e.Nonce
 }
 
 func (f *fileRefreshTokenStore) Delete(refreshToken string) error {

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 	audience     TEXT    NOT NULL DEFAULT '',
 	family_id    TEXT    NOT NULL DEFAULT '',
 	expires_at   INTEGER NOT NULL,
-	revoked      INTEGER NOT NULL DEFAULT 0
+	revoked      INTEGER NOT NULL DEFAULT 0,
+	nonce        TEXT    NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_rt_family  ON refresh_tokens (family_id) WHERE revoked = 0;
 CREATE INDEX IF NOT EXISTS idx_rt_expires ON refresh_tokens (expires_at);
@@ -41,6 +42,10 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("initialising SQLite refresh token store schema: %w", err)
 	}
+	// Add nonce column to existing databases created before this field was introduced.
+	// ALTER TABLE ADD COLUMN is idempotent in SQLite when the column already exists
+	// (returns "duplicate column name" which we intentionally ignore).
+	_, _ = db.Exec(`ALTER TABLE refresh_tokens ADD COLUMN nonce TEXT NOT NULL DEFAULT ''`)
 	if path != ":memory:" {
 		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
 			slog.Warn("SQLite refresh token store chmod failed", "path", path, "err", err)
@@ -121,6 +126,26 @@ func (s *sqliteRefreshTokenStore) RevokeFamily(familyID string) error {
 		return fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
 	}
 	return nil
+}
+
+func (s *sqliteRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
+	_, err := s.db.Exec(
+		`UPDATE refresh_tokens SET nonce = ? WHERE token_hash = ? AND expires_at > ?`,
+		nonce, tokenKey(refreshToken), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving refresh token nonce: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteRefreshTokenStore) LookupNonce(refreshToken string) string {
+	var nonce string
+	_ = s.db.QueryRow(
+		`SELECT nonce FROM refresh_tokens WHERE token_hash = ? AND expires_at > ?`,
+		tokenKey(refreshToken), time.Now().Unix(),
+	).Scan(&nonce)
+	return nonce
 }
 
 func (s *sqliteRefreshTokenStore) Delete(refreshToken string) error {

--- a/internal/auth/tokenstore_sqlite_migrate.go
+++ b/internal/auth/tokenstore_sqlite_migrate.go
@@ -45,8 +45,8 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 		return fmt.Errorf("beginning migration transaction: %w", err)
 	}
 	stmt, err := tx.Prepare(
-		`INSERT OR IGNORE INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
+		`INSERT OR IGNORE INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked, nonce)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 	)
 	if err != nil {
 		_ = tx.Rollback()
@@ -60,7 +60,7 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 		if e.Revoked {
 			revokedInt = 1
 		}
-		if _, err := stmt.Exec(hash, e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt.Unix(), revokedInt); err != nil {
+		if _, err := stmt.Exec(hash, e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt.Unix(), revokedInt, e.Nonce); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("migrating refresh token entry: %w", err)
 		}

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -542,6 +542,32 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if err := rts.Sweep(); err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
+
+	// SaveNonce attaches nonce to an existing RT entry; LookupNonce returns it.
+	if err := rts.Save("rt-nonce", "access-tok-n", "", "fid-n", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-nonce: %v", err)
+	}
+	if err := rts.SaveNonce("rt-nonce", "nonce-abc"); err != nil {
+		t.Fatalf("SaveNonce: %v", err)
+	}
+	if got := rts.LookupNonce("rt-nonce"); got != "nonce-abc" {
+		t.Errorf("LookupNonce: got %q, want %q", got, "nonce-abc")
+	}
+	// LookupNonce returns "" for unknown token.
+	if got := rts.LookupNonce("no-such-rt"); got != "" {
+		t.Errorf("LookupNonce on absent: got %q, want empty", got)
+	}
+	// SaveNonce on absent token is a no-op (no error).
+	if err := rts.SaveNonce("no-such-rt", "nonce-xyz"); err != nil {
+		t.Fatalf("SaveNonce on absent returned error: %v", err)
+	}
+	// LookupNonce returns "" for expired token.
+	if err := rts.Save("rt-nonce-exp", "access-tok-exp", "", "fid-exp", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save expired rt-nonce: %v", err)
+	}
+	if got := rts.LookupNonce("rt-nonce-exp"); got != "" {
+		t.Errorf("LookupNonce on expired: got %q, want empty", got)
+	}
 }
 
 // ── memRefreshTokenStore ──────────────────────────────────────────────────────
@@ -753,10 +779,12 @@ func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, string, time.
 func (f *alwaysFailRefreshStore) LookupAny(_ string) (string, string, string, time.Time, bool, bool) {
 	return "", "", "", time.Time{}, false, false
 }
-func (f *alwaysFailRefreshStore) Revoke(_ string) error       { return nil }
-func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error { return nil }
-func (f *alwaysFailRefreshStore) Delete(_ string) error       { return errInjectedStoreFailure }
-func (f *alwaysFailRefreshStore) Sweep() error                { return nil }
+func (f *alwaysFailRefreshStore) Revoke(_ string) error          { return nil }
+func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error    { return nil }
+func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error    { return nil }
+func (f *alwaysFailRefreshStore) LookupNonce(_ string) string    { return "" }
+func (f *alwaysFailRefreshStore) Delete(_ string) error          { return errInjectedStoreFailure }
+func (f *alwaysFailRefreshStore) Sweep() error                   { return nil }
 
 // testRefreshTokenStoreReuseDetection exercises LookupAny and RevokeFamily on
 // the given RefreshTokenStore.  It is shared across in-memory and file-backed

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -73,6 +73,34 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 	if err := ts.Sweep(); err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
+
+	// SaveNonce attaches nonce to an existing entry; Lookup returns it.
+	if err := ts.Save("tok-nonce", "dave", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save tok-nonce: %v", err)
+	}
+	if err := ts.SaveNonce("tok-nonce", "nonce-abc"); err != nil {
+		t.Fatalf("SaveNonce: %v", err)
+	}
+	recN, okN := ts.Lookup("tok-nonce")
+	if !okN {
+		t.Fatal("Lookup tok-nonce: expected hit after SaveNonce")
+	}
+	if recN.Nonce != "nonce-abc" {
+		t.Errorf("SaveNonce: Nonce got %q, want %q", recN.Nonce, "nonce-abc")
+	}
+
+	// SaveNonce on absent token is a no-op (no error).
+	if err := ts.SaveNonce("no-such-token", "nonce-xyz"); err != nil {
+		t.Fatalf("SaveNonce on absent token returned error: %v", err)
+	}
+
+	// SaveNonce on expired token is a no-op (no error).
+	if err := ts.Save("tok-expired-nonce", "eve", nil, time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save expired nonce token: %v", err)
+	}
+	if err := ts.SaveNonce("tok-expired-nonce", "nonce-xyz"); err != nil {
+		t.Fatalf("SaveNonce on expired token returned error: %v", err)
+	}
 }
 
 // ── memTokenStore ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `TokenRecord` / `memEntry` / `fileEntry` に `Nonce` フィールドを追加し、access token に nonce を永続化
- `tokenAuthCode` で `CacheToken` 後に `SaveTokenNonce` を呼び出し、builtin/non-builtin 両パスで nonce を保存
- `tokenRefresh` で `LookupToken` から nonce を取得し `writeTokenResponse` に渡すことで、refresh 後の `id_token` にも元の nonce クレームを含める（OIDC Core §12.2 準拠）

## Test plan

- [x] `TestMemTokenStore` / `TestFileTokenStore`: `SaveNonce` の基本動作（保存・Lookup での返却・absent/expired 時の no-op）
- [x] `TestTokenRefreshNoncePropagated`: builtin mode で nonce あり/なし の refresh フローで id_token の nonce クレームが正しく引き継がれることを確認

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)