### PR TITLE
feat(upstreamoauth): upstream OAuth 認可フロー（PKCE・state・コールバック） #116

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -315,6 +315,19 @@ func main() {
 			)
 			mux.Handle("GET /upstream/callback/{routeName}", callbackHandler)
 			slog.Info("upstream OAuth callback endpoint registered", "path", "/upstream/callback/{routeName}")
+
+			// Background sweeper: remove expired state entries and token records
+			// so that abandoned auth flows do not accumulate indefinitely.
+			go func() {
+				t := time.NewTicker(5 * time.Minute)
+				defer t.Stop()
+				for range t.C {
+					upstreamStateStore.Sweep()
+					if err := upstreamTokenStore.Sweep(); err != nil {
+						slog.Warn("upstream token store sweep failed", "err", err)
+					}
+				}
+			}()
 			break
 		}
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -356,7 +356,7 @@ func main() {
 			// between the gateway auth middleware and the proxy handler so that
 			// authenticated users without a valid upstream token are redirected
 			// to the upstream authorization endpoint.
-			var proxyHandler http.Handler = h
+			proxyHandler := http.Handler(h)
 			if route.UpstreamOAuth != "" && upstreamManager != nil {
 				proxyHandler = upstreamoauth.NewAuthorizeMiddleware(
 					route.Name,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scottlz0310/mcp-gateway/internal/proxy"
 	"github.com/scottlz0310/mcp-gateway/internal/router"
 	"github.com/scottlz0310/mcp-gateway/internal/setup"
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
 )
 
 func main() {
@@ -291,6 +292,33 @@ func main() {
 		_, _ = fmt.Fprintln(w, `{"status":"ok"}`)
 	})
 
+	// Initialize upstream OAuth components when any route has upstream_oauth configured.
+	var upstreamManager *upstreamoauth.Manager
+	var upstreamStateStore upstreamoauth.StateStore
+	var upstreamTokenStore auth.UpstreamTokenStore
+	for _, r := range routes {
+		if r.UpstreamOAuth != "" {
+			clientStore, err := upstreamoauth.NewFileClientStore(cfg.upstreamClientStorePath)
+			if err != nil {
+				slog.Error("failed to initialize upstream client store", "err", err)
+				os.Exit(1)
+			}
+			upstreamManager = upstreamoauth.NewManager(clientStore, publicURL)
+			upstreamStateStore = upstreamoauth.NewStateStore()
+			upstreamTokenStore, err = auth.NewFileUpstreamTokenStore(cfg.upstreamTokenStorePath)
+			if err != nil {
+				slog.Error("failed to initialize upstream token store", "err", err)
+				os.Exit(1)
+			}
+			callbackHandler := upstreamoauth.NewCallbackHandler(
+				upstreamStateStore, upstreamManager, upstreamTokenStore, publicURL, nil,
+			)
+			mux.Handle("GET /upstream/callback/{routeName}", callbackHandler)
+			slog.Info("upstream OAuth callback endpoint registered", "path", "/upstream/callback/{routeName}")
+			break
+		}
+	}
+
 	// Proxy routes — apply auth middleware unless the route opts out.
 	// Each authenticated route also exposes its own RFC 9728 PRM document at
 	// /.well-known/oauth-protected-resource{prefix}, and 401 responses point
@@ -323,7 +351,25 @@ func main() {
 				authOpts = append(authOpts, middleware.WithResourceMetadataURL(publicURL+routePRMPath))
 			}
 			routeAuth := middleware.Auth(oauthHandler, authOpts...)
-			wrapped = routeAuth(h)
+
+			// For routes with upstream OAuth, insert the authorize middleware
+			// between the gateway auth middleware and the proxy handler so that
+			// authenticated users without a valid upstream token are redirected
+			// to the upstream authorization endpoint.
+			var proxyHandler http.Handler = h
+			if route.UpstreamOAuth != "" && upstreamManager != nil {
+				proxyHandler = upstreamoauth.NewAuthorizeMiddleware(
+					route.Name,
+					route.UpstreamOAuth,
+					route.UpstreamOAuthScope,
+					route.Upstream.String(),
+					upstreamManager,
+					upstreamStateStore,
+					upstreamTokenStore,
+					publicURL,
+				)(h)
+			}
+			wrapped = routeAuth(proxyHandler)
 		}
 		mux.Handle(route.Prefix, wrapped)
 		mux.Handle(route.Prefix+"/", wrapped)
@@ -333,6 +379,7 @@ func main() {
 			"upstream", route.Upstream.String(),
 			"auth_required", !route.NoAuth,
 			"upstream_bearer_token_env", route.UpstreamBearerTokenEnv != "",
+			"upstream_oauth", route.UpstreamOAuth != "",
 		)
 	}
 
@@ -438,6 +485,9 @@ type config struct {
 	configPath           string
 	allowedRedirectHosts   []string
 	allowedRedirectSchemes []string
+	// upstream OAuth state paths
+	upstreamClientStorePath string
+	upstreamTokenStorePath  string
 }
 
 func loadConfig() config {
@@ -485,6 +535,8 @@ func loadConfig() config {
 		configPath:           getEnv("MCP_CONFIG_FILE", filepath.Join(stateDir, "config.yaml")),
 		allowedRedirectHosts:   splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
 		allowedRedirectSchemes: splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES")),
+		upstreamClientStorePath: filepath.Join(stateDir, "upstream_clients.json"),
+		upstreamTokenStorePath:  filepath.Join(stateDir, "upstream_tokens.json"),
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -157,6 +157,12 @@ func parseRoutes(env []string) ([]Route, error) {
 			delete(options, "upstream_oauth")
 		}
 
+		// upstream_oauth is incompatible with auth=none: per-user OAuth delegation
+		// requires an authenticated subject from the gateway Auth middleware.
+		if upstreamOAuth != "" && noAuth {
+			return nil, fmt.Errorf("%s: upstream_oauth is incompatible with auth=none; upstream OAuth requires gateway authentication", key)
+		}
+
 		// upstream_oauth_scope: space-separated OAuth scope string.
 		// Comma-separated values are normalised to space-separated.
 		// upstream_oauth must be set when upstream_oauth_scope is specified.
@@ -311,6 +317,10 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 				}
 				upstreamOAuth = strings.TrimRight(upstreamOAuth, "/")
 			}
+		}
+		// upstream_oauth is incompatible with no_auth for the same reason as parseRoutes.
+		if upstreamOAuth != "" && r.NoAuth {
+			return nil, fmt.Errorf("route %q: upstream_oauth is incompatible with no_auth; upstream OAuth requires gateway authentication", name)
 		}
 		// upstream_oauth_scope: normalise comma-separated to space-separated.
 		// upstream_oauth must be set when upstream_oauth_scope is specified.

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -749,3 +749,55 @@ func TestParseFromConfig_UpstreamOAuthScopeNilTreatedAsAbsent(t *testing.T) {
 		t.Errorf("UpstreamOAuthScope should be empty for nil input, got %q", routes[0].UpstreamOAuthScope)
 	}
 }
+
+// upstream_oauth + auth=none の非互換性テスト（回帰）
+
+func TestParseRoutes_UpstreamOAuthIncompatibleWithAuthNone(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|auth=none|upstream_oauth=auto"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error: upstream_oauth is incompatible with auth=none")
+	}
+	if !strings.Contains(err.Error(), "incompatible") {
+		t.Errorf("error message should mention incompatibility, got: %v", err)
+	}
+}
+
+func TestParseRoutes_UpstreamOAuthWithAuthOAuthIsValid(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|auth=oauth|upstream_oauth=auto"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 || routes[0].UpstreamOAuth != "auto" {
+		t.Errorf("expected valid route with upstream_oauth=auto")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthIncompatibleWithNoAuth(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			NoAuth: true, UpstreamOAuth: strPtr("auto")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error: upstream_oauth is incompatible with no_auth")
+	}
+	if !strings.Contains(err.Error(), "incompatible") {
+		t.Errorf("error message should mention incompatibility, got: %v", err)
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthWithAuthRequiredIsValid(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			NoAuth: false, UpstreamOAuth: strPtr("auto")},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 || routes[0].UpstreamOAuth != "auto" {
+		t.Errorf("expected valid route with upstream_oauth=auto")
+	}
+}

--- a/internal/upstreamoauth/callback.go
+++ b/internal/upstreamoauth/callback.go
@@ -1,0 +1,198 @@
+package upstreamoauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+)
+
+// CallbackHandler handles GET /upstream/callback/{routeName}.
+// It validates the state parameter, exchanges the authorization code for an
+// upstream access token, and stores the result in UpstreamTokenStore.
+// Subject recovery uses the state store — not middleware.IdentityFromContext —
+// because the callback may arrive outside the gateway auth middleware chain.
+type CallbackHandler struct {
+	stateStore StateStore
+	manager    *Manager
+	tokenStore auth.UpstreamTokenStore
+	publicURL  string
+	httpClient *http.Client
+}
+
+// NewCallbackHandler creates a CallbackHandler. If httpClient is nil,
+// a client with DefaultHTTPTimeout is used.
+func NewCallbackHandler(
+	stateStore StateStore,
+	manager *Manager,
+	tokenStore auth.UpstreamTokenStore,
+	publicURL string,
+	httpClient *http.Client,
+) *CallbackHandler {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: DefaultHTTPTimeout}
+	}
+	return &CallbackHandler{
+		stateStore: stateStore,
+		manager:    manager,
+		tokenStore: tokenStore,
+		publicURL:  strings.TrimRight(publicURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	routeName := r.PathValue("routeName")
+	if routeName == "" {
+		http.Error(w, "missing route name", http.StatusBadRequest)
+		return
+	}
+
+	stateKey := r.URL.Query().Get("state")
+	if stateKey == "" {
+		http.Error(w, "missing state parameter", http.StatusBadRequest)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		errParam := r.URL.Query().Get("error")
+		if errParam == "" {
+			errParam = "unknown_error"
+		}
+		http.Error(w, "authorization denied: "+errParam, http.StatusBadRequest)
+		return
+	}
+
+	state, ok := h.stateStore.Pop(stateKey)
+	if !ok {
+		slog.Warn("upstream OAuth callback: invalid or expired state",
+			"route", routeName,
+			"state_prefix", stateKey[:min(8, len(stateKey))],
+		)
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	if state.RouteName != routeName {
+		slog.Warn("upstream OAuth callback: route name mismatch",
+			"expected", state.RouteName, "got", routeName)
+		http.Error(w, "state route mismatch", http.StatusBadRequest)
+		return
+	}
+
+	rec, ok := h.manager.LoadClient(routeName)
+	if !ok || rec.ClientID == "" {
+		slog.Error("upstream OAuth callback: no client registration for route", "route", routeName)
+		http.Error(w, "upstream client not registered", http.StatusInternalServerError)
+		return
+	}
+
+	redirectURI := fmt.Sprintf("%s/upstream/callback/%s",
+		h.publicURL,
+		url.PathEscape(routeName),
+	)
+
+	tokenResp, err := h.exchangeCode(r.Context(), rec, code, state.CodeVerifier, redirectURI)
+	if err != nil {
+		slog.Error("upstream OAuth callback: token exchange failed", "route", routeName, "err", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	var expiresAt time.Time
+	if tokenResp.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+
+	if err := h.tokenStore.Save(state.Subject, routeName, auth.UpstreamTokenRecord{
+		Issuer:       rec.Issuer,
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresAt:    expiresAt,
+		Scope:        tokenResp.Scope,
+	}); err != nil {
+		slog.Error("upstream OAuth callback: failed to save token", "route", routeName, "err", err)
+		http.Error(w, "failed to save token", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("upstream OAuth: authorization complete",
+		"route", routeName,
+		"subject_hash", subjectHash(state.Subject),
+	)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprintf(w,
+		"<html><body><p>Authorization complete. You may now access <strong>%s</strong>.</p></body></html>",
+		routeName,
+	)
+}
+
+// tokenExchangeResponse is the subset of the OAuth 2.0 token response used here.
+type tokenExchangeResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+}
+
+func (h *CallbackHandler) exchangeCode(
+	ctx context.Context,
+	rec ClientRecord,
+	code, codeVerifier, redirectURI string,
+) (*tokenExchangeResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("code_verifier", codeVerifier)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", rec.ClientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rec.TokenEndpoint,
+		bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if rec.ClientSecret != "" {
+		req.SetBasicAuth(rec.ClientID, rec.ClientSecret)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", rec.TokenEndpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("token endpoint %s: unexpected status %d: %s",
+			rec.TokenEndpoint, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var tr tokenExchangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("decoding token response from %s: %w", rec.TokenEndpoint, err)
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("token response from %s missing access_token", rec.TokenEndpoint)
+	}
+	return &tr, nil
+}
+
+// subjectHash returns a short hex prefix of the subject SHA256 for safe logging.
+func subjectHash(subject string) string {
+	h := sha256.Sum256([]byte(subject))
+	return fmt.Sprintf("%x", h[:4])
+}

--- a/internal/upstreamoauth/callback.go
+++ b/internal/upstreamoauth/callback.go
@@ -63,16 +63,9 @@ func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		errParam := r.URL.Query().Get("error")
-		if errParam == "" {
-			errParam = "unknown_error"
-		}
-		http.Error(w, "authorization denied: "+errParam, http.StatusBadRequest)
-		return
-	}
-
+	// Pop the state immediately once stateKey is present, even when code is
+	// absent or the upstream returned an error. Consuming the state before any
+	// early return prevents state reuse if the state value is leaked.
 	state, ok := h.stateStore.Pop(stateKey)
 	if !ok {
 		slog.Warn("upstream OAuth callback: invalid or expired state",
@@ -80,6 +73,16 @@ func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"state_prefix", stateKey[:min(8, len(stateKey))],
 		)
 		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		errParam := r.URL.Query().Get("error")
+		if errParam == "" {
+			errParam = "unknown_error"
+		}
+		http.Error(w, "authorization denied: "+errParam, http.StatusBadRequest)
 		return
 	}
 
@@ -109,10 +112,16 @@ func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var expiresAt time.Time
-	if tokenResp.ExpiresIn > 0 {
-		expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	// Reject tokens with no expiry information: storing a zero ExpiresAt would
+	// cause Lookup to treat the token as permanently valid, which is unsafe for
+	// upstream access tokens that may be silently revoked by the upstream AS.
+	if tokenResp.ExpiresIn <= 0 {
+		slog.Error("upstream OAuth callback: token response missing required expires_in",
+			"route", routeName, "token_endpoint", rec.TokenEndpoint)
+		http.Error(w, "upstream token missing required expiry", http.StatusBadGateway)
+		return
 	}
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
 	if err := h.tokenStore.Save(state.Subject, routeName, auth.UpstreamTokenRecord{
 		Issuer:       rec.Issuer,

--- a/internal/upstreamoauth/callback_test.go
+++ b/internal/upstreamoauth/callback_test.go
@@ -164,6 +164,7 @@ func TestCallbackHandler_SubjectFromStateNotFromContext(t *testing.T) {
 	ts := makeTokenServer(t, map[string]any{
 		"access_token": "tok-alice",
 		"token_type":   "Bearer",
+		"expires_in":   3600,
 	})
 	defer ts.Close()
 
@@ -211,7 +212,7 @@ func TestCallbackHandler_RedirectURIConstruction(t *testing.T) {
 			capturedForm = r.Form
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer"}`))
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
 	}))
 	defer ts.Close()
 
@@ -250,8 +251,17 @@ func TestCallbackHandler_RedirectURIConstruction(t *testing.T) {
 }
 
 func TestCallbackHandler_MissingCode_ErrorParam(t *testing.T) {
+	// Upstream AS denies authorization and returns error=access_denied (no code).
+	// The state must still be consumed (Pop) to prevent reuse.
 	stateStore := upstreamoauth.NewStateStore()
 	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	stateStore.Save("s", upstreamoauth.OAuthState{
+		Subject:      "user",
+		RouteName:    "myroute",
+		CodeVerifier: "ver",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
 
 	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{},
 		tokenStore, "http://localhost:8080", nil)
@@ -264,5 +274,55 @@ func TestCallbackHandler_MissingCode_ErrorParam(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	// State must have been consumed: a second request with the same state must fail.
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/upstream/callback/myroute?state=s&code=code2", nil)
+	req2.SetPathValue("routeName", "myroute")
+	handler.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusBadRequest {
+		t.Errorf("state reuse after error: status = %d, want %d (state should be consumed)", rr2.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCallbackHandler_MissingExpiresIn(t *testing.T) {
+	// Token response without expires_in must be rejected (zero ExpiresAt is unsafe).
+	ts := makeTokenServer(t, map[string]any{
+		"access_token": "tok",
+		"token_type":   "Bearer",
+		// expires_in intentionally omitted
+	})
+	defer ts.Close()
+
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	stateStore.Save("s", upstreamoauth.OAuthState{
+		Subject:      "user",
+		RouteName:    "myroute",
+		CodeVerifier: "ver",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, tokenStore, "http://localhost:8080", ts.Client())
+
+	req := httptest.NewRequest("GET", "/upstream/callback/myroute?state=s&code=c", nil)
+	req.SetPathValue("routeName", "myroute")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d; token without expires_in should be rejected", rr.Code, http.StatusBadGateway)
+	}
+	// Token must not be saved when expires_in is missing.
+	if _, ok := tokenStore.Lookup("user", "myroute"); ok {
+		t.Error("token must not be saved when expires_in is missing")
 	}
 }

--- a/internal/upstreamoauth/callback_test.go
+++ b/internal/upstreamoauth/callback_test.go
@@ -1,0 +1,268 @@
+package upstreamoauth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
+)
+
+// testClientStore is a minimal in-memory ClientStore for testing.
+type testClientStore struct {
+	records map[string]upstreamoauth.ClientRecord
+}
+
+func (s *testClientStore) Load(routeName string) (upstreamoauth.ClientRecord, bool) {
+	r, ok := s.records[routeName]
+	return r, ok
+}
+
+func (s *testClientStore) Save(record upstreamoauth.ClientRecord) error {
+	s.records[record.RouteName] = record
+	return nil
+}
+
+func (s *testClientStore) All() []upstreamoauth.ClientRecord {
+	out := make([]upstreamoauth.ClientRecord, 0, len(s.records))
+	for _, r := range s.records {
+		out = append(out, r)
+	}
+	return out
+}
+
+func makeTokenServer(t *testing.T, response any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+}
+
+func makeCallbackHandler(
+	stateStore upstreamoauth.StateStore,
+	clientRecords map[string]upstreamoauth.ClientRecord,
+	tokenStore auth.UpstreamTokenStore,
+	publicURL string,
+	httpClient *http.Client,
+) *upstreamoauth.CallbackHandler {
+	cs := &testClientStore{records: clientRecords}
+	mgr := upstreamoauth.NewManager(cs, publicURL)
+	return upstreamoauth.NewCallbackHandler(stateStore, mgr, tokenStore, publicURL, httpClient)
+}
+
+func TestCallbackHandler_Success(t *testing.T) {
+	ts := makeTokenServer(t, map[string]any{
+		"access_token":  "tok123",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": "ref456",
+		"scope":         "read write",
+	})
+	defer ts.Close()
+
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	codeVerifier, _ := upstreamoauth.GenerateCodeVerifier()
+	stateStore.Save("state-key", upstreamoauth.OAuthState{
+		Subject:      "user@example.com",
+		RouteName:    "myroute",
+		OriginalPath: "/mcp/myroute",
+		CodeVerifier: codeVerifier,
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			Issuer:        "https://upstream.example.com",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "client-id",
+			ClientSecret:  "client-secret",
+		},
+	}, tokenStore, "http://localhost:8080", ts.Client())
+
+	req := httptest.NewRequest("GET", "/upstream/callback/myroute?state=state-key&code=auth-code", nil)
+	req.SetPathValue("routeName", "myroute")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	rec, ok := tokenStore.Lookup("user@example.com", "myroute")
+	if !ok {
+		t.Fatal("expected token to be saved in UpstreamTokenStore")
+	}
+	if rec.AccessToken != "tok123" {
+		t.Errorf("AccessToken = %q, want %q", rec.AccessToken, "tok123")
+	}
+	if rec.RefreshToken != "ref456" {
+		t.Errorf("RefreshToken = %q, want %q", rec.RefreshToken, "ref456")
+	}
+	if rec.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt must not be zero when expires_in > 0")
+	}
+}
+
+func TestCallbackHandler_InvalidState(t *testing.T) {
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{},
+		tokenStore, "http://localhost:8080", nil)
+
+	req := httptest.NewRequest("GET", "/upstream/callback/myroute?state=nonexistent&code=auth-code", nil)
+	req.SetPathValue("routeName", "myroute")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCallbackHandler_RouteMismatch(t *testing.T) {
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	stateStore.Save("state-key", upstreamoauth.OAuthState{
+		Subject:      "user",
+		RouteName:    "route-a", // state is for route-a
+		CodeVerifier: "verifier",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{},
+		tokenStore, "http://localhost:8080", nil)
+
+	// callback arrives for route-b
+	req := httptest.NewRequest("GET", "/upstream/callback/route-b?state=state-key&code=code", nil)
+	req.SetPathValue("routeName", "route-b")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCallbackHandler_SubjectFromStateNotFromContext(t *testing.T) {
+	// Verifies subject is recovered from StateStore, not middleware.IdentityFromContext.
+	// The request has no auth middleware context (identity = "").
+	const subject = "alice@example.com"
+
+	ts := makeTokenServer(t, map[string]any{
+		"access_token": "tok-alice",
+		"token_type":   "Bearer",
+	})
+	defer ts.Close()
+
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	stateStore.Save("s", upstreamoauth.OAuthState{
+		Subject:      subject,
+		RouteName:    "myroute",
+		CodeVerifier: "ver",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, tokenStore, "http://localhost:8080", ts.Client())
+
+	// No auth middleware context — IdentityFromContext returns "".
+	req := httptest.NewRequest("GET", "/upstream/callback/myroute?state=s&code=c", nil)
+	req.SetPathValue("routeName", "myroute")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	_, ok := tokenStore.Lookup(subject, "myroute")
+	if !ok {
+		t.Error("expected token to be saved using subject from state store, not from middleware context")
+	}
+}
+
+func TestCallbackHandler_RedirectURIConstruction(t *testing.T) {
+	const publicURL = "https://gateway.example.com"
+	const routeName = "cloudflare"
+
+	var capturedForm url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			capturedForm = r.Form
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer"}`))
+	}))
+	defer ts.Close()
+
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	stateStore.Save("s", upstreamoauth.OAuthState{
+		Subject:      "user",
+		RouteName:    routeName,
+		CodeVerifier: "ver",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:     routeName,
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, tokenStore, publicURL, ts.Client())
+
+	req := httptest.NewRequest("GET", "/upstream/callback/"+routeName+"?state=s&code=c", nil)
+	req.SetPathValue("routeName", routeName)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	wantRedirectURI := publicURL + "/upstream/callback/" + routeName
+	if capturedForm.Get("redirect_uri") != wantRedirectURI {
+		t.Errorf("redirect_uri = %q, want %q", capturedForm.Get("redirect_uri"), wantRedirectURI)
+	}
+}
+
+func TestCallbackHandler_MissingCode_ErrorParam(t *testing.T) {
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	handler := makeCallbackHandler(stateStore, map[string]upstreamoauth.ClientRecord{},
+		tokenStore, "http://localhost:8080", nil)
+
+	req := httptest.NewRequest("GET", "/upstream/callback/myroute?state=s&error=access_denied", nil)
+	req.SetPathValue("routeName", "myroute")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -1,0 +1,109 @@
+package upstreamoauth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/middleware"
+)
+
+const stateTTL = 10 * time.Minute
+
+func generateStateKey() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// NewAuthorizeMiddleware returns middleware that redirects authenticated users
+// to the upstream authorization endpoint when they have no valid upstream token.
+//
+// The middleware must sit between the gateway Auth middleware (which sets the
+// identity in context) and the proxy handler.
+func NewAuthorizeMiddleware(
+	routeName string,
+	upstreamOAuth string,
+	upstreamOAuthScope string,
+	resourceURL string,
+	manager *Manager,
+	stateStore StateStore,
+	tokenStore auth.UpstreamTokenStore,
+	publicURL string,
+) func(http.Handler) http.Handler {
+	trimmedPublicURL := strings.TrimRight(publicURL, "/")
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			subject := middleware.IdentityFromContext(r.Context())
+			if subject == "" {
+				http.Error(w, "unauthenticated", http.StatusUnauthorized)
+				return
+			}
+
+			if _, ok := tokenStore.Lookup(subject, routeName); ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			rec, err := manager.EnsureClient(r.Context(), routeName, upstreamOAuth, resourceURL)
+			if err != nil {
+				slog.Error("upstream OAuth: EnsureClient failed", "route", routeName, "err", err)
+				http.Error(w, "upstream OAuth configuration error", http.StatusBadGateway)
+				return
+			}
+
+			codeVerifier, err := GenerateCodeVerifier()
+			if err != nil {
+				slog.Error("upstream OAuth: code_verifier generation failed", "err", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			stateKey, err := generateStateKey()
+			if err != nil {
+				slog.Error("upstream OAuth: state generation failed", "err", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+
+			stateStore.Save(stateKey, OAuthState{
+				Subject:      subject,
+				RouteName:    routeName,
+				OriginalPath: r.URL.RequestURI(),
+				CodeVerifier: codeVerifier,
+				ExpiresAt:    time.Now().Add(stateTTL),
+			})
+
+			redirectURI := fmt.Sprintf("%s/upstream/callback/%s",
+				trimmedPublicURL,
+				url.PathEscape(routeName),
+			)
+			authURL, err := url.Parse(rec.AuthorizationEndpoint)
+			if err != nil {
+				slog.Error("upstream OAuth: invalid authorization_endpoint", "url", rec.AuthorizationEndpoint, "err", err)
+				http.Error(w, "upstream OAuth configuration error", http.StatusBadGateway)
+				return
+			}
+			q := authURL.Query()
+			q.Set("client_id", rec.ClientID)
+			q.Set("redirect_uri", redirectURI)
+			if upstreamOAuthScope != "" {
+				q.Set("scope", upstreamOAuthScope)
+			}
+			q.Set("response_type", "code")
+			q.Set("code_challenge", S256Challenge(codeVerifier))
+			q.Set("code_challenge_method", "S256")
+			q.Set("state", stateKey)
+			authURL.RawQuery = q.Encode()
+
+			http.Redirect(w, r, authURL.String(), http.StatusFound)
+		})
+	}
+}

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -1,0 +1,216 @@
+package upstreamoauth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/middleware"
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
+)
+
+func withIdentity(r *http.Request, subject string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), middleware.ContextKeyIdentity, subject))
+}
+
+func TestAuthorizeMiddleware_Unauthenticated(t *testing.T) {
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		"myroute", "https://as.example.com", "", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called for unauthenticated request")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthorizeMiddleware_ValidToken_PassThrough(t *testing.T) {
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("alice@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "existing-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		"myroute", "https://as.example.com", "", "", mgr,
+		upstreamoauth.NewStateStore(), tokenStore, "http://localhost:8080",
+	)
+	nextCalled := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
+	req = withIdentity(req, "alice@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called when valid token exists")
+	}
+}
+
+func TestAuthorizeMiddleware_RedirectWithPKCE(t *testing.T) {
+	const (
+		routeName = "myroute"
+		publicURL = "http://localhost:8080"
+		subject   = "bob@example.com"
+	)
+
+	// Pre-register a client so EnsureClient short-circuits without network I/O.
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:             routeName,
+			Issuer:                "https://as.example.com",
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			TokenEndpoint:         "https://as.example.com/token",
+			ClientID:              "client-id",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, publicURL)
+
+	stateStore := upstreamoauth.NewStateStore()
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		routeName, "https://as.example.com", "read write", "", mgr, stateStore, tokenStore, publicURL,
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called when redirect is expected")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
+	req = withIdentity(req, subject)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusFound, rr.Body.String())
+	}
+
+	loc := rr.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("expected Location header in redirect response")
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("invalid Location URL: %v", err)
+	}
+	q := u.Query()
+
+	if q.Get("client_id") != "client-id" {
+		t.Errorf("client_id = %q, want %q", q.Get("client_id"), "client-id")
+	}
+	wantRedirectURI := publicURL + "/upstream/callback/" + routeName
+	if q.Get("redirect_uri") != wantRedirectURI {
+		t.Errorf("redirect_uri = %q, want %q", q.Get("redirect_uri"), wantRedirectURI)
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want %q", q.Get("response_type"), "code")
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want %q", q.Get("code_challenge_method"), "S256")
+	}
+	if q.Get("code_challenge") == "" {
+		t.Error("code_challenge must not be empty")
+	}
+	if q.Get("scope") != "read write" {
+		t.Errorf("scope = %q, want %q", q.Get("scope"), "read write")
+	}
+
+	stateKey := q.Get("state")
+	if stateKey == "" {
+		t.Fatal("state parameter must not be empty")
+	}
+	savedState, ok := stateStore.Pop(stateKey)
+	if !ok {
+		t.Fatal("state key must be saved in StateStore")
+	}
+	if savedState.Subject != subject {
+		t.Errorf("state.Subject = %q, want %q", savedState.Subject, subject)
+	}
+	if savedState.RouteName != routeName {
+		t.Errorf("state.RouteName = %q, want %q", savedState.RouteName, routeName)
+	}
+	if savedState.CodeVerifier == "" {
+		t.Error("state.CodeVerifier must not be empty")
+	}
+}
+
+func TestAuthorizeMiddleware_ScopeOmitted(t *testing.T) {
+	const routeName = "myroute"
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:             routeName,
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			ClientID:              "cid",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		routeName, "https://as.example.com", "", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
+	req = withIdentity(req, "user@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+	}
+	loc := rr.Header().Get("Location")
+	u, _ := url.Parse(loc)
+	if u.Query().Get("scope") != "" {
+		t.Errorf("scope must be omitted when upstreamOAuthScope is empty, got %q", u.Query().Get("scope"))
+	}
+}
+
+func TestAuthorizeMiddleware_EnsureClientError(t *testing.T) {
+	// AS returns 404 → discovery fails → EnsureClient error → 502.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		"myroute", ts.URL, "", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called on EnsureClient error")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
+	req = withIdentity(req, "user@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+	}
+}

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -111,6 +111,12 @@ func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, re
 	return v.(sfResult).record, nil
 }
 
+// LoadClient returns the persisted ClientRecord for routeName without
+// performing discovery or DCR. Returns (zero, false) when no record exists.
+func (m *Manager) LoadClient(routeName string) (ClientRecord, bool) {
+	return m.store.Load(routeName)
+}
+
 // discoverCached returns AS metadata for routeName, using the in-memory
 // cache to avoid repeated network calls for the same route.
 func (m *Manager) discoverCached(ctx context.Context, routeName, upstreamOAuth, resourceURL string) (*AuthServerMetadata, error) {

--- a/internal/upstreamoauth/pkce.go
+++ b/internal/upstreamoauth/pkce.go
@@ -1,0 +1,24 @@
+package upstreamoauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// GenerateCodeVerifier returns a cryptographically random PKCE code_verifier
+// using 32 bytes of entropy, base64url-encoded without padding (RFC 7636 §4.1).
+func GenerateCodeVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// S256Challenge computes the PKCE code_challenge from verifier using the S256
+// method: BASE64URL(SHA256(ASCII(verifier))) without padding (RFC 7636 §4.2).
+func S256Challenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}

--- a/internal/upstreamoauth/pkce_test.go
+++ b/internal/upstreamoauth/pkce_test.go
@@ -1,0 +1,79 @@
+package upstreamoauth_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
+)
+
+func TestGenerateCodeVerifier_Uniqueness(t *testing.T) {
+	v1, err := upstreamoauth.GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier() error: %v", err)
+	}
+	v2, err := upstreamoauth.GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier() error: %v", err)
+	}
+	if v1 == v2 {
+		t.Error("expected different verifiers on each call")
+	}
+}
+
+func TestGenerateCodeVerifier_Format(t *testing.T) {
+	v, err := upstreamoauth.GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier() error: %v", err)
+	}
+	// base64url-encoded 32 bytes = 43 characters (no padding)
+	if len(v) != 43 {
+		t.Errorf("code_verifier length = %d, want 43", len(v))
+	}
+	// Must not contain padding characters
+	if strings.Contains(v, "=") {
+		t.Errorf("code_verifier must not contain '=' padding: %q", v)
+	}
+	// Must be valid base64url
+	if _, err := base64.RawURLEncoding.DecodeString(v); err != nil {
+		t.Errorf("code_verifier is not valid base64url: %v", err)
+	}
+}
+
+func TestS256Challenge_Correctness(t *testing.T) {
+	// RFC 7636 §B test vector
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	got := upstreamoauth.S256Challenge(verifier)
+
+	h := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(h[:])
+
+	if got != want {
+		t.Errorf("S256Challenge(%q) = %q, want %q", verifier, got, want)
+	}
+}
+
+func TestS256Challenge_NoPadding(t *testing.T) {
+	verifier := "test-verifier-value"
+	challenge := upstreamoauth.S256Challenge(verifier)
+	if strings.Contains(challenge, "=") {
+		t.Errorf("S256Challenge must not contain '=' padding: %q", challenge)
+	}
+}
+
+func TestS256Challenge_RoundTrip(t *testing.T) {
+	v, err := upstreamoauth.GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier() error: %v", err)
+	}
+	challenge := upstreamoauth.S256Challenge(v)
+
+	// Verify manually
+	h := sha256.Sum256([]byte(v))
+	want := base64.RawURLEncoding.EncodeToString(h[:])
+	if challenge != want {
+		t.Errorf("S256Challenge round-trip mismatch: got %q, want %q", challenge, want)
+	}
+}

--- a/internal/upstreamoauth/statestore.go
+++ b/internal/upstreamoauth/statestore.go
@@ -1,0 +1,70 @@
+package upstreamoauth
+
+import (
+	"sync"
+	"time"
+)
+
+// OAuthState holds the per-authorization-request state keyed by the opaque
+// state parameter. Stored in-memory and consumed exactly once on callback
+// to prevent replay attacks.
+type OAuthState struct {
+	Subject      string    // gateway-authenticated user identity (from Auth middleware at flow start)
+	RouteName    string
+	OriginalPath string    // reserved for future transparent redirect restore; unused in MVP
+	CodeVerifier string    // PKCE code_verifier
+	ExpiresAt    time.Time // state expiry (10 minutes from creation)
+}
+
+// StateStore is a thread-safe in-memory store for upstream OAuth authorization
+// states. Each state entry is consumed exactly once via Pop to prevent replay
+// attacks. Expired entries are removed by Sweep.
+type StateStore interface {
+	Save(key string, state OAuthState)
+	// Pop returns and deletes the state for key. Returns (zero, false) when
+	// the key is absent or the entry has expired.
+	Pop(key string) (OAuthState, bool)
+	// Sweep removes all expired entries.
+	Sweep()
+}
+
+type memStateStore struct {
+	mu      sync.Mutex
+	entries map[string]OAuthState
+}
+
+// NewStateStore returns a new in-memory StateStore.
+func NewStateStore() StateStore {
+	return &memStateStore{entries: make(map[string]OAuthState)}
+}
+
+func (s *memStateStore) Save(key string, state OAuthState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = state
+}
+
+func (s *memStateStore) Pop(key string) (OAuthState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.entries[key]
+	if !ok {
+		return OAuthState{}, false
+	}
+	delete(s.entries, key)
+	if time.Now().After(state.ExpiresAt) {
+		return OAuthState{}, false
+	}
+	return state, true
+}
+
+func (s *memStateStore) Sweep() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, v := range s.entries {
+		if now.After(v.ExpiresAt) {
+			delete(s.entries, k)
+		}
+	}
+}

--- a/internal/upstreamoauth/statestore_test.go
+++ b/internal/upstreamoauth/statestore_test.go
@@ -1,0 +1,108 @@
+package upstreamoauth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
+)
+
+func TestStateStore_SaveAndPop(t *testing.T) {
+	store := upstreamoauth.NewStateStore()
+	state := upstreamoauth.OAuthState{
+		Subject:      "user1",
+		RouteName:    "route1",
+		OriginalPath: "/mcp/test",
+		CodeVerifier: "verifier123",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	}
+	store.Save("key1", state)
+
+	got, ok := store.Pop("key1")
+	if !ok {
+		t.Fatal("expected to find state")
+	}
+	if got.Subject != state.Subject {
+		t.Errorf("Subject = %q, want %q", got.Subject, state.Subject)
+	}
+	if got.RouteName != state.RouteName {
+		t.Errorf("RouteName = %q, want %q", got.RouteName, state.RouteName)
+	}
+	if got.CodeVerifier != state.CodeVerifier {
+		t.Errorf("CodeVerifier = %q, want %q", got.CodeVerifier, state.CodeVerifier)
+	}
+}
+
+func TestStateStore_PopConsumed(t *testing.T) {
+	store := upstreamoauth.NewStateStore()
+	store.Save("key", upstreamoauth.OAuthState{
+		Subject:   "user",
+		RouteName: "route",
+		ExpiresAt: time.Now().Add(10 * time.Minute),
+	})
+
+	_, ok := store.Pop("key")
+	if !ok {
+		t.Fatal("first Pop: expected to find state")
+	}
+	// second Pop must return false (replay prevention)
+	_, ok = store.Pop("key")
+	if ok {
+		t.Error("second Pop: expected state to be consumed after first Pop")
+	}
+}
+
+func TestStateStore_NonExistentKey(t *testing.T) {
+	store := upstreamoauth.NewStateStore()
+	_, ok := store.Pop("nonexistent")
+	if ok {
+		t.Error("expected false for nonexistent key")
+	}
+}
+
+func TestStateStore_ExpiredEntryRejected(t *testing.T) {
+	store := upstreamoauth.NewStateStore()
+	store.Save("expired-key", upstreamoauth.OAuthState{
+		Subject:      "user1",
+		RouteName:    "route1",
+		CodeVerifier: "ver",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute), // already expired
+	})
+
+	_, ok := store.Pop("expired-key")
+	if ok {
+		t.Error("expected expired state to be rejected by Pop")
+	}
+}
+
+func TestStateStore_Sweep(t *testing.T) {
+	store := upstreamoauth.NewStateStore()
+
+	store.Save("active", upstreamoauth.OAuthState{
+		Subject:   "user1",
+		RouteName: "route1",
+		ExpiresAt: time.Now().Add(10 * time.Minute),
+	})
+	store.Save("expired1", upstreamoauth.OAuthState{
+		Subject:   "user2",
+		RouteName: "route1",
+		ExpiresAt: time.Now().Add(-1 * time.Minute),
+	})
+	store.Save("expired2", upstreamoauth.OAuthState{
+		Subject:   "user3",
+		RouteName: "route2",
+		ExpiresAt: time.Now().Add(-5 * time.Minute),
+	})
+
+	store.Sweep()
+
+	if _, ok := store.Pop("active"); !ok {
+		t.Error("active state should survive Sweep")
+	}
+	if _, ok := store.Pop("expired1"); ok {
+		t.Error("expired1 should be removed by Sweep")
+	}
+	if _, ok := store.Pop("expired2"); ok {
+		t.Error("expired2 should be removed by Sweep")
+	}
+}


### PR DESCRIPTION
## Summary

- PKCE `code_verifier` / `code_challenge` 生成（S256、RFC 7636）
- in-memory `StateStore`（TTL 10分・Pop でリプレイ防止・Sweep でTTL切れ削除）
- 認可フロー開始ミドルウェア（`NewAuthorizeMiddleware`）: upstream トークンなし → 302 リダイレクト to upstream authorization endpoint
- コールバックハンドラ `GET /upstream/callback/{routeName}`: state 検証 → コード交換 → `UpstreamTokenStore.Save`
  - subject は state store から復元（`middleware.IdentityFromContext` 非依存）
- `Manager.LoadClient` メソッド追加（コールバック時の ClientRecord 参照）
- `main.go`: upstream_oauth が設定されたルートが存在する場合にストア・マネージャ・コールバックを初期化し、各ルートにAuthorizeMiddlewareを適用

## スコープ外（後続 ISSUE）

- プロキシへのトークン注入（#117）
- upstream トークンのリフレッシュ（#118）
- コールバック後の元リクエストへの透過的な復元

## Test plan

- [x] `statestore_test.go`: Save/Pop・消費確認・不存在キー・TTL切れ拒否・Sweep
- [x] `pkce_test.go`: GenerateCodeVerifier の一意性・フォーマット、S256Challenge の正確性・ノーパディング
- [x] `callback_test.go`: 正常フロー・不正state・ルート名不一致・subject復元（contextなし）・redirect_uri組み立て・エラーパラメータ
- [x] 全テスト PASS / staticcheck 0 issues

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)