### PR TITLE
feat(auth): UpstreamTokenStore — upstream OAuth ユーザートークン永続化 (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Upstream OAuth user token store (`UpstreamTokenStore`) ([#115](https://github.com/scottlz0310/mcp-gateway/issues/115))
+  - `UpstreamTokenRecord`: in-memory型（`Subject`/`RouteName` はメモリ上のみ）
+  - `upstreamTokenFileEntry`: on-disk型（`Subject`/`RouteName` を含まず、identity情報をディスクに書かない）
+  - キーは `sha256(subject + "\x00" + routeName)` の hex 文字列
+  - `UpstreamTokenStore` インターフェース: `Save` / `Lookup` / `Delete` / `Sweep`
+  - `memUpstreamTokenStore`: テスト・デフォルト用 in-memory 実装
+  - `fileUpstreamTokenStore`: JSON file-backed 実装（`upstream_tokens.json`）、atomic write (mode 0600)、起動時 sweep、親ディレクトリ確認 + chmod
 - Upstream OAuth metadata discovery and Dynamic Client Registration (`internal/upstreamoauth` package) ([#114](https://github.com/scottlz0310/mcp-gateway/issues/114))
   - `DiscoverFromIssuer`: RFC 8414 one-step AS metadata fetch (`/.well-known/oauth-authorization-server{issuerPath}`)
   - `DiscoverFromResource`: RFC 9728 → RFC 8414 two-step discovery (`/.well-known/oauth-protected-resource{path}` → AS metadata)

--- a/internal/auth/tokenstore_upstream.go
+++ b/internal/auth/tokenstore_upstream.go
@@ -1,0 +1,296 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// UpstreamTokenRecord is the in-memory representation of an upstream OAuth
+// token for a specific (subject, route) pair.
+// Subject and RouteName are not persisted to disk; they are recovered from the
+// map key (sha256 hash) at runtime via the caller-supplied lookup key.
+type UpstreamTokenRecord struct {
+	Subject      string    // in-memory only; not written to disk
+	RouteName    string    // in-memory only; not written to disk
+	Issuer       string
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time // zero value = expiry unknown / treat as permanent
+	Scope        string
+}
+
+// UpstreamTokenStore persists upstream OAuth access_token / refresh_token pairs
+// keyed by (subject, routeName). Implementations must be safe for concurrent use.
+type UpstreamTokenStore interface {
+	// Save writes or replaces the upstream token record for (subject, routeName).
+	Save(subject, routeName string, record UpstreamTokenRecord) error
+	// Lookup returns the token record for (subject, routeName).
+	// Returns false when no record exists or the record has expired.
+	Lookup(subject, routeName string) (UpstreamTokenRecord, bool)
+	// Delete removes the token record for (subject, routeName).
+	Delete(subject, routeName string) error
+	// Sweep removes all expired entries.
+	Sweep() error
+}
+
+// upstreamTokenKey returns the map key for (subject, routeName).
+// Raw identity is not stored; only the hash appears in the file.
+func upstreamTokenKey(subject, routeName string) string {
+	h := sha256.Sum256([]byte(subject + "\x00" + routeName))
+	return hex.EncodeToString(h[:])
+}
+
+// upstreamTokenFileEntry is the on-disk representation of a single upstream
+// token record. Subject and RouteName are intentionally absent from the JSON
+// so that raw identity information is never written to disk.
+type upstreamTokenFileEntry struct {
+	Issuer       string    `json:"issuer"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	Scope        string    `json:"scope,omitempty"`
+}
+
+func (e upstreamTokenFileEntry) expired() bool {
+	return !e.ExpiresAt.IsZero() && time.Now().After(e.ExpiresAt)
+}
+
+// ── in-memory implementation ─────────────────────────────────────────────────
+
+type memUpstreamTokenStore struct {
+	mu      sync.RWMutex
+	entries map[string]UpstreamTokenRecord // key: upstreamTokenKey
+}
+
+// NewMemUpstreamTokenStore returns an in-memory UpstreamTokenStore suitable
+// for testing or configurations without a persistent state directory.
+func NewMemUpstreamTokenStore() UpstreamTokenStore {
+	return &memUpstreamTokenStore{entries: make(map[string]UpstreamTokenRecord)}
+}
+
+func (m *memUpstreamTokenStore) Save(subject, routeName string, record UpstreamTokenRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	record.Subject = subject
+	record.RouteName = routeName
+	m.entries[upstreamTokenKey(subject, routeName)] = record
+	return nil
+}
+
+func (m *memUpstreamTokenStore) Lookup(subject, routeName string) (UpstreamTokenRecord, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	rec, ok := m.entries[upstreamTokenKey(subject, routeName)]
+	if !ok {
+		return UpstreamTokenRecord{}, false
+	}
+	if !rec.ExpiresAt.IsZero() && time.Now().After(rec.ExpiresAt) {
+		return UpstreamTokenRecord{}, false
+	}
+	return rec, true
+}
+
+func (m *memUpstreamTokenStore) Delete(subject, routeName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, upstreamTokenKey(subject, routeName))
+	return nil
+}
+
+func (m *memUpstreamTokenStore) Sweep() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	for k, v := range m.entries {
+		if !v.ExpiresAt.IsZero() && now.After(v.ExpiresAt) {
+			delete(m.entries, k)
+		}
+	}
+	return nil
+}
+
+// ── file-backed implementation ────────────────────────────────────────────────
+
+type fileUpstreamTokenStore struct {
+	mu      sync.RWMutex
+	path    string
+	entries map[string]upstreamTokenFileEntry // key: upstreamTokenKey
+}
+
+// NewFileUpstreamTokenStore returns a file-backed UpstreamTokenStore that
+// loads existing entries from path on startup, sweeps expired entries, and
+// flushes atomically on every write. The file is written with mode 0600.
+// If path does not exist the store starts empty; the parent directory must
+// exist and be writable.
+func NewFileUpstreamTokenStore(path string) (UpstreamTokenStore, error) {
+	s := &fileUpstreamTokenStore{
+		path:    path,
+		entries: make(map[string]upstreamTokenFileEntry),
+	}
+	if err := s.load(); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("loading upstream token store %q: %w", path, err)
+		}
+		dir := filepath.Dir(path)
+		info, statErr := os.Stat(dir)
+		if statErr != nil {
+			return nil, fmt.Errorf("upstream token store parent directory inaccessible %q: %w", dir, statErr)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("upstream token store parent path is not a directory %q", dir)
+		}
+		f, createErr := os.CreateTemp(dir, ".upstreamtokens-writecheck-*")
+		if createErr != nil {
+			return nil, fmt.Errorf("upstream token store parent directory not writable %q: %w", dir, createErr)
+		}
+		name := f.Name()
+		if closeErr := f.Close(); closeErr != nil {
+			_ = os.Remove(name)
+			return nil, fmt.Errorf("closing upstream token store probe file in %q: %w", dir, closeErr)
+		}
+		if removeErr := os.Remove(name); removeErr != nil {
+			return nil, fmt.Errorf("removing upstream token store probe file %q: %w", name, removeErr)
+		}
+	}
+	s.mu.Lock()
+	if changed := s.sweepLocked(); changed {
+		if err := s.flush(); err != nil {
+			count := len(s.entries)
+			s.mu.Unlock()
+			slog.Warn("upstream token store startup sweep flush failed", "path", path, "err", err)
+			slog.Info("upstream token store loaded", "path", path, "entries", count)
+			return s, nil
+		}
+	}
+	count := len(s.entries)
+	s.mu.Unlock()
+	if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+		slog.Warn("upstream token store chmod failed", "path", path, "err", err)
+	}
+	slog.Info("upstream token store loaded", "path", path, "entries", count)
+	return s, nil
+}
+
+func (s *fileUpstreamTokenStore) Save(subject, routeName string, record UpstreamTokenRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := upstreamTokenKey(subject, routeName)
+	prev, hadPrev := s.entries[key]
+	s.entries[key] = upstreamTokenFileEntry{
+		Issuer:       record.Issuer,
+		AccessToken:  record.AccessToken,
+		RefreshToken: record.RefreshToken,
+		ExpiresAt:    record.ExpiresAt,
+		Scope:        record.Scope,
+	}
+	if err := s.flush(); err != nil {
+		if hadPrev {
+			s.entries[key] = prev
+		} else {
+			delete(s.entries, key)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *fileUpstreamTokenStore) Lookup(subject, routeName string) (UpstreamTokenRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[upstreamTokenKey(subject, routeName)]
+	if !ok || entry.expired() {
+		return UpstreamTokenRecord{}, false
+	}
+	return UpstreamTokenRecord{
+		Subject:      subject,
+		RouteName:    routeName,
+		Issuer:       entry.Issuer,
+		AccessToken:  entry.AccessToken,
+		RefreshToken: entry.RefreshToken,
+		ExpiresAt:    entry.ExpiresAt,
+		Scope:        entry.Scope,
+	}, true
+}
+
+func (s *fileUpstreamTokenStore) Delete(subject, routeName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, upstreamTokenKey(subject, routeName))
+	return s.flush()
+}
+
+func (s *fileUpstreamTokenStore) Sweep() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if changed := s.sweepLocked(); !changed {
+		return nil
+	}
+	return s.flush()
+}
+
+func (s *fileUpstreamTokenStore) sweepLocked() bool {
+	changed := false
+	for k, v := range s.entries {
+		if v.expired() {
+			delete(s.entries, k)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (s *fileUpstreamTokenStore) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, &s.entries)
+}
+
+// flush writes entries to disk atomically via temp file + rename.
+// Must be called with s.mu held for writing.
+func (s *fileUpstreamTokenStore) flush() error {
+	data, err := json.Marshal(s.entries)
+	if err != nil {
+		return fmt.Errorf("marshaling upstream token store: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("writing upstream token store temp file: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err == nil {
+		return nil
+	}
+	backup := s.path + ".bak"
+	_ = os.Remove(backup)
+	hadOriginal := false
+	if err2 := os.Rename(s.path, backup); err2 == nil {
+		hadOriginal = true
+	} else if !os.IsNotExist(err2) {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("backing up upstream token store: %w", err2)
+	}
+	if err2 := os.Rename(tmp, s.path); err2 != nil {
+		if hadOriginal {
+			if restoreErr := os.Rename(backup, s.path); restoreErr != nil {
+				return fmt.Errorf("renaming upstream token store: %w (restore failed: %v)", err2, restoreErr)
+			}
+		}
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming upstream token store: %w", err2)
+	}
+	if hadOriginal {
+		_ = os.Remove(backup)
+	}
+	return nil
+}

--- a/internal/auth/tokenstore_upstream.go
+++ b/internal/auth/tokenstore_upstream.go
@@ -51,15 +51,15 @@ func upstreamTokenKey(subject, routeName string) string {
 // token record. Subject and RouteName are intentionally absent from the JSON
 // so that raw identity information is never written to disk.
 type upstreamTokenFileEntry struct {
-	Issuer       string    `json:"issuer"`
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token,omitempty"`
-	ExpiresAt    time.Time `json:"expires_at"`
-	Scope        string    `json:"scope,omitempty"`
+	Issuer       string     `json:"issuer"`
+	AccessToken  string     `json:"access_token"`
+	RefreshToken string     `json:"refresh_token,omitempty"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	Scope        string     `json:"scope,omitempty"`
 }
 
 func (e upstreamTokenFileEntry) expired() bool {
-	return !e.ExpiresAt.IsZero() && time.Now().After(e.ExpiresAt)
+	return e.ExpiresAt != nil && time.Now().After(*e.ExpiresAt)
 }
 
 // ── in-memory implementation ─────────────────────────────────────────────────
@@ -183,11 +183,16 @@ func (s *fileUpstreamTokenStore) Save(subject, routeName string, record Upstream
 	defer s.mu.Unlock()
 	key := upstreamTokenKey(subject, routeName)
 	prev, hadPrev := s.entries[key]
+	var expiresAt *time.Time
+	if !record.ExpiresAt.IsZero() {
+		t := record.ExpiresAt
+		expiresAt = &t
+	}
 	s.entries[key] = upstreamTokenFileEntry{
 		Issuer:       record.Issuer,
 		AccessToken:  record.AccessToken,
 		RefreshToken: record.RefreshToken,
-		ExpiresAt:    record.ExpiresAt,
+		ExpiresAt:    expiresAt,
 		Scope:        record.Scope,
 	}
 	if err := s.flush(); err != nil {
@@ -208,13 +213,17 @@ func (s *fileUpstreamTokenStore) Lookup(subject, routeName string) (UpstreamToke
 	if !ok || entry.expired() {
 		return UpstreamTokenRecord{}, false
 	}
+	var expiresAt time.Time
+	if entry.ExpiresAt != nil {
+		expiresAt = *entry.ExpiresAt
+	}
 	return UpstreamTokenRecord{
 		Subject:      subject,
 		RouteName:    routeName,
 		Issuer:       entry.Issuer,
 		AccessToken:  entry.AccessToken,
 		RefreshToken: entry.RefreshToken,
-		ExpiresAt:    entry.ExpiresAt,
+		ExpiresAt:    expiresAt,
 		Scope:        entry.Scope,
 	}, true
 }
@@ -222,8 +231,16 @@ func (s *fileUpstreamTokenStore) Lookup(subject, routeName string) (UpstreamToke
 func (s *fileUpstreamTokenStore) Delete(subject, routeName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.entries, upstreamTokenKey(subject, routeName))
-	return s.flush()
+	key := upstreamTokenKey(subject, routeName)
+	prev, hadPrev := s.entries[key]
+	delete(s.entries, key)
+	if err := s.flush(); err != nil {
+		if hadPrev {
+			s.entries[key] = prev
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *fileUpstreamTokenStore) Sweep() error {

--- a/internal/auth/tokenstore_upstream_test.go
+++ b/internal/auth/tokenstore_upstream_test.go
@@ -1,0 +1,339 @@
+package auth
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// upstreamTokenStoreContract はすべての UpstreamTokenStore 実装が満たすべき
+// 共通コントラクトテストを実行する。
+func upstreamTokenStoreContract(t *testing.T, newStore func(t *testing.T) UpstreamTokenStore) {
+	t.Helper()
+
+	t.Run("Save and Lookup", func(t *testing.T) {
+		s := newStore(t)
+		rec := UpstreamTokenRecord{
+			Issuer:       "https://as.example.com",
+			AccessToken:  "at-abc",
+			RefreshToken: "rt-abc",
+			Scope:        "openid profile",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		}
+		if err := s.Save("user1", "route-a", rec); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		got, ok := s.Lookup("user1", "route-a")
+		if !ok {
+			t.Fatal("Lookup: expected record, got not-found")
+		}
+		if got.AccessToken != rec.AccessToken {
+			t.Errorf("AccessToken: got %q, want %q", got.AccessToken, rec.AccessToken)
+		}
+		if got.Subject != "user1" {
+			t.Errorf("Subject: got %q, want user1", got.Subject)
+		}
+		if got.RouteName != "route-a" {
+			t.Errorf("RouteName: got %q, want route-a", got.RouteName)
+		}
+	})
+
+	t.Run("Lookup absent returns false", func(t *testing.T) {
+		s := newStore(t)
+		_, ok := s.Lookup("nobody", "no-route")
+		if ok {
+			t.Fatal("Lookup: expected not-found for absent key, got found")
+		}
+	})
+
+	t.Run("Lookup expired returns false", func(t *testing.T) {
+		s := newStore(t)
+		rec := UpstreamTokenRecord{
+			Issuer:      "https://as.example.com",
+			AccessToken: "at-expired",
+			ExpiresAt:   time.Now().Add(-time.Second), // already expired
+		}
+		if err := s.Save("user2", "route-b", rec); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		_, ok := s.Lookup("user2", "route-b")
+		if ok {
+			t.Fatal("Lookup: expected not-found for expired entry, got found")
+		}
+	})
+
+	t.Run("ExpiresAt zero is permanent (never swept)", func(t *testing.T) {
+		s := newStore(t)
+		rec := UpstreamTokenRecord{
+			Issuer:      "https://as.example.com",
+			AccessToken: "at-permanent",
+			ExpiresAt:   time.Time{}, // zero = permanent
+		}
+		if err := s.Save("user3", "route-c", rec); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if err := s.Sweep(); err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		_, ok := s.Lookup("user3", "route-c")
+		if !ok {
+			t.Fatal("Lookup: permanent entry must survive Sweep")
+		}
+	})
+
+	t.Run("Sweep removes expired entries", func(t *testing.T) {
+		s := newStore(t)
+		expired := UpstreamTokenRecord{
+			Issuer:      "https://as.example.com",
+			AccessToken: "at-sweep",
+			ExpiresAt:   time.Now().Add(-time.Second),
+		}
+		live := UpstreamTokenRecord{
+			Issuer:      "https://as.example.com",
+			AccessToken: "at-live",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		}
+		if err := s.Save("user4", "route-d", expired); err != nil {
+			t.Fatalf("Save expired: %v", err)
+		}
+		if err := s.Save("user5", "route-e", live); err != nil {
+			t.Fatalf("Save live: %v", err)
+		}
+		if err := s.Sweep(); err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if _, ok := s.Lookup("user4", "route-d"); ok {
+			t.Error("expired entry should be removed by Sweep")
+		}
+		if _, ok := s.Lookup("user5", "route-e"); !ok {
+			t.Error("live entry should survive Sweep")
+		}
+	})
+
+	t.Run("Delete removes entry", func(t *testing.T) {
+		s := newStore(t)
+		rec := UpstreamTokenRecord{
+			Issuer:      "https://as.example.com",
+			AccessToken: "at-delete",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		}
+		if err := s.Save("user6", "route-f", rec); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if err := s.Delete("user6", "route-f"); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if _, ok := s.Lookup("user6", "route-f"); ok {
+			t.Error("Lookup: entry should be absent after Delete")
+		}
+	})
+
+	t.Run("Keys are independent per (subject, routeName)", func(t *testing.T) {
+		s := newStore(t)
+		if err := s.Save("user7", "route-g", UpstreamTokenRecord{
+			Issuer: "a", AccessToken: "token-a", ExpiresAt: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("Save user7/route-g: %v", err)
+		}
+		if err := s.Save("user7", "route-h", UpstreamTokenRecord{
+			Issuer: "b", AccessToken: "token-b", ExpiresAt: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("Save user7/route-h: %v", err)
+		}
+		if err := s.Save("user8", "route-g", UpstreamTokenRecord{
+			Issuer: "c", AccessToken: "token-c", ExpiresAt: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("Save user8/route-g: %v", err)
+		}
+		r1, _ := s.Lookup("user7", "route-g")
+		r2, _ := s.Lookup("user7", "route-h")
+		r3, _ := s.Lookup("user8", "route-g")
+		if r1.AccessToken != "token-a" || r2.AccessToken != "token-b" || r3.AccessToken != "token-c" {
+			t.Errorf("Lookup returned wrong tokens: %q %q %q", r1.AccessToken, r2.AccessToken, r3.AccessToken)
+		}
+	})
+}
+
+func TestMemUpstreamTokenStore_Contract(t *testing.T) {
+	upstreamTokenStoreContract(t, func(t *testing.T) UpstreamTokenStore {
+		t.Helper()
+		return NewMemUpstreamTokenStore()
+	})
+}
+
+func TestFileUpstreamTokenStore_Contract(t *testing.T) {
+	upstreamTokenStoreContract(t, func(t *testing.T) UpstreamTokenStore {
+		t.Helper()
+		dir := t.TempDir()
+		s, err := NewFileUpstreamTokenStore(filepath.Join(dir, "upstream_tokens.json"))
+		if err != nil {
+			t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+		}
+		return s
+	})
+}
+
+func TestFileUpstreamTokenStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+
+	s1, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore (first): %v", err)
+	}
+	rec := UpstreamTokenRecord{
+		Issuer:       "https://as.example.com",
+		AccessToken:  "at-persist",
+		RefreshToken: "rt-persist",
+		Scope:        "openid",
+		ExpiresAt:    time.Now().Add(time.Hour).Truncate(time.Second),
+	}
+	if err := s1.Save("user-p", "route-p", rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// 別インスタンスで同じファイルを開き直す
+	s2, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore (second): %v", err)
+	}
+	got, ok := s2.Lookup("user-p", "route-p")
+	if !ok {
+		t.Fatal("Lookup (second instance): expected record, got not-found")
+	}
+	if got.AccessToken != rec.AccessToken {
+		t.Errorf("AccessToken: got %q, want %q", got.AccessToken, rec.AccessToken)
+	}
+	if got.RefreshToken != rec.RefreshToken {
+		t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, rec.RefreshToken)
+	}
+}
+
+func TestFileUpstreamTokenStore_StartupSweep(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+
+	s1, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore (first): %v", err)
+	}
+	expired := UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-stale",
+		ExpiresAt:   time.Now().Add(-time.Minute), // already expired
+	}
+	live := UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-live",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	if err := s1.Save("user-s1", "route-s", expired); err != nil {
+		t.Fatalf("Save expired: %v", err)
+	}
+	if err := s1.Save("user-s2", "route-s", live); err != nil {
+		t.Fatalf("Save live: %v", err)
+	}
+
+	// 再起動 → startup sweep で期限切れエントリが除去されるはず
+	s2, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore (second): %v", err)
+	}
+	if _, ok := s2.Lookup("user-s1", "route-s"); ok {
+		t.Error("startup sweep should have removed expired entry")
+	}
+	if _, ok := s2.Lookup("user-s2", "route-s"); !ok {
+		t.Error("live entry must survive startup sweep")
+	}
+}
+
+func TestFileUpstreamTokenStore_IdentityNotInJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+
+	s, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+	}
+	if err := s.Save("alice", "my-route", UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-secret",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(raw)
+	if strings.Contains(content, "alice") {
+		t.Error("subject 'alice' must not appear in the JSON file")
+	}
+	if strings.Contains(content, "my-route") {
+		t.Error("routeName 'my-route' must not appear in the JSON file")
+	}
+
+	// キーは 64 文字の hex 文字列（sha256）であること
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	for k := range m {
+		if len(k) != 64 {
+			t.Errorf("key %q is not a 64-char sha256 hex string", k)
+		}
+	}
+}
+
+func TestFileUpstreamTokenStore_NonExistentFileOK(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewFileUpstreamTokenStore(filepath.Join(dir, "does_not_exist.json"))
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore with non-existent file: %v", err)
+	}
+	if _, ok := s.Lookup("nobody", "no-route"); ok {
+		t.Error("expected empty store")
+	}
+}
+
+func TestFileUpstreamTokenStore_ParentDirNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent-dir", "upstream_tokens.json")
+	_, err := NewFileUpstreamTokenStore(path)
+	if err == nil {
+		t.Fatal("expected error when parent directory does not exist, got nil")
+	}
+}
+
+func TestFileUpstreamTokenStore_FileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows では POSIX ファイルパーミッションは適用されない")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+	s, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+	}
+	if err := s.Save("user", "route", UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0o077 != 0 {
+		t.Errorf("file permissions %o are too permissive (want 0600)", perm)
+	}
+}

--- a/internal/auth/tokenstore_upstream_test.go
+++ b/internal/auth/tokenstore_upstream_test.go
@@ -310,6 +310,105 @@ func TestFileUpstreamTokenStore_ParentDirNotExist(t *testing.T) {
 	}
 }
 
+func TestFileUpstreamTokenStore_LoadInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := NewFileUpstreamTokenStore(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestFileUpstreamTokenStore_SaveRollbackOnFlushFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows では chmod によるフラッシュ失敗シミュレーションは不可")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+	s, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+	}
+	// 先に 1 エントリ保存してから上書き Save でロールバックをテスト
+	existing := UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-existing",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	if err := s.Save("user-rb", "route-rb", existing); err != nil {
+		t.Fatalf("Save (initial): %v", err)
+	}
+
+	// ディレクトリを read-only にして flush を失敗させる
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod dir: %v", err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o755) }()
+
+	newRec := UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-new",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	saveErr := s.Save("user-rb", "route-rb", newRec)
+	_ = os.Chmod(dir, 0o755)
+	if saveErr == nil {
+		t.Fatal("expected error when flush fails, got nil")
+	}
+
+	// rollback: 元のエントリが復元されているはず
+	got, ok := s.Lookup("user-rb", "route-rb")
+	if !ok {
+		t.Fatal("entry should be restored after failed Save")
+	}
+	if got.AccessToken != existing.AccessToken {
+		t.Errorf("rollback: AccessToken got %q, want %q", got.AccessToken, existing.AccessToken)
+	}
+}
+
+func TestFileUpstreamTokenStore_DeleteRollbackOnFlushFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows では chmod によるフラッシュ失敗シミュレーションは不可")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+	s, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+	}
+	rec := UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-del-rb",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	if err := s.Save("user-drb", "route-drb", rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod dir: %v", err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o755) }()
+
+	delErr := s.Delete("user-drb", "route-drb")
+	_ = os.Chmod(dir, 0o755)
+	if delErr == nil {
+		t.Fatal("expected error when flush fails, got nil")
+	}
+
+	// rollback: エントリが復元されているはず
+	got, ok := s.Lookup("user-drb", "route-drb")
+	if !ok {
+		t.Fatal("entry should be restored after failed Delete")
+	}
+	if got.AccessToken != rec.AccessToken {
+		t.Errorf("rollback: AccessToken got %q, want %q", got.AccessToken, rec.AccessToken)
+	}
+}
+
 func TestFileUpstreamTokenStore_FileMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows では POSIX ファイルパーミッションは適用されない")

--- a/internal/auth/tokenstore_upstream_test.go
+++ b/internal/auth/tokenstore_upstream_test.go
@@ -291,6 +291,58 @@ func TestFileUpstreamTokenStore_IdentityNotInJSON(t *testing.T) {
 	}
 }
 
+// TestFileUpstreamTokenStore_PermanentEntryHasNoExpiresAtInJSON verifies that
+// the on-disk contract for permanent entries (zero ExpiresAt) is upheld:
+// the expires_at JSON field must be absent, and the entry must survive a reload.
+// This guards against regressions where ExpiresAt reverts to value time.Time
+// (making omitempty ineffective) or the nil→zero conversion is lost.
+func TestFileUpstreamTokenStore_PermanentEntryHasNoExpiresAtInJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upstream_tokens.json")
+
+	s1, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore: %v", err)
+	}
+	if err := s1.Save("user-perm", "route-perm", UpstreamTokenRecord{
+		Issuer:      "https://as.example.com",
+		AccessToken: "at-permanent",
+		ExpiresAt:   time.Time{}, // zero = permanent
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// on-disk JSON に expires_at フィールドが含まれないこと（omitempty が機能している証拠）
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(raw), "expires_at") {
+		t.Errorf("permanent entry must not have expires_at in JSON; got: %s", raw)
+	}
+
+	// リロード後も permanent として扱われること（Lookup が成功し ExpiresAt がゼロ値）
+	s2, err := NewFileUpstreamTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewFileUpstreamTokenStore (reload): %v", err)
+	}
+	got, ok := s2.Lookup("user-perm", "route-perm")
+	if !ok {
+		t.Fatal("permanent entry must be found after reload")
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt after reload: got %v, want zero (permanent)", got.ExpiresAt)
+	}
+
+	// Sweep 後も残ること
+	if err := s2.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, ok := s2.Lookup("user-perm", "route-perm"); !ok {
+		t.Error("permanent entry must survive Sweep")
+	}
+}
+
 func TestFileUpstreamTokenStore_NonExistentFileOK(t *testing.T) {
 	dir := t.TempDir()
 	s, err := NewFileUpstreamTokenStore(filepath.Join(dir, "does_not_exist.json"))


### PR DESCRIPTION
## Summary

- `internal/auth/tokenstore_upstream.go` を新規追加（ISSUE #115）
- `(subject, routeName)` をキーとする upstream OAuth access_token / refresh_token 永続化ストアを実装
- キーは `sha256(subject + "\x00" + routeName)` の hex 文字列（identity 情報をディスクに書かない）
- `ExpiresAt` が zero の場合は無期限扱い（Sweep 対象外）

## Files Changed

| ファイル | 内容 |
|---------|------|
| `internal/auth/tokenstore_upstream.go` | `UpstreamTokenRecord` / `UpstreamTokenStore` / `memUpstreamTokenStore` / `fileUpstreamTokenStore` |
| `internal/auth/tokenstore_upstream_test.go` | コントラクトテスト / 永続化テスト / identity-not-in-JSON テスト |
| `CHANGELOG.md` | [Unreleased] ### Added に追記 |

## Test plan

- [ ] `go test ./internal/auth/...` が全件 PASS（CI で自動検証）
- [ ] `TestMemUpstreamTokenStore_Contract` / `TestFileUpstreamTokenStore_Contract` — 7サブテスト
- [ ] `TestFileUpstreamTokenStore_Persistence` — 再起動後もデータが残ること
- [ ] `TestFileUpstreamTokenStore_StartupSweep` — 起動時に期限切れエントリが除去されること
- [ ] `TestFileUpstreamTokenStore_IdentityNotInJSON` — subject / routeName が JSON に現れないこと

Closes #115

🤖 Generated with [Claude Code](https://claude.ai/claude-code)