### PR TITLE
feat(upstreamoauth): upstream OAuth metadata discovery と Dynamic Client Registration (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Upstream OAuth metadata discovery and Dynamic Client Registration (`internal/upstreamoauth` package) ([#114](https://github.com/scottlz0310/mcp-gateway/issues/114))
+  - `DiscoverFromIssuer`: RFC 8414 one-step AS metadata fetch (`/.well-known/oauth-authorization-server{issuerPath}`)
+  - `DiscoverFromResource`: RFC 9728 → RFC 8414 two-step discovery (`/.well-known/oauth-protected-resource{path}` → AS metadata)
+  - `RegisterClient`: RFC 7591 Dynamic Client Registration (`POST registration_endpoint`); accepts 200 OK and 201 Created
+  - `ClientStore` / `fileClientStore`: JSON-backed `upstream_clients.json` with atomic write (temp+rename, mode 0600) and Windows fallback
+  - `Manager.EnsureClient`: lazy discovery + DCR on first access per route; fast-path store hit when `client_id` already registered; in-memory AS metadata cache to avoid repeated network calls per route
 - Upstream OAuth route option parsing and validation ([#113](https://github.com/scottlz0310/mcp-gateway/issues/113))
   - `Route` struct gains `UpstreamOAuth` ("auto" or absolute issuer URL) and `UpstreamOAuthScope` (space-separated scopes) fields
   - `ROUTE_*` env-var parser accepts `upstream_oauth=auto|<issuer-url>` and `upstream_oauth_scope=<scopes>`

--- a/internal/upstreamoauth/clientstore.go
+++ b/internal/upstreamoauth/clientstore.go
@@ -1,0 +1,137 @@
+package upstreamoauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// ClientRecord holds the persisted upstream OAuth client registration metadata
+// for a single gateway route.
+type ClientRecord struct {
+	RouteName             string    `json:"route_name"`
+	Issuer                string    `json:"issuer"`
+	AuthorizationEndpoint string    `json:"authorization_endpoint"`
+	TokenEndpoint         string    `json:"token_endpoint"`
+	RegistrationEndpoint  string    `json:"registration_endpoint,omitempty"`
+	ClientID              string    `json:"client_id"`
+	ClientSecret          string    `json:"client_secret,omitempty"`
+	RegisteredAt          time.Time `json:"registered_at"`
+}
+
+// ClientStore persists upstream OAuth client registration records to a
+// JSON file (upstream_clients.json). Reads and writes are safe for concurrent
+// use; writes are atomic (temp file + rename, mode 0600).
+type ClientStore interface {
+	// Load returns the ClientRecord for routeName, or (zero, false) if absent.
+	Load(routeName string) (ClientRecord, bool)
+	// Save writes or replaces the record for record.RouteName atomically.
+	Save(record ClientRecord) error
+	// All returns a snapshot of all stored records (order unspecified).
+	All() []ClientRecord
+}
+
+type fileClientStore struct {
+	mu      sync.RWMutex
+	path    string
+	records map[string]ClientRecord // keyed by RouteName
+}
+
+// NewFileClientStore loads existing records from path and returns a ClientStore.
+// If path does not exist, an empty store is returned without error.
+// The file is written with mode 0600 (owner read/write only).
+func NewFileClientStore(path string) (ClientStore, error) {
+	s := &fileClientStore{
+		path:    path,
+		records: make(map[string]ClientRecord),
+	}
+	if err := s.load(); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("loading upstream client store %q: %w", path, err)
+	}
+	return s, nil
+}
+
+func (s *fileClientStore) Load(routeName string) (ClientRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[routeName]
+	return r, ok
+}
+
+func (s *fileClientStore) Save(record ClientRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev, hadPrev := s.records[record.RouteName]
+	s.records[record.RouteName] = record
+	if err := s.flush(); err != nil {
+		if hadPrev {
+			s.records[record.RouteName] = prev
+		} else {
+			delete(s.records, record.RouteName)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *fileClientStore) All() []ClientRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ClientRecord, 0, len(s.records))
+	for _, r := range s.records {
+		out = append(out, r)
+	}
+	return out
+}
+
+func (s *fileClientStore) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, &s.records)
+}
+
+// flush writes s.records to disk atomically via temp file + rename.
+// Must be called with s.mu held for writing.
+func (s *fileClientStore) flush() error {
+	data, err := json.MarshalIndent(s.records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling upstream client store: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("writing upstream client store temp file: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err == nil {
+		return nil
+	}
+	// Windows fallback: backup the existing file, promote the temp, remove backup.
+	backup := s.path + ".bak"
+	_ = os.Remove(backup)
+	hadOriginal := false
+	if err2 := os.Rename(s.path, backup); err2 == nil {
+		hadOriginal = true
+	} else if !os.IsNotExist(err2) {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("backing up upstream client store: %w", err2)
+	}
+	if err2 := os.Rename(tmp, s.path); err2 != nil {
+		if hadOriginal {
+			if restoreErr := os.Rename(backup, s.path); restoreErr != nil {
+				return fmt.Errorf("renaming upstream client store: %w (restore failed: %v)", err2, restoreErr)
+			}
+		}
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming upstream client store: %w", err2)
+	}
+	if hadOriginal {
+		_ = os.Remove(backup)
+	}
+	return nil
+}

--- a/internal/upstreamoauth/clientstore.go
+++ b/internal/upstreamoauth/clientstore.go
@@ -3,7 +3,9 @@ package upstreamoauth
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -47,8 +49,38 @@ func NewFileClientStore(path string) (ClientStore, error) {
 		path:    path,
 		records: make(map[string]ClientRecord),
 	}
-	if err := s.load(); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("loading upstream client store %q: %w", path, err)
+	if err := s.load(); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("loading upstream client store %q: %w", path, err)
+		}
+		// File doesn't exist yet — verify the parent directory exists and is writable
+		// so the first Save doesn't fail silently at runtime.
+		dir := filepath.Dir(path)
+		info, statErr := os.Stat(dir)
+		if statErr != nil {
+			return nil, fmt.Errorf("upstream client store parent directory inaccessible %q: %w", dir, statErr)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("upstream client store parent path is not a directory %q", dir)
+		}
+		f, createErr := os.CreateTemp(dir, ".upstreamclients-writecheck-*")
+		if createErr != nil {
+			return nil, fmt.Errorf("upstream client store parent directory not writable %q: %w", dir, createErr)
+		}
+		name := f.Name()
+		if closeErr := f.Close(); closeErr != nil {
+			_ = os.Remove(name)
+			return nil, fmt.Errorf("closing upstream client store probe file in %q: %w", dir, closeErr)
+		}
+		if removeErr := os.Remove(name); removeErr != nil {
+			return nil, fmt.Errorf("removing upstream client store probe file %q: %w", name, removeErr)
+		}
+	} else {
+		// Best-effort: enforce owner-only permissions on an existing file so
+		// client_secret is protected even when the file was created with looser perms.
+		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+			slog.Warn("upstream client store chmod failed", "path", path, "err", err)
+		}
 	}
 	return s, nil
 }

--- a/internal/upstreamoauth/clientstore_test.go
+++ b/internal/upstreamoauth/clientstore_test.go
@@ -148,6 +148,14 @@ func TestFileClientStore_NonExistentFileIsOK(t *testing.T) {
 	}
 }
 
+func TestFileClientStore_ParentDirNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent-dir", "upstream_clients.json")
+	_, err := NewFileClientStore(path)
+	if err == nil {
+		t.Fatal("expected error when parent directory does not exist, got nil")
+	}
+}
+
 func TestFileClientStore_FileMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows では POSIX ファイルパーミッションは適用されない")

--- a/internal/upstreamoauth/clientstore_test.go
+++ b/internal/upstreamoauth/clientstore_test.go
@@ -1,0 +1,168 @@
+package upstreamoauth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) (ClientStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_clients.json")
+	s, err := NewFileClientStore(path)
+	if err != nil {
+		t.Fatalf("NewFileClientStore: %v", err)
+	}
+	return s, path
+}
+
+func sampleRecord(routeName string) ClientRecord {
+	return ClientRecord{
+		RouteName:             routeName,
+		Issuer:                "https://as.example.com",
+		AuthorizationEndpoint: "https://as.example.com/authorize",
+		TokenEndpoint:         "https://as.example.com/token",
+		RegistrationEndpoint:  "https://as.example.com/register",
+		ClientID:              "cid-" + routeName,
+		ClientSecret:          "secret-" + routeName,
+		RegisteredAt:          time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func TestFileClientStore_SaveAndLoad(t *testing.T) {
+	s, _ := newTestStore(t)
+	rec := sampleRecord("route-a")
+
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, ok := s.Load("route-a")
+	if !ok {
+		t.Fatal("Load: expected record, got not-found")
+	}
+	if got.ClientID != rec.ClientID {
+		t.Errorf("ClientID: got %q, want %q", got.ClientID, rec.ClientID)
+	}
+}
+
+func TestFileClientStore_LoadAbsent(t *testing.T) {
+	s, _ := newTestStore(t)
+	_, ok := s.Load("nonexistent")
+	if ok {
+		t.Fatal("Load: expected not-found for absent key, got found")
+	}
+}
+
+func TestFileClientStore_Persistence(t *testing.T) {
+	_, path := newTestStore(t)
+	rec := sampleRecord("route-b")
+
+	s1, err := NewFileClientStore(path)
+	if err != nil {
+		t.Fatalf("NewFileClientStore (first): %v", err)
+	}
+	if err := s1.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// 別インスタンスで同じファイルを開き直す
+	s2, err := NewFileClientStore(path)
+	if err != nil {
+		t.Fatalf("NewFileClientStore (second): %v", err)
+	}
+	got, ok := s2.Load("route-b")
+	if !ok {
+		t.Fatal("Load (second instance): expected record, got not-found")
+	}
+	if got.ClientID != rec.ClientID {
+		t.Errorf("ClientID: got %q, want %q", got.ClientID, rec.ClientID)
+	}
+}
+
+func TestFileClientStore_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_clients.json")
+	// 空ファイルを事前作成
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s, err := NewFileClientStore(path)
+	if err != nil {
+		t.Fatalf("NewFileClientStore with empty file: %v", err)
+	}
+	if all := s.All(); len(all) != 0 {
+		t.Errorf("expected 0 records from empty file, got %d", len(all))
+	}
+}
+
+func TestFileClientStore_All(t *testing.T) {
+	s, _ := newTestStore(t)
+	routes := []string{"route-x", "route-y", "route-z"}
+	for _, r := range routes {
+		if err := s.Save(sampleRecord(r)); err != nil {
+			t.Fatalf("Save(%q): %v", r, err)
+		}
+	}
+
+	all := s.All()
+	if len(all) != len(routes) {
+		t.Errorf("All(): got %d records, want %d", len(all), len(routes))
+	}
+}
+
+func TestFileClientStore_SaveUpdatesExisting(t *testing.T) {
+	s, _ := newTestStore(t)
+	rec := sampleRecord("route-update")
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save (initial): %v", err)
+	}
+
+	rec.ClientID = "new-client-id"
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save (update): %v", err)
+	}
+
+	got, ok := s.Load("route-update")
+	if !ok {
+		t.Fatal("Load: expected record after update")
+	}
+	if got.ClientID != "new-client-id" {
+		t.Errorf("ClientID after update: got %q, want %q", got.ClientID, "new-client-id")
+	}
+}
+
+func TestFileClientStore_NonExistentFileIsOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does_not_exist.json")
+	s, err := NewFileClientStore(path)
+	if err != nil {
+		t.Fatalf("NewFileClientStore with non-existent file: %v", err)
+	}
+	if all := s.All(); len(all) != 0 {
+		t.Errorf("expected 0 records, got %d", len(all))
+	}
+}
+
+func TestFileClientStore_FileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows では POSIX ファイルパーミッションは適用されない")
+	}
+	s, path := newTestStore(t)
+	if err := s.Save(sampleRecord("route-mode")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0o077 != 0 {
+		t.Errorf("file permissions %o are too permissive (want 0600)", perm)
+	}
+}

--- a/internal/upstreamoauth/dcr.go
+++ b/internal/upstreamoauth/dcr.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 )
 
 // DCRRequest is the RFC 7591 §2 client metadata registration request body.
@@ -47,7 +49,8 @@ func RegisterClient(ctx context.Context, client *http.Client, registrationEndpoi
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("DCR at %s: unexpected status %d", registrationEndpoint, resp.StatusCode)
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("DCR at %s: unexpected status %d: %s", registrationEndpoint, resp.StatusCode, strings.TrimSpace(string(snippet)))
 	}
 	var dcrResp DCRResponse
 	if err := json.NewDecoder(resp.Body).Decode(&dcrResp); err != nil {

--- a/internal/upstreamoauth/dcr.go
+++ b/internal/upstreamoauth/dcr.go
@@ -1,0 +1,60 @@
+package upstreamoauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// DCRRequest is the RFC 7591 §2 client metadata registration request body.
+type DCRRequest struct {
+	RedirectURIs            []string `json:"redirect_uris"`
+	ClientName              string   `json:"client_name,omitempty"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+// DCRResponse is the RFC 7591 §3.2.1 client information response.
+type DCRResponse struct {
+	ClientID              string `json:"client_id"`
+	ClientSecret          string `json:"client_secret,omitempty"`
+	ClientIDIssuedAt      int64  `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt int64  `json:"client_secret_expires_at,omitempty"`
+}
+
+// RegisterClient performs RFC 7591 Dynamic Client Registration by posting req
+// to registrationEndpoint. Both 200 OK and 201 Created are accepted per
+// common server implementations.
+func RegisterClient(ctx context.Context, client *http.Client, registrationEndpoint string, req DCRRequest) (*DCRResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DCR request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating DCR request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", registrationEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("DCR at %s: unexpected status %d", registrationEndpoint, resp.StatusCode)
+	}
+	var dcrResp DCRResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dcrResp); err != nil {
+		return nil, fmt.Errorf("decoding DCR response from %s: %w", registrationEndpoint, err)
+	}
+	if dcrResp.ClientID == "" {
+		return nil, fmt.Errorf("DCR response from %s missing required client_id", registrationEndpoint)
+	}
+	return &dcrResp, nil
+}

--- a/internal/upstreamoauth/dcr.go
+++ b/internal/upstreamoauth/dcr.go
@@ -44,7 +44,7 @@ func RegisterClient(ctx context.Context, client *http.Client, registrationEndpoi
 	if err != nil {
 		return nil, fmt.Errorf("POST %s: %w", registrationEndpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("DCR at %s: unexpected status %d", registrationEndpoint, resp.StatusCode)

--- a/internal/upstreamoauth/dcr_test.go
+++ b/internal/upstreamoauth/dcr_test.go
@@ -65,7 +65,7 @@ func TestRegisterClient_200OK(t *testing.T) {
 
 func TestRegisterClient_Non2xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "bad request", http.StatusBadRequest)
+		http.Error(w, "invalid_redirect_uri", http.StatusBadRequest)
 	}))
 	defer srv.Close()
 
@@ -74,6 +74,10 @@ func TestRegisterClient_Non2xx(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for non-2xx response, got nil")
+	}
+	// レスポンスボディがエラーメッセージに含まれること
+	if errMsg := err.Error(); len(errMsg) == 0 {
+		t.Error("error message should not be empty")
 	}
 }
 

--- a/internal/upstreamoauth/dcr_test.go
+++ b/internal/upstreamoauth/dcr_test.go
@@ -1,0 +1,110 @@
+package upstreamoauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterClient_201Created(t *testing.T) {
+	want := DCRResponse{
+		ClientID:     "client-id-abc",
+		ClientSecret: "secret-xyz",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	req := DCRRequest{
+		RedirectURIs:            []string{"https://gateway.example.com/callback"},
+		ClientName:              "mcp-gateway/test-route",
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+	}
+	got, err := RegisterClient(context.Background(), srv.Client(), srv.URL+"/register", req)
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+	if got.ClientID != want.ClientID {
+		t.Errorf("ClientID: got %q, want %q", got.ClientID, want.ClientID)
+	}
+	if got.ClientSecret != want.ClientSecret {
+		t.Errorf("ClientSecret: got %q, want %q", got.ClientSecret, want.ClientSecret)
+	}
+}
+
+func TestRegisterClient_200OK(t *testing.T) {
+	want := DCRResponse{ClientID: "cid-200"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	got, err := RegisterClient(context.Background(), srv.Client(), srv.URL+"/register", DCRRequest{
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+	if got.ClientID != want.ClientID {
+		t.Errorf("ClientID: got %q, want %q", got.ClientID, want.ClientID)
+	}
+}
+
+func TestRegisterClient_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, err := RegisterClient(context.Background(), srv.Client(), srv.URL+"/register", DCRRequest{
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-2xx response, got nil")
+	}
+}
+
+func TestRegisterClient_MissingClientID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		// client_id が欠落したレスポンス
+		_ = json.NewEncoder(w).Encode(map[string]string{"client_secret": "secret"})
+	}))
+	defer srv.Close()
+
+	_, err := RegisterClient(context.Background(), srv.Client(), srv.URL+"/register", DCRRequest{
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing client_id, got nil")
+	}
+}
+
+func TestRegisterClient_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := RegisterClient(context.Background(), srv.Client(), srv.URL+"/register", DCRRequest{
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}

--- a/internal/upstreamoauth/discovery.go
+++ b/internal/upstreamoauth/discovery.go
@@ -1,0 +1,130 @@
+package upstreamoauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// AuthServerMetadata は RFC 8414 §3.2 Authorization Server Metadata。
+// 必須フィールド + DCR に必要なフィールドのみ定義する。
+type AuthServerMetadata struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	RegistrationEndpoint          string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported               []string `json:"scopes_supported,omitempty"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+}
+
+// ProtectedResourceMetadata は RFC 9728 §3 Protected Resource Metadata。
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// DefaultHTTPTimeout is the timeout applied to each discovery HTTP request.
+const DefaultHTTPTimeout = 10 * time.Second
+
+// DiscoverFromIssuer retrieves RFC 8414 Authorization Server Metadata for
+// the given issuer URL. issuerURL must be a normalized absolute URL without
+// a trailing slash.
+func DiscoverFromIssuer(ctx context.Context, client *http.Client, issuerURL string) (*AuthServerMetadata, error) {
+	wellKnownURL, err := buildASMetaURL(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("building AS metadata URL for %q: %w", issuerURL, err)
+	}
+	meta, err := fetchJSON[AuthServerMetadata](ctx, client, wellKnownURL)
+	if err != nil {
+		return nil, fmt.Errorf("AS metadata discovery for %q: %w", issuerURL, err)
+	}
+	if meta.Issuer == "" || meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
+		return nil, fmt.Errorf("AS metadata from %q is missing required fields (issuer/authorization_endpoint/token_endpoint)", wellKnownURL)
+	}
+	return meta, nil
+}
+
+// DiscoverFromResource performs RFC 9728 → RFC 8414 two-step discovery using
+// the upstream resource URL. resourceURL is the upstream host+path the gateway
+// routes to (e.g. "https://mcp.example.com/sse").
+func DiscoverFromResource(ctx context.Context, client *http.Client, resourceURL string) (*AuthServerMetadata, error) {
+	prmURL, err := buildPRMURL(resourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("building PRM URL for %q: %w", resourceURL, err)
+	}
+	prm, err := fetchJSON[ProtectedResourceMetadata](ctx, client, prmURL)
+	if err != nil {
+		return nil, fmt.Errorf("PRM discovery at %q: %w", prmURL, err)
+	}
+	if len(prm.AuthorizationServers) == 0 {
+		return nil, fmt.Errorf("PRM at %q contains no authorization_servers", prmURL)
+	}
+	issuerURL := strings.TrimRight(prm.AuthorizationServers[0], "/")
+	meta, err := DiscoverFromIssuer(ctx, client, issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("AS metadata discovery (via PRM %q): %w", prmURL, err)
+	}
+	return meta, nil
+}
+
+// buildPRMURL constructs the RFC 9728 §3 well-known PRM URL:
+//
+//	{scheme}://{host}/.well-known/oauth-protected-resource{path}
+func buildPRMURL(resourceURL string) (string, error) {
+	u, err := url.Parse(resourceURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing resource URL: %w", err)
+	}
+	path := strings.TrimRight(u.Path, "/")
+	out := *u
+	out.Path = "/.well-known/oauth-protected-resource" + path
+	out.RawQuery = ""
+	out.Fragment = ""
+	return out.String(), nil
+}
+
+// buildASMetaURL constructs the RFC 8414 §3.1 well-known URL by inserting
+// "/.well-known/" between the host component and the path component of the
+// issuer identifier.
+//
+//	issuer = "https://example.com"           → "https://example.com/.well-known/oauth-authorization-server"
+//	issuer = "https://example.com/tenant1"   → "https://example.com/.well-known/oauth-authorization-server/tenant1"
+func buildASMetaURL(issuerURL string) (string, error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing issuer URL: %w", err)
+	}
+	issuerPath := strings.TrimRight(u.Path, "/")
+	out := *u
+	out.Path = "/.well-known/oauth-authorization-server" + issuerPath
+	out.RawQuery = ""
+	out.Fragment = ""
+	return out.String(), nil
+}
+
+// fetchJSON performs an HTTP GET to rawURL and JSON-decodes the response body
+// into a value of type T. Non-200 responses are returned as errors.
+func fetchJSON[T any](ctx context.Context, client *http.Client, rawURL string) (*T, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", rawURL, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: unexpected status %d", rawURL, resp.StatusCode)
+	}
+	var result T
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response from %s: %w", rawURL, err)
+	}
+	return &result, nil
+}

--- a/internal/upstreamoauth/discovery.go
+++ b/internal/upstreamoauth/discovery.go
@@ -118,7 +118,7 @@ func fetchJSON[T any](ctx context.Context, client *http.Client, rawURL string) (
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: unexpected status %d", rawURL, resp.StatusCode)
 	}

--- a/internal/upstreamoauth/discovery.go
+++ b/internal/upstreamoauth/discovery.go
@@ -31,8 +31,8 @@ type ProtectedResourceMetadata struct {
 const DefaultHTTPTimeout = 10 * time.Second
 
 // DiscoverFromIssuer retrieves RFC 8414 Authorization Server Metadata for
-// the given issuer URL. issuerURL must be a normalized absolute URL without
-// a trailing slash.
+// the given issuer URL. A trailing slash in issuerURL is trimmed automatically.
+// The response issuer is validated to match issuerURL per RFC 8414 §3.3.
 func DiscoverFromIssuer(ctx context.Context, client *http.Client, issuerURL string) (*AuthServerMetadata, error) {
 	wellKnownURL, err := buildASMetaURL(issuerURL)
 	if err != nil {
@@ -44,6 +44,10 @@ func DiscoverFromIssuer(ctx context.Context, client *http.Client, issuerURL stri
 	}
 	if meta.Issuer == "" || meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
 		return nil, fmt.Errorf("AS metadata from %q is missing required fields (issuer/authorization_endpoint/token_endpoint)", wellKnownURL)
+	}
+	// RFC 8414 §3.3: the issuer in the response MUST be identical to the issuer used to build the well-known URL.
+	if strings.TrimRight(meta.Issuer, "/") != strings.TrimRight(issuerURL, "/") {
+		return nil, fmt.Errorf("AS metadata issuer %q does not match requested issuer %q", meta.Issuer, issuerURL)
 	}
 	return meta, nil
 }
@@ -59,6 +63,10 @@ func DiscoverFromResource(ctx context.Context, client *http.Client, resourceURL 
 	prm, err := fetchJSON[ProtectedResourceMetadata](ctx, client, prmURL)
 	if err != nil {
 		return nil, fmt.Errorf("PRM discovery at %q: %w", prmURL, err)
+	}
+	// RFC 9728 §4: the resource in the PRM response MUST match the resource identifier used to build the PRM URL.
+	if strings.TrimRight(prm.Resource, "/") != strings.TrimRight(resourceURL, "/") {
+		return nil, fmt.Errorf("PRM resource %q does not match requested resource %q", prm.Resource, resourceURL)
 	}
 	if len(prm.AuthorizationServers) == 0 {
 		return nil, fmt.Errorf("PRM at %q contains no authorization_servers", prmURL)
@@ -79,6 +87,9 @@ func buildPRMURL(resourceURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parsing resource URL: %w", err)
 	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("resource URL %q must be an absolute URL with scheme and host", resourceURL)
+	}
 	path := strings.TrimRight(u.Path, "/")
 	out := *u
 	out.Path = "/.well-known/oauth-protected-resource" + path
@@ -97,6 +108,9 @@ func buildASMetaURL(issuerURL string) (string, error) {
 	u, err := url.Parse(issuerURL)
 	if err != nil {
 		return "", fmt.Errorf("parsing issuer URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("issuer URL %q must be an absolute URL with scheme and host", issuerURL)
 	}
 	issuerPath := strings.TrimRight(u.Path, "/")
 	out := *u

--- a/internal/upstreamoauth/discovery_test.go
+++ b/internal/upstreamoauth/discovery_test.go
@@ -1,0 +1,196 @@
+package upstreamoauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildPRMURL(t *testing.T) {
+	tests := []struct {
+		resourceURL string
+		want        string
+	}{
+		{"https://mcp.example.com/sse", "https://mcp.example.com/.well-known/oauth-protected-resource/sse"},
+		{"https://mcp.example.com/", "https://mcp.example.com/.well-known/oauth-protected-resource"},
+		{"https://mcp.example.com", "https://mcp.example.com/.well-known/oauth-protected-resource"},
+		{"https://mcp.example.com/v1/mcp", "https://mcp.example.com/.well-known/oauth-protected-resource/v1/mcp"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.resourceURL, func(t *testing.T) {
+			got, err := buildPRMURL(tc.resourceURL)
+			if err != nil {
+				t.Fatalf("buildPRMURL: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildASMetaURL(t *testing.T) {
+	tests := []struct {
+		issuerURL string
+		want      string
+	}{
+		{"https://example.com", "https://example.com/.well-known/oauth-authorization-server"},
+		{"https://example.com/", "https://example.com/.well-known/oauth-authorization-server"},
+		{"https://example.com/tenant1", "https://example.com/.well-known/oauth-authorization-server/tenant1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.issuerURL, func(t *testing.T) {
+			got, err := buildASMetaURL(tc.issuerURL)
+			if err != nil {
+				t.Fatalf("buildASMetaURL: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverFromIssuer(t *testing.T) {
+	asMeta := AuthServerMetadata{
+		Issuer:                "https://as.example.com",
+		AuthorizationEndpoint: "https://as.example.com/authorize",
+		TokenEndpoint:         "https://as.example.com/token",
+		RegistrationEndpoint:  "https://as.example.com/register",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(asMeta)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	meta, err := DiscoverFromIssuer(context.Background(), client, srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverFromIssuer: %v", err)
+	}
+	if meta.Issuer != asMeta.Issuer {
+		t.Errorf("Issuer: got %q, want %q", meta.Issuer, asMeta.Issuer)
+	}
+	if meta.RegistrationEndpoint != asMeta.RegistrationEndpoint {
+		t.Errorf("RegistrationEndpoint: got %q, want %q", meta.RegistrationEndpoint, asMeta.RegistrationEndpoint)
+	}
+}
+
+func TestDiscoverFromIssuer_MissingRequiredFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// issuer のみ — authorization_endpoint と token_endpoint が欠落
+		_ = json.NewEncoder(w).Encode(map[string]string{"issuer": "https://as.example.com"})
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromIssuer(context.Background(), srv.Client(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for missing required fields, got nil")
+	}
+}
+
+func TestDiscoverFromIssuer_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromIssuer(context.Background(), srv.Client(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for non-200 response, got nil")
+	}
+}
+
+func TestDiscoverFromIssuer_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromIssuer(context.Background(), srv.Client(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestDiscoverFromResource_TwoStep(t *testing.T) {
+	// asSrv: RFC 8414 Authorization Server Metadata endpoint
+	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// asSrv.URL is not accessible here (closure issue) so we hardcode stable fields.
+		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+			Issuer:                "https://as.example.com",
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			TokenEndpoint:         "https://as.example.com/token",
+			RegistrationEndpoint:  "https://as.example.com/register",
+		})
+	}))
+	defer asSrv.Close()
+
+	// prmSrv: RFC 9728 Protected Resource Metadata endpoint → points to asSrv
+	var prmSrv *httptest.Server
+	prmSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-protected-resource/sse" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             prmSrv.URL + "/sse",
+			AuthorizationServers: []string{asSrv.URL},
+		})
+	}))
+	defer prmSrv.Close()
+
+	meta, err := DiscoverFromResource(context.Background(), prmSrv.Client(), prmSrv.URL+"/sse")
+	if err != nil {
+		t.Fatalf("DiscoverFromResource: %v", err)
+	}
+	if meta.AuthorizationEndpoint != "https://as.example.com/authorize" {
+		t.Errorf("AuthorizationEndpoint: got %q", meta.AuthorizationEndpoint)
+	}
+	if meta.RegistrationEndpoint != "https://as.example.com/register" {
+		t.Errorf("RegistrationEndpoint: got %q", meta.RegistrationEndpoint)
+	}
+}
+
+func TestDiscoverFromResource_NoAuthServers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             "https://mcp.example.com/sse",
+			AuthorizationServers: []string{},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromResource(context.Background(), srv.Client(), srv.URL+"/sse")
+	if err == nil {
+		t.Fatal("expected error for empty authorization_servers, got nil")
+	}
+}
+
+func TestDiscoverFromResource_PRMFetchFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromResource(context.Background(), srv.Client(), srv.URL+"/sse")
+	if err == nil {
+		t.Fatal("expected error for PRM fetch failure, got nil")
+	}
+}

--- a/internal/upstreamoauth/discovery_test.go
+++ b/internal/upstreamoauth/discovery_test.go
@@ -31,6 +31,13 @@ func TestBuildPRMURL(t *testing.T) {
 	}
 }
 
+func TestBuildPRMURL_NonAbsolute(t *testing.T) {
+	_, err := buildPRMURL("/sse")
+	if err == nil {
+		t.Fatal("expected error for non-absolute URL, got nil")
+	}
+}
+
 func TestBuildASMetaURL(t *testing.T) {
 	tests := []struct {
 		issuerURL string
@@ -53,33 +60,40 @@ func TestBuildASMetaURL(t *testing.T) {
 	}
 }
 
-func TestDiscoverFromIssuer(t *testing.T) {
-	asMeta := AuthServerMetadata{
-		Issuer:                "https://as.example.com",
-		AuthorizationEndpoint: "https://as.example.com/authorize",
-		TokenEndpoint:         "https://as.example.com/token",
-		RegistrationEndpoint:  "https://as.example.com/register",
+func TestBuildASMetaURL_NonAbsolute(t *testing.T) {
+	_, err := buildASMetaURL("/tenant1")
+	if err == nil {
+		t.Fatal("expected error for non-absolute issuer URL, got nil")
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+}
+
+func TestDiscoverFromIssuer(t *testing.T) {
+	// var 宣言後に代入することでクロージャ内でサーバー URL を issuer として使用できる（RFC 8414 §3.3 issuer 検証に対応）。
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/oauth-authorization-server" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(asMeta)
+		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+			Issuer:                srv.URL,
+			AuthorizationEndpoint: srv.URL + "/authorize",
+			TokenEndpoint:         srv.URL + "/token",
+			RegistrationEndpoint:  srv.URL + "/register",
+		})
 	}))
 	defer srv.Close()
 
-	client := srv.Client()
-	meta, err := DiscoverFromIssuer(context.Background(), client, srv.URL)
+	meta, err := DiscoverFromIssuer(context.Background(), srv.Client(), srv.URL)
 	if err != nil {
 		t.Fatalf("DiscoverFromIssuer: %v", err)
 	}
-	if meta.Issuer != asMeta.Issuer {
-		t.Errorf("Issuer: got %q, want %q", meta.Issuer, asMeta.Issuer)
+	if meta.Issuer != srv.URL {
+		t.Errorf("Issuer: got %q, want %q", meta.Issuer, srv.URL)
 	}
-	if meta.RegistrationEndpoint != asMeta.RegistrationEndpoint {
-		t.Errorf("RegistrationEndpoint: got %q, want %q", meta.RegistrationEndpoint, asMeta.RegistrationEndpoint)
+	if meta.RegistrationEndpoint != srv.URL+"/register" {
+		t.Errorf("RegistrationEndpoint: got %q, want %q", meta.RegistrationEndpoint, srv.URL+"/register")
 	}
 }
 
@@ -122,20 +136,39 @@ func TestDiscoverFromIssuer_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestDiscoverFromIssuer_IssuerMismatch(t *testing.T) {
+	// RFC 8414 §3.3: issuer in response must match requested issuer
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+			Issuer:                "https://different-as.example.com", // mismatch
+			AuthorizationEndpoint: "https://different-as.example.com/authorize",
+			TokenEndpoint:         "https://different-as.example.com/token",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromIssuer(context.Background(), srv.Client(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error for issuer mismatch, got nil")
+	}
+}
+
 func TestDiscoverFromResource_TwoStep(t *testing.T) {
-	// asSrv: RFC 8414 Authorization Server Metadata endpoint
-	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// asSrv: RFC 8414 Authorization Server Metadata endpoint.
+	// var 宣言後に代入することで issuer を asSrv.URL に一致させる（RFC 8414 §3.3 issuer 検証に対応）。
+	var asSrv *httptest.Server
+	asSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/oauth-authorization-server" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		// asSrv.URL is not accessible here (closure issue) so we hardcode stable fields.
 		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
-			Issuer:                "https://as.example.com",
-			AuthorizationEndpoint: "https://as.example.com/authorize",
-			TokenEndpoint:         "https://as.example.com/token",
-			RegistrationEndpoint:  "https://as.example.com/register",
+			Issuer:                asSrv.URL,
+			AuthorizationEndpoint: asSrv.URL + "/authorize",
+			TokenEndpoint:         asSrv.URL + "/token",
+			RegistrationEndpoint:  asSrv.URL + "/register",
 		})
 	}))
 	defer asSrv.Close()
@@ -159,19 +192,20 @@ func TestDiscoverFromResource_TwoStep(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverFromResource: %v", err)
 	}
-	if meta.AuthorizationEndpoint != "https://as.example.com/authorize" {
-		t.Errorf("AuthorizationEndpoint: got %q", meta.AuthorizationEndpoint)
+	if meta.AuthorizationEndpoint != asSrv.URL+"/authorize" {
+		t.Errorf("AuthorizationEndpoint: got %q, want %q", meta.AuthorizationEndpoint, asSrv.URL+"/authorize")
 	}
-	if meta.RegistrationEndpoint != "https://as.example.com/register" {
-		t.Errorf("RegistrationEndpoint: got %q", meta.RegistrationEndpoint)
+	if meta.RegistrationEndpoint != asSrv.URL+"/register" {
+		t.Errorf("RegistrationEndpoint: got %q, want %q", meta.RegistrationEndpoint, asSrv.URL+"/register")
 	}
 }
 
 func TestDiscoverFromResource_NoAuthServers(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
-			Resource:             "https://mcp.example.com/sse",
+			Resource:             srv.URL + "/sse", // resource 一致させて authorization_servers チェックまで到達させる
 			AuthorizationServers: []string{},
 		})
 	}))
@@ -180,6 +214,24 @@ func TestDiscoverFromResource_NoAuthServers(t *testing.T) {
 	_, err := DiscoverFromResource(context.Background(), srv.Client(), srv.URL+"/sse")
 	if err == nil {
 		t.Fatal("expected error for empty authorization_servers, got nil")
+	}
+}
+
+func TestDiscoverFromResource_ResourceMismatch(t *testing.T) {
+	// RFC 9728 §4: PRM resource must match the requested resource identifier
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             "https://different-resource.example.com/sse", // mismatch
+			AuthorizationServers: []string{srv.URL},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverFromResource(context.Background(), srv.Client(), srv.URL+"/sse")
+	if err == nil {
+		t.Fatal("expected error for resource mismatch, got nil")
 	}
 }
 

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -1,0 +1,117 @@
+package upstreamoauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Manager orchestrates upstream OAuth metadata discovery and Dynamic Client
+// Registration for gateway routes that have UpstreamOAuth configured.
+//
+// Discovery is performed lazily on the first EnsureClient call for each route;
+// the result is cached in memory so subsequent calls skip the network round-trip.
+// DCR is skipped when a ClientRecord with a non-empty ClientID already exists
+// in the ClientStore (loaded from disk on startup).
+type Manager struct {
+	store      ClientStore
+	httpClient *http.Client
+	publicURL  string // gateway public base URL for redirect_uri construction
+
+	mu    sync.RWMutex
+	cache map[string]*AuthServerMetadata // keyed by route name
+}
+
+// NewManager creates a Manager backed by store. publicURL is the gateway's
+// canonical base URL (e.g. "https://gateway.example.com"); it is used to
+// construct the redirect_uri sent during DCR.
+func NewManager(store ClientStore, publicURL string) *Manager {
+	return &Manager{
+		store:      store,
+		httpClient: &http.Client{Timeout: DefaultHTTPTimeout},
+		publicURL:  strings.TrimRight(publicURL, "/"),
+		cache:      make(map[string]*AuthServerMetadata),
+	}
+}
+
+// EnsureClient returns the ClientRecord for routeName, performing discovery
+// and DCR if no valid registration exists yet.
+//
+//   - upstreamOAuth: "auto" (RFC 9728 + RFC 8414 two-step) or an absolute
+//     issuer URL (RFC 8414 one-step).
+//   - resourceURL: the upstream URL for "auto" discovery (e.g.
+//     "https://mcp.example.com/sse"). Ignored when upstreamOAuth is an issuer URL.
+func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, resourceURL string) (ClientRecord, error) {
+	if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
+		return rec, nil
+	}
+
+	meta, err := m.discoverCached(ctx, routeName, upstreamOAuth, resourceURL)
+	if err != nil {
+		return ClientRecord{}, fmt.Errorf("upstream OAuth discovery for route %q: %w", routeName, err)
+	}
+
+	if meta.RegistrationEndpoint == "" {
+		return ClientRecord{}, fmt.Errorf("upstream AS for route %q does not expose a registration_endpoint; Dynamic Client Registration is required", routeName)
+	}
+
+	redirectURI := m.publicURL + "/upstream/callback/" + routeName
+	dcrReq := DCRRequest{
+		RedirectURIs:            []string{redirectURI},
+		ClientName:              "mcp-gateway/" + routeName,
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+	}
+	dcrResp, err := RegisterClient(ctx, m.httpClient, meta.RegistrationEndpoint, dcrReq)
+	if err != nil {
+		return ClientRecord{}, fmt.Errorf("Dynamic Client Registration for route %q: %w", routeName, err)
+	}
+
+	record := ClientRecord{
+		RouteName:             routeName,
+		Issuer:                meta.Issuer,
+		AuthorizationEndpoint: meta.AuthorizationEndpoint,
+		TokenEndpoint:         meta.TokenEndpoint,
+		RegistrationEndpoint:  meta.RegistrationEndpoint,
+		ClientID:              dcrResp.ClientID,
+		ClientSecret:          dcrResp.ClientSecret,
+		RegisteredAt:          time.Now().UTC(),
+	}
+	if err := m.store.Save(record); err != nil {
+		slog.Warn("upstream client store save failed; DCR result will not survive restart",
+			"route", routeName, "err", err)
+	}
+	return record, nil
+}
+
+// discoverCached returns AS metadata for routeName, using the in-memory
+// cache to avoid repeated network calls for the same route.
+func (m *Manager) discoverCached(ctx context.Context, routeName, upstreamOAuth, resourceURL string) (*AuthServerMetadata, error) {
+	m.mu.RLock()
+	cached, ok := m.cache[routeName]
+	m.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	var meta *AuthServerMetadata
+	var err error
+	if strings.EqualFold(upstreamOAuth, "auto") {
+		meta, err = DiscoverFromResource(ctx, m.httpClient, resourceURL)
+	} else {
+		meta, err = DiscoverFromIssuer(ctx, m.httpClient, upstreamOAuth)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	m.cache[routeName] = meta
+	m.mu.Unlock()
+	return meta, nil
+}

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -69,7 +69,7 @@ func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, re
 	}
 	dcrResp, err := RegisterClient(ctx, m.httpClient, meta.RegistrationEndpoint, dcrReq)
 	if err != nil {
-		return ClientRecord{}, fmt.Errorf("Dynamic Client Registration for route %q: %w", routeName, err)
+		return ClientRecord{}, fmt.Errorf("dynamic client registration for route %q: %w", routeName, err)
 	}
 
 	record := ClientRecord{

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -3,11 +3,13 @@ package upstreamoauth
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // Manager orchestrates upstream OAuth metadata discovery and Dynamic Client
@@ -17,13 +19,18 @@ import (
 // the result is cached in memory so subsequent calls skip the network round-trip.
 // DCR is skipped when a ClientRecord with a non-empty ClientID already exists
 // in the ClientStore (loaded from disk on startup).
+//
+// Concurrent EnsureClient calls for the same route are serialised via a
+// singleflight.Group so that only one discovery + DCR + store.Save sequence
+// executes regardless of how many goroutines race on the first access.
 type Manager struct {
 	store      ClientStore
 	httpClient *http.Client
 	publicURL  string // gateway public base URL for redirect_uri construction
 
-	mu    sync.RWMutex
-	cache map[string]*AuthServerMetadata // keyed by route name
+	mu      sync.RWMutex
+	cache   map[string]*AuthServerMetadata // keyed by route name
+	sfGroup singleflight.Group
 }
 
 // NewManager creates a Manager backed by store. publicURL is the gateway's
@@ -45,48 +52,63 @@ func NewManager(store ClientStore, publicURL string) *Manager {
 //     issuer URL (RFC 8414 one-step).
 //   - resourceURL: the upstream URL for "auto" discovery (e.g.
 //     "https://mcp.example.com/sse"). Ignored when upstreamOAuth is an issuer URL.
+//
+// Concurrent calls for the same routeName are coalesced via singleflight so
+// that discovery + DCR + store.Save only executes once.
 func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, resourceURL string) (ClientRecord, error) {
 	if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
 		return rec, nil
 	}
 
-	meta, err := m.discoverCached(ctx, routeName, upstreamOAuth, resourceURL)
+	type sfResult struct{ record ClientRecord }
+	v, err, _ := m.sfGroup.Do(routeName, func() (any, error) {
+		// Re-check inside the singleflight critical section so that the follower
+		// goroutines skip DCR when the leader already persisted the record.
+		if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
+			return sfResult{record: rec}, nil
+		}
+
+		meta, err := m.discoverCached(ctx, routeName, upstreamOAuth, resourceURL)
+		if err != nil {
+			return nil, fmt.Errorf("upstream OAuth discovery for route %q: %w", routeName, err)
+		}
+
+		if meta.RegistrationEndpoint == "" {
+			return nil, fmt.Errorf("upstream AS for route %q does not expose a registration_endpoint; Dynamic Client Registration is required", routeName)
+		}
+
+		redirectURI := m.publicURL + "/upstream/callback/" + url.PathEscape(routeName)
+		dcrReq := DCRRequest{
+			RedirectURIs:            []string{redirectURI},
+			ClientName:              "mcp-gateway/" + routeName,
+			GrantTypes:              []string{"authorization_code"},
+			ResponseTypes:           []string{"code"},
+			TokenEndpointAuthMethod: "client_secret_basic",
+		}
+		dcrResp, err := RegisterClient(ctx, m.httpClient, meta.RegistrationEndpoint, dcrReq)
+		if err != nil {
+			return nil, fmt.Errorf("dynamic client registration for route %q: %w", routeName, err)
+		}
+
+		record := ClientRecord{
+			RouteName:             routeName,
+			Issuer:                meta.Issuer,
+			AuthorizationEndpoint: meta.AuthorizationEndpoint,
+			TokenEndpoint:         meta.TokenEndpoint,
+			RegistrationEndpoint:  meta.RegistrationEndpoint,
+			ClientID:              dcrResp.ClientID,
+			ClientSecret:          dcrResp.ClientSecret,
+			RegisteredAt:          time.Now().UTC(),
+		}
+		if err := m.store.Save(record); err != nil {
+			return nil, fmt.Errorf("saving upstream client for route %q: %w", routeName, err)
+		}
+		return sfResult{record: record}, nil
+	})
 	if err != nil {
-		return ClientRecord{}, fmt.Errorf("upstream OAuth discovery for route %q: %w", routeName, err)
+		return ClientRecord{}, err
 	}
-
-	if meta.RegistrationEndpoint == "" {
-		return ClientRecord{}, fmt.Errorf("upstream AS for route %q does not expose a registration_endpoint; Dynamic Client Registration is required", routeName)
-	}
-
-	redirectURI := m.publicURL + "/upstream/callback/" + routeName
-	dcrReq := DCRRequest{
-		RedirectURIs:            []string{redirectURI},
-		ClientName:              "mcp-gateway/" + routeName,
-		GrantTypes:              []string{"authorization_code"},
-		ResponseTypes:           []string{"code"},
-		TokenEndpointAuthMethod: "client_secret_basic",
-	}
-	dcrResp, err := RegisterClient(ctx, m.httpClient, meta.RegistrationEndpoint, dcrReq)
-	if err != nil {
-		return ClientRecord{}, fmt.Errorf("dynamic client registration for route %q: %w", routeName, err)
-	}
-
-	record := ClientRecord{
-		RouteName:             routeName,
-		Issuer:                meta.Issuer,
-		AuthorizationEndpoint: meta.AuthorizationEndpoint,
-		TokenEndpoint:         meta.TokenEndpoint,
-		RegistrationEndpoint:  meta.RegistrationEndpoint,
-		ClientID:              dcrResp.ClientID,
-		ClientSecret:          dcrResp.ClientSecret,
-		RegisteredAt:          time.Now().UTC(),
-	}
-	if err := m.store.Save(record); err != nil {
-		slog.Warn("upstream client store save failed; DCR result will not survive restart",
-			"route", routeName, "err", err)
-	}
-	return record, nil
+	return v.(sfResult).record, nil
 }
 
 // discoverCached returns AS metadata for routeName, using the in-memory

--- a/internal/upstreamoauth/manager_test.go
+++ b/internal/upstreamoauth/manager_test.go
@@ -3,6 +3,7 @@ package upstreamoauth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -23,6 +24,7 @@ func newTestManager(t *testing.T, publicURL string) *Manager {
 
 // setupASAndDCR は AS metadata と DCR エンドポイントを提供するテストサーバーを返す。
 // dcrCalls に DCR リクエスト回数を記録する。
+// RFC 8414 §3.3 の issuer 検証に対応するため、issuer はサーバー自身の URL を返す。
 func setupASAndDCR(t *testing.T, clientID string, dcrCalls *atomic.Int32) *httptest.Server {
 	t.Helper()
 	var srv *httptest.Server
@@ -31,7 +33,7 @@ func setupASAndDCR(t *testing.T, clientID string, dcrCalls *atomic.Int32) *httpt
 		switch r.URL.Path {
 		case "/.well-known/oauth-authorization-server":
 			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
-				Issuer:                srv.URL,
+				Issuer:                srv.URL, // must match issuerURL per RFC 8414 §3.3
 				AuthorizationEndpoint: srv.URL + "/authorize",
 				TokenEndpoint:         srv.URL + "/token",
 				RegistrationEndpoint:  srv.URL + "/register",
@@ -140,17 +142,18 @@ func TestManager_EnsureClient_SkipDCRWhenClientIDExists(t *testing.T) {
 func TestManager_EnsureClient_MissingRegistrationEndpoint(t *testing.T) {
 	m := newTestManager(t, "https://gateway.example.com")
 
-	// registration_endpoint のない AS
-	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// registration_endpoint のない AS（issuer は自身の URL に一致させ RFC 8414 §3.3 検証を通過させる）
+	var asSrv *httptest.Server
+	asSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/oauth-authorization-server" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
-			Issuer:                "https://as.example.com",
-			AuthorizationEndpoint: "https://as.example.com/authorize",
-			TokenEndpoint:         "https://as.example.com/token",
+			Issuer:                asSrv.URL,
+			AuthorizationEndpoint: asSrv.URL + "/authorize",
+			TokenEndpoint:         asSrv.URL + "/token",
 			// RegistrationEndpoint 欠落
 		})
 	}))
@@ -213,11 +216,52 @@ func TestManager_EnsureClient_Auto_TwoStep(t *testing.T) {
 	}
 }
 
+func TestManager_EnsureClient_SaveFailureReturnsError(t *testing.T) {
+	// store.Save が失敗した場合、EnsureClient はエラーを返す（警告のみで成功扱いにしない）
+	failStore := &alwaysFailClientStore{}
+
+	m := NewManager(failStore, "https://gateway.example.com")
+
+	var asSrv *httptest.Server
+	asSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                asSrv.URL,
+				AuthorizationEndpoint: asSrv.URL + "/authorize",
+				TokenEndpoint:         asSrv.URL + "/token",
+				RegistrationEndpoint:  asSrv.URL + "/register",
+			})
+		case "/register":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(DCRResponse{ClientID: "cid-fail-save"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer asSrv.Close()
+	m.httpClient = asSrv.Client()
+
+	_, err := m.EnsureClient(context.Background(), "save-fail-route", asSrv.URL, "")
+	if err == nil {
+		t.Fatal("expected error when store.Save fails, got nil")
+	}
+}
+
+// alwaysFailClientStore は Save が常に失敗する ClientStore スタブ。
+type alwaysFailClientStore struct{}
+
+func (s *alwaysFailClientStore) Load(_ string) (ClientRecord, bool) { return ClientRecord{}, false }
+func (s *alwaysFailClientStore) Save(_ ClientRecord) error           { return fmt.Errorf("disk full") }
+func (s *alwaysFailClientStore) All() []ClientRecord                 { return nil }
+
 func TestManager_discoverCached_NoSecondNetworkCall(t *testing.T) {
 	m := newTestManager(t, "https://gateway.example.com")
 
 	var discoverCalls atomic.Int32
-	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var asSrv *httptest.Server
+	asSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		discoverCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/.well-known/oauth-authorization-server" {
@@ -225,10 +269,10 @@ func TestManager_discoverCached_NoSecondNetworkCall(t *testing.T) {
 			return
 		}
 		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
-			Issuer:                "https://as.example.com",
-			AuthorizationEndpoint: "https://as.example.com/authorize",
-			TokenEndpoint:         "https://as.example.com/token",
-			RegistrationEndpoint:  "https://as.example.com/register",
+			Issuer:                asSrv.URL,
+			AuthorizationEndpoint: asSrv.URL + "/authorize",
+			TokenEndpoint:         asSrv.URL + "/token",
+			RegistrationEndpoint:  asSrv.URL + "/register",
 		})
 	}))
 	defer asSrv.Close()

--- a/internal/upstreamoauth/manager_test.go
+++ b/internal/upstreamoauth/manager_test.go
@@ -1,0 +1,249 @@
+package upstreamoauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// newTestManager は一時ファイルストアを使った Manager を返す。
+func newTestManager(t *testing.T, publicURL string) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewFileClientStore(filepath.Join(dir, "upstream_clients.json"))
+	if err != nil {
+		t.Fatalf("NewFileClientStore: %v", err)
+	}
+	return NewManager(store, publicURL)
+}
+
+// setupASAndDCR は AS metadata と DCR エンドポイントを提供するテストサーバーを返す。
+// dcrCalls に DCR リクエスト回数を記録する。
+func setupASAndDCR(t *testing.T, clientID string, dcrCalls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                srv.URL,
+				AuthorizationEndpoint: srv.URL + "/authorize",
+				TokenEndpoint:         srv.URL + "/token",
+				RegistrationEndpoint:  srv.URL + "/register",
+			})
+		case "/register":
+			if dcrCalls != nil {
+				dcrCalls.Add(1)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(DCRResponse{
+				ClientID:     clientID,
+				ClientSecret: "secret-" + clientID,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+func TestManager_EnsureClient_FullFlow(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var dcrCalls atomic.Int32
+	asSrv := setupASAndDCR(t, "cid-route1", &dcrCalls)
+	defer asSrv.Close()
+
+	m.httpClient = asSrv.Client()
+
+	rec, err := m.EnsureClient(context.Background(), "route1", asSrv.URL, "")
+	if err != nil {
+		t.Fatalf("EnsureClient: %v", err)
+	}
+	if rec.ClientID != "cid-route1" {
+		t.Errorf("ClientID: got %q, want %q", rec.ClientID, "cid-route1")
+	}
+	if rec.RouteName != "route1" {
+		t.Errorf("RouteName: got %q, want %q", rec.RouteName, "route1")
+	}
+	if dcrCalls.Load() != 1 {
+		t.Errorf("DCR calls: got %d, want 1", dcrCalls.Load())
+	}
+}
+
+func TestManager_EnsureClient_CacheHit(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var dcrCalls atomic.Int32
+	asSrv := setupASAndDCR(t, "cid-cached", &dcrCalls)
+	defer asSrv.Close()
+
+	m.httpClient = asSrv.Client()
+
+	// 1 回目: discovery + DCR
+	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, ""); err != nil {
+		t.Fatalf("EnsureClient (first): %v", err)
+	}
+
+	// 2 回目: store から即返却（network call なし）
+	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, ""); err != nil {
+		t.Fatalf("EnsureClient (second): %v", err)
+	}
+
+	if dcrCalls.Load() != 1 {
+		t.Errorf("DCR calls: got %d, want 1 (second call must use store cache)", dcrCalls.Load())
+	}
+}
+
+func TestManager_EnsureClient_SkipDCRWhenClientIDExists(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileClientStore(filepath.Join(dir, "upstream_clients.json"))
+	if err != nil {
+		t.Fatalf("NewFileClientStore: %v", err)
+	}
+
+	// 事前に ClientID を保存しておく
+	if err := store.Save(ClientRecord{
+		RouteName:             "pre-registered",
+		Issuer:                "https://as.example.com",
+		AuthorizationEndpoint: "https://as.example.com/authorize",
+		TokenEndpoint:         "https://as.example.com/token",
+		ClientID:              "existing-cid",
+	}); err != nil {
+		t.Fatalf("Save pre-registered: %v", err)
+	}
+
+	m := NewManager(store, "https://gateway.example.com")
+
+	var dcrCalls atomic.Int32
+	asSrv := setupASAndDCR(t, "new-cid", &dcrCalls)
+	defer asSrv.Close()
+	m.httpClient = asSrv.Client()
+
+	rec, err := m.EnsureClient(context.Background(), "pre-registered", asSrv.URL, "")
+	if err != nil {
+		t.Fatalf("EnsureClient: %v", err)
+	}
+	if rec.ClientID != "existing-cid" {
+		t.Errorf("ClientID: got %q, want existing-cid", rec.ClientID)
+	}
+	if dcrCalls.Load() != 0 {
+		t.Errorf("DCR should not be called when client_id already exists, got %d calls", dcrCalls.Load())
+	}
+}
+
+func TestManager_EnsureClient_MissingRegistrationEndpoint(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	// registration_endpoint のない AS
+	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+			Issuer:                "https://as.example.com",
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			TokenEndpoint:         "https://as.example.com/token",
+			// RegistrationEndpoint 欠落
+		})
+	}))
+	defer asSrv.Close()
+
+	m.httpClient = asSrv.Client()
+
+	_, err := m.EnsureClient(context.Background(), "no-dcr-route", asSrv.URL, "")
+	if err == nil {
+		t.Fatal("expected error for missing registration_endpoint, got nil")
+	}
+}
+
+func TestManager_EnsureClient_Auto_TwoStep(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var asSrv *httptest.Server
+	asSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                asSrv.URL,
+				AuthorizationEndpoint: asSrv.URL + "/authorize",
+				TokenEndpoint:         asSrv.URL + "/token",
+				RegistrationEndpoint:  asSrv.URL + "/register",
+			})
+		case "/register":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(DCRResponse{ClientID: "cid-auto"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer asSrv.Close()
+
+	var prmSrv *httptest.Server
+	prmSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-protected-resource/sse" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             prmSrv.URL + "/sse",
+			AuthorizationServers: []string{asSrv.URL},
+		})
+	}))
+	defer prmSrv.Close()
+
+	// auto 検索: httpClient は両サーバーに接続できる必要がある（どちらも plain HTTP）
+	m.httpClient = prmSrv.Client()
+
+	rec, err := m.EnsureClient(context.Background(), "auto-route", "auto", prmSrv.URL+"/sse")
+	if err != nil {
+		t.Fatalf("EnsureClient (auto): %v", err)
+	}
+	if rec.ClientID != "cid-auto" {
+		t.Errorf("ClientID: got %q, want cid-auto", rec.ClientID)
+	}
+}
+
+func TestManager_discoverCached_NoSecondNetworkCall(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var discoverCalls atomic.Int32
+	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		discoverCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+			Issuer:                "https://as.example.com",
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			TokenEndpoint:         "https://as.example.com/token",
+			RegistrationEndpoint:  "https://as.example.com/register",
+		})
+	}))
+	defer asSrv.Close()
+	m.httpClient = asSrv.Client()
+
+	ctx := context.Background()
+	if _, err := m.discoverCached(ctx, "r1", asSrv.URL, ""); err != nil {
+		t.Fatalf("discoverCached (first): %v", err)
+	}
+	callsAfterFirst := discoverCalls.Load()
+
+	if _, err := m.discoverCached(ctx, "r1", asSrv.URL, ""); err != nil {
+		t.Fatalf("discoverCached (second): %v", err)
+	}
+	if discoverCalls.Load() != callsAfterFirst {
+		t.Errorf("discovery network call count increased on second call: %d → %d", callsAfterFirst, discoverCalls.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/upstreamoauth` パッケージを新規追加（ISSUE #114）
- RFC 9728 (PRM) → RFC 8414 (AS Metadata) の2ステップ discovery と、RFC 8414 直接 discovery に対応
- RFC 7591 Dynamic Client Registration を実装し、`upstream_clients.json`（atomic write, mode 0600）に永続化
- `Manager.EnsureClient` でルートごとに lazy discovery + DCR を行い、in-memory cache で重複ネットワーク呼び出しを防止

## Files Changed

| ファイル | 内容 |
|---------|------|
| `internal/upstreamoauth/discovery.go` | `DiscoverFromIssuer` (RFC 8414) / `DiscoverFromResource` (RFC 9728→8414) |
| `internal/upstreamoauth/dcr.go` | `RegisterClient` (RFC 7591) |
| `internal/upstreamoauth/clientstore.go` | `ClientStore` / `fileClientStore` (atomic write) |
| `internal/upstreamoauth/manager.go` | `Manager.EnsureClient` + `discoverCached` |
| `internal/upstreamoauth/*_test.go` | httptest による全ケーステスト |
| `CHANGELOG.md` | [Unreleased] ### Added に追記 |

## Test plan

- [ ] `go test ./internal/upstreamoauth/...` が全件 PASS することを確認（CI で自動検証）
- [ ] 2ステップ discovery フロー（`auto`）が正しく動作するか (`TestDiscoverFromResource_TwoStep`, `TestManager_EnsureClient_Auto_TwoStep`)
- [ ] store hit で DCR 呼び出しが発生しないことを確認 (`TestManager_EnsureClient_CacheHit`, `TestManager_EnsureClient_SkipDCRWhenClientIDExists`)
- [ ] `registration_endpoint` 欠落時にルートレベルのエラーが返ることを確認 (`TestManager_EnsureClient_MissingRegistrationEndpoint`)

Closes #114

🤖 Generated with [Claude Code](https://claude.ai/claude-code)