### PR TITLE
feat(proxy): upstream OAuth トークン注入と 401 時のトークン削除 #117

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -337,7 +337,14 @@ func main() {
 	// /.well-known/oauth-protected-resource{prefix}, and 401 responses point
 	// resource_metadata at that route-scoped URL.
 	for _, route := range routes {
-		h := proxy.NewHandler(route.Upstream, oauthHandler, route.UpstreamBearerTokenEnv, route.Prefix)
+		var upstreamOAuthOpts *proxy.UpstreamOAuthOptions
+		if route.UpstreamOAuth != "" && upstreamTokenStore != nil {
+			upstreamOAuthOpts = &proxy.UpstreamOAuthOptions{
+				TokenStore: upstreamTokenStore,
+				RouteName:  route.Name,
+			}
+		}
+		h := proxy.NewHandler(route.Upstream, oauthHandler, route.UpstreamBearerTokenEnv, route.Prefix, upstreamOAuthOpts)
 		var wrapped http.Handler
 		if route.NoAuth {
 			wrapped = h

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -134,18 +134,23 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 					// Delete the stale token so the next request triggers re-authorization.
 					// Automatic refresh is handled by #118.
 					subject := middleware.IdentityFromContext(resp.Request.Context())
-					if subject != "" {
-						if err := upstreamOAuth.TokenStore.Delete(subject, upstreamOAuth.RouteName); err != nil {
-							slog.Warn("upstream OAuth: failed to delete stale token",
-								"route", upstreamOAuth.RouteName,
-								"err", err,
-							)
-						}
+					if subject == "" {
+						slog.Warn("upstream OAuth: upstream 401; no authenticated subject in context, stale token not deleted",
+							"route", upstreamOAuth.RouteName,
+							"path", resp.Request.URL.Path,
+						)
+					} else if err := upstreamOAuth.TokenStore.Delete(subject, upstreamOAuth.RouteName); err != nil {
+						slog.Warn("upstream OAuth: upstream 401; failed to delete stale token, re-authorization may not trigger",
+							"route", upstreamOAuth.RouteName,
+							"path", resp.Request.URL.Path,
+							"err", err,
+						)
+					} else {
+						slog.Warn("upstream OAuth: upstream 401; token deleted, re-authorization required",
+							"route", upstreamOAuth.RouteName,
+							"path", resp.Request.URL.Path,
+						)
 					}
-					slog.Warn("upstream OAuth: upstream 401; token deleted, re-authorization required",
-						"route", upstreamOAuth.RouteName,
-						"path", resp.Request.URL.Path,
-					)
 				} else if upstreamBearerTokenEnv != "" {
 					// The 401 came from an upstream-credential route.
 					// This is a problem with the upstream API token, not the

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
 
@@ -18,19 +19,29 @@ type TokenInvalidator interface {
 	InvalidateCachedToken(token string)
 }
 
+// UpstreamOAuthOptions configures per-user upstream OAuth token injection.
+// When non-nil, the proxy reads the upstream access token from TokenStore
+// instead of forwarding the gateway client token.
+type UpstreamOAuthOptions struct {
+	TokenStore auth.UpstreamTokenStore
+	RouteName  string
+}
+
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
 // requests to the upstream MCP server. It performs header sanitization,
 // injects the verified user identifier as X-Authenticated-User (and the
 // legacy X-GitHub-Login during the migration window), and invalidates the
 // token cache when the upstream returns HTTP 401.
 //
-// When upstreamBearerTokenEnv is non-empty, the named environment variable
-// is read on each request and its value is injected as the upstream
-// Authorization Bearer token instead of the client OAuth context token.
-// In this mode, upstream 401 responses are NOT treated as client token
-// invalidation events — the failure belongs to the upstream credential,
-// not the client session.
-func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv string, prefix string) http.Handler {
+// Token injection priority:
+//  1. upstreamOAuth non-nil → per-user token from UpstreamTokenStore
+//  2. upstreamBearerTokenEnv non-empty → token from named env var
+//  3. otherwise → gateway client OAuth token from context
+//
+// When upstreamOAuth is set and upstream returns 401, the stale token is
+// deleted from TokenStore and re-authorization is required (#118 handles
+// automatic refresh).
+func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv string, prefix string, upstreamOAuth *UpstreamOAuthOptions) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			// Strip prefix before SetURL so that SetURL correctly joins
@@ -71,7 +82,20 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 			// Always strip client-supplied Authorization first to prevent spoofing,
 			// then inject the appropriate upstream credential.
 			pr.Out.Header.Del("Authorization")
-			if upstreamBearerTokenEnv != "" {
+			if upstreamOAuth != nil {
+				// Per-user upstream OAuth token: inject the user's upstream access token.
+				// NewAuthorizeMiddleware guarantees a token exists before reaching here;
+				// the Lookup is defensive against misconfigured middleware chains.
+				subject := middleware.IdentityFromContext(pr.In.Context())
+				if rec, ok := upstreamOAuth.TokenStore.Lookup(subject, upstreamOAuth.RouteName); ok {
+					pr.Out.Header.Set("Authorization", "Bearer "+rec.AccessToken)
+				} else {
+					slog.Warn("upstream OAuth: token not found at proxy injection; request forwarded without Authorization",
+						"route", upstreamOAuth.RouteName,
+						"path", pr.Out.URL.Path,
+					)
+				}
+			} else if upstreamBearerTokenEnv != "" {
 				// Upstream credential injection: read the named env var at request time.
 				// A warning is emitted when the env var is unset or empty so that
 				// rotated or missing credentials are visible in logs.
@@ -105,7 +129,24 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 
 		ModifyResponse: func(resp *http.Response) error {
 			if resp.StatusCode == http.StatusUnauthorized {
-				if upstreamBearerTokenEnv != "" {
+				if upstreamOAuth != nil {
+					// The 401 came from an upstream OAuth route.
+					// Delete the stale token so the next request triggers re-authorization.
+					// Automatic refresh is handled by #118.
+					subject := middleware.IdentityFromContext(resp.Request.Context())
+					if subject != "" {
+						if err := upstreamOAuth.TokenStore.Delete(subject, upstreamOAuth.RouteName); err != nil {
+							slog.Warn("upstream OAuth: failed to delete stale token",
+								"route", upstreamOAuth.RouteName,
+								"err", err,
+							)
+						}
+					}
+					slog.Warn("upstream OAuth: upstream 401; token deleted, re-authorization required",
+						"route", upstreamOAuth.RouteName,
+						"path", resp.Request.URL.Path,
+					)
+				} else if upstreamBearerTokenEnv != "" {
 					// The 401 came from an upstream-credential route.
 					// This is a problem with the upstream API token, not the
 					// client OAuth session — do NOT invalidate the client cache.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -559,5 +560,72 @@ func TestProxyUpstreamOAuthDoesNotInvalidateGatewayTokenOn401(t *testing.T) {
 
 	if len(inv.tokens) != 0 {
 		t.Errorf("expected no gateway token invalidation for upstream_oauth route, got %v", inv.tokens)
+	}
+}
+
+// deleteErrStore wraps UpstreamTokenStore and returns a fixed error from Delete.
+type deleteErrStore struct {
+	inner     auth.UpstreamTokenStore
+	deleteErr error
+}
+
+func (s *deleteErrStore) Save(subject, routeName string, rec auth.UpstreamTokenRecord) error {
+	return s.inner.Save(subject, routeName, rec)
+}
+func (s *deleteErrStore) Lookup(subject, routeName string) (auth.UpstreamTokenRecord, bool) {
+	return s.inner.Lookup(subject, routeName)
+}
+func (s *deleteErrStore) Delete(_, _ string) error { return s.deleteErr }
+func (s *deleteErrStore) Sweep() error             { return s.inner.Sweep() }
+
+func TestProxyUpstreamOAuthNoSubjectOn401(t *testing.T) {
+	// subject が空（middleware なし）の場合 Delete は呼ばれず 401 がそのまま返る。
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+	})
+
+	// request without identity in context
+	req := httptest.NewRequest(http.MethodGet, "/mcp/myroute/sse", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestProxyUpstreamOAuthDeleteErrorOn401(t *testing.T) {
+	// Delete が失敗した場合も 401 がそのまま返る（panic しない）。
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	inner := auth.NewMemUpstreamTokenStore()
+	_ = inner.Save("dave@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "tok",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+	tokenStore := &deleteErrStore{inner: inner, deleteErr: fmt.Errorf("flush error")}
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("dave@example.com", "gateway-client-token"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	// token must remain in store (Delete failed)
+	if _, ok := inner.Lookup("dave@example.com", "myroute"); !ok {
+		t.Error("token should remain when Delete fails")
 	}
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -7,7 +7,9 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
 	"github.com/scottlz0310/mcp-gateway/internal/middleware"
 )
 
@@ -52,7 +54,7 @@ func TestProxyInjectsIdentityHeaders(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "", "")
+	h := NewHandler(u, &mockInvalidator{}, "", "", nil)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice", "tok"))
@@ -88,7 +90,7 @@ func TestProxyStripsClientSpoofableHeaders(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "", "")
+	h := NewHandler(u, &mockInvalidator{}, "", "", nil)
 
 	r := requestWithContext("bob", "tok")
 	r.Header.Set("X-Forwarded-For", "1.2.3.4")
@@ -134,7 +136,7 @@ func TestProxyNormalizesAuthorization(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "", "")
+	h := NewHandler(u, &mockInvalidator{}, "", "", nil)
 
 	r := requestWithContext("carol", "ctx-token")
 	r.Header.Set("Authorization", "Bearer client-supplied-token")
@@ -153,7 +155,7 @@ func TestProxyInvalidatesCacheOn401(t *testing.T) {
 
 	u, _ := url.Parse(upstream.URL)
 	inv := &mockInvalidator{}
-	h := NewHandler(u, inv, "", "")
+	h := NewHandler(u, inv, "", "", nil)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("dave", "secret-token"))
@@ -172,7 +174,7 @@ func TestProxySanitizesHeaderInjectionCharacters(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "", "")
+	h := NewHandler(u, &mockInvalidator{}, "", "", nil)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice\r\nevil: injected", "tok"))
@@ -187,7 +189,7 @@ func TestProxyNilInvalidatorDoesNotPanicOn401(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, nil, "", "")
+	h := NewHandler(u, nil, "", "", nil)
 
 	w := httptest.NewRecorder()
 	// Must not panic.
@@ -214,7 +216,7 @@ func TestMiddlewareToProxyInjectsIdentityHeaders(t *testing.T) {
 
 	u, _ := url.Parse(upstream.URL)
 	validator := &testValidator{login: "octocat"}
-	chain := middleware.Auth(validator)(NewHandler(u, &mockInvalidator{}, "", ""))
+	chain := middleware.Auth(validator)(NewHandler(u, &mockInvalidator{}, "", "", nil))
 
 	r := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
 	r.Header.Set("Authorization", "Bearer real-github-token")
@@ -245,7 +247,7 @@ func TestProxyUpstreamBearerEnvInjectsToken(t *testing.T) {
 
 	t.Setenv("UPSTREAM_TEST_TOKEN", "env-api-token")
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN", "")
+	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN", "", nil)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("alice", "client-oauth-token"))
@@ -265,7 +267,7 @@ func TestProxyUpstreamBearerEnvStripsClientAuth(t *testing.T) {
 
 	t.Setenv("UPSTREAM_TEST_TOKEN2", "real-env-token")
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN2", "")
+	h := NewHandler(u, &mockInvalidator{}, "UPSTREAM_TEST_TOKEN2", "", nil)
 
 	req := requestWithContext("bob", "client-token")
 	req.Header.Set("Authorization", "Bearer client-supplied-auth")
@@ -284,7 +286,7 @@ func TestProxyUpstreamBearerEnvDoesNotInvalidateOn401(t *testing.T) {
 	t.Setenv("UPSTREAM_TEST_TOKEN3", "some-api-token")
 	u, _ := url.Parse(upstream.URL)
 	inv := &mockInvalidator{}
-	h := NewHandler(u, inv, "UPSTREAM_TEST_TOKEN3", "")
+	h := NewHandler(u, inv, "UPSTREAM_TEST_TOKEN3", "", nil)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, requestWithContext("carol", "client-oauth-token"))
@@ -343,7 +345,7 @@ func TestProxyStripsRoutingPrefix(t *testing.T) {
 			defer upstream.Close()
 
 			u, _ := url.Parse(upstream.URL)
-			h := NewHandler(u, &mockInvalidator{}, "", tc.prefix)
+			h := NewHandler(u, &mockInvalidator{}, "", tc.prefix, nil)
 
 			r := httptest.NewRequest(http.MethodGet, tc.requestPath, nil)
 			ctx := context.WithValue(r.Context(), middleware.ContextKeyIdentity, "alice")
@@ -424,7 +426,7 @@ func TestProxyStripsRoutingPrefixWithUpstreamBasePath(t *testing.T) {
 			defer upstream.Close()
 
 			u, _ := url.Parse(upstream.URL + tc.upstreamBase)
-			h := NewHandler(u, &mockInvalidator{}, "", tc.prefix)
+			h := NewHandler(u, &mockInvalidator{}, "", tc.prefix, nil)
 
 			r := httptest.NewRequest(http.MethodGet, tc.requestTarget, nil)
 			ctx := context.WithValue(r.Context(), middleware.ContextKeyIdentity, "alice")
@@ -460,7 +462,7 @@ func TestProxyStripsRoutingPrefixRawPath(t *testing.T) {
 	defer upstream.Close()
 
 	u, _ := url.Parse(upstream.URL)
-	h := NewHandler(u, &mockInvalidator{}, "", "/mcp/test")
+	h := NewHandler(u, &mockInvalidator{}, "", "/mcp/test", nil)
 
 	// %40 encodes '@': Path = /mcp/test/file@name, RawPath = /mcp/test/file%40name.
 	r := httptest.NewRequest(http.MethodGet, "/mcp/test/file%40name", nil)
@@ -476,5 +478,86 @@ func TestProxyStripsRoutingPrefixRawPath(t *testing.T) {
 	}
 	if gotRawPath != "/file%40name" {
 		t.Errorf("upstream RawPath: got %q, want %q", gotRawPath, "/file%40name")
+	}
+}
+
+func TestProxyUpstreamOAuthInjectsToken(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("alice@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "upstream-access-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+	})
+
+	r := requestWithContext("alice@example.com", "gateway-client-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if gotAuth != "Bearer upstream-access-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer upstream-access-token")
+	}
+}
+
+func TestProxyUpstreamOAuthDeletesTokenOn401(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("bob@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "stale-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("bob@example.com", "gateway-client-token"))
+
+	if _, ok := tokenStore.Lookup("bob@example.com", "myroute"); ok {
+		t.Error("expected upstream token to be deleted after upstream 401")
+	}
+}
+
+func TestProxyUpstreamOAuthDoesNotInvalidateGatewayTokenOn401(t *testing.T) {
+	// When upstream_oauth is set and upstream returns 401, the gateway
+	// client token cache must NOT be invalidated (the 401 is the upstream AS
+	// rejecting our per-user token, not the gateway session token).
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("carol@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "upstream-tok",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	u, _ := url.Parse(upstream.URL)
+	inv := &mockInvalidator{}
+	h := NewHandler(u, inv, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("carol@example.com", "gateway-client-token"))
+
+	if len(inv.tokens) != 0 {
+		t.Errorf("expected no gateway token invalidation for upstream_oauth route, got %v", inv.tokens)
 	}
 }


### PR DESCRIPTION
## Summary

- `proxy.NewHandler` に `UpstreamOAuthOptions` を追加し、`upstream_oauth` 設定ルートで `UpstreamTokenStore` からユーザー別アクセストークンを取得して `Authorization: Bearer` として注入する
- upstream が 401 を返した場合は `TokenStore` の該当エントリを削除し再認証を要求する（自動 refresh は #118）
- gateway クライアントトークンのキャッシュ無効化は行わない（upstream AS 側の拒否のため）
- 既存の `upstreamBearerTokenEnv` / gateway fallback フローは変更なし（リグレッションテスト済み）

## Changes

- `internal/proxy/handler.go`: `UpstreamOAuthOptions` struct 追加、`NewHandler` シグネチャ拡張、注入ロジック・401 ハンドリング拡張
- `internal/proxy/handler_test.go`: 既存テストに `nil` 引数追加（リグレッション）+ 新規テスト 3 件
- `cmd/server/main.go`: `NewHandler` 呼び出し更新（`upstream_oauth` ルートで `UpstreamOAuthOptions` を渡す）

## Test plan

- [ ] `TestProxyUpstreamOAuthInjectsToken`: UpstreamTokenStore のトークンが Authorization ヘッダに注入されること
- [ ] `TestProxyUpstreamOAuthDeletesTokenOn401`: upstream 401 で TokenStore エントリが削除されること
- [ ] `TestProxyUpstreamOAuthDoesNotInvalidateGatewayTokenOn401`: upstream_oauth ルートの 401 で gateway トークンキャッシュが無効化されないこと
- [ ] 既存テスト（`upstream_bearer_token_env` / gateway fallback）が全て pass であること

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)