### PR TITLE
feat(proxy): upstream OAuth proactive refresh + 401 transparent retry (#118)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -296,6 +296,7 @@ func main() {
 	var upstreamManager *upstreamoauth.Manager
 	var upstreamStateStore upstreamoauth.StateStore
 	var upstreamTokenStore auth.UpstreamTokenStore
+	var upstreamRefresher *upstreamoauth.Refresher
 	for _, r := range routes {
 		if r.UpstreamOAuth != "" {
 			clientStore, err := upstreamoauth.NewFileClientStore(cfg.upstreamClientStorePath)
@@ -310,6 +311,7 @@ func main() {
 				slog.Error("failed to initialize upstream token store", "err", err)
 				os.Exit(1)
 			}
+			upstreamRefresher = upstreamoauth.NewRefresher(upstreamTokenStore, upstreamManager, nil)
 			callbackHandler := upstreamoauth.NewCallbackHandler(
 				upstreamStateStore, upstreamManager, upstreamTokenStore, publicURL, nil,
 			)
@@ -342,6 +344,7 @@ func main() {
 			upstreamOAuthOpts = &proxy.UpstreamOAuthOptions{
 				TokenStore: upstreamTokenStore,
 				RouteName:  route.Name,
+				Refresher:  upstreamRefresher,
 			}
 		}
 		h := proxy.NewHandler(route.Upstream, oauthHandler, route.UpstreamBearerTokenEnv, route.Prefix, upstreamOAuthOpts)

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -41,17 +41,23 @@ type UpstreamOAuthOptions struct {
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
 // requests to the upstream MCP server. It performs header sanitization,
 // injects the verified user identifier as X-Authenticated-User (and the
-// legacy X-GitHub-Login during the migration window), and invalidates the
-// token cache when the upstream returns HTTP 401.
+// legacy X-GitHub-Login during the migration window), and handles upstream
+// HTTP 401 responses according to the configured token source.
 //
 // Token injection priority:
-//  1. upstreamOAuth non-nil → per-user token from UpstreamTokenStore
-//  2. upstreamBearerTokenEnv non-empty → token from named env var
-//  3. otherwise → gateway client OAuth token from context
+//  1. upstreamOAuth non-nil → per-user token from UpstreamTokenStore,
+//     with optional proactive refresh via UpstreamOAuthOptions.Refresher.
+//  2. upstreamBearerTokenEnv non-empty → token from named env var.
+//  3. otherwise → gateway client OAuth token from context.
 //
-// When upstreamOAuth is set and upstream returns 401, the stale token is
-// deleted from TokenStore and re-authorization is required (#118 handles
-// automatic refresh).
+// Upstream 401 handling:
+//   - upstreamOAuth with Refresher: refreshingTransport intercepts the 401,
+//     calls RefreshAfter401, and retries with the new token transparently.
+//     If refresh fails, the 401 propagates and ModifyResponse logs it.
+//   - upstreamOAuth without Refresher: the stale token is deleted from
+//     TokenStore so the next request triggers re-authorization.
+//   - upstreamBearerTokenEnv: logs a warning; env var token must be rotated.
+//   - otherwise: invalidates the gateway client token cache.
 func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv string, prefix string, upstreamOAuth *UpstreamOAuthOptions) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
@@ -19,12 +20,22 @@ type TokenInvalidator interface {
 	InvalidateCachedToken(token string)
 }
 
+// UpstreamTokenRefresher handles proactive and 401-triggered upstream OAuth
+// token refresh. Implemented by upstreamoauth.Refresher.
+type UpstreamTokenRefresher interface {
+	EnsureFreshToken(ctx context.Context, subject, routeName string, rec auth.UpstreamTokenRecord) (auth.UpstreamTokenRecord, bool)
+	RefreshAfter401(ctx context.Context, subject, routeName string) (auth.UpstreamTokenRecord, bool)
+}
+
 // UpstreamOAuthOptions configures per-user upstream OAuth token injection.
 // When non-nil, the proxy reads the upstream access token from TokenStore
 // instead of forwarding the gateway client token.
+// Refresher is optional: when set, proactive refresh is attempted before
+// injection and 401 responses trigger transparent token refresh + retry.
 type UpstreamOAuthOptions struct {
 	TokenStore auth.UpstreamTokenStore
 	RouteName  string
+	Refresher  UpstreamTokenRefresher // nil = no proactive/auto refresh
 }
 
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
@@ -88,7 +99,17 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 				// the Lookup is defensive against misconfigured middleware chains.
 				subject := middleware.IdentityFromContext(pr.In.Context())
 				if rec, ok := upstreamOAuth.TokenStore.Lookup(subject, upstreamOAuth.RouteName); ok {
-					pr.Out.Header.Set("Authorization", "Bearer "+rec.AccessToken)
+					if upstreamOAuth.Refresher != nil {
+						rec, ok = upstreamOAuth.Refresher.EnsureFreshToken(pr.In.Context(), subject, upstreamOAuth.RouteName, rec)
+					}
+					if ok {
+						pr.Out.Header.Set("Authorization", "Bearer "+rec.AccessToken)
+					} else {
+						slog.Warn("upstream OAuth: proactive refresh failed; forwarding without Authorization",
+							"route", upstreamOAuth.RouteName,
+							"path", pr.Out.URL.Path,
+						)
+					}
 				} else {
 					slog.Warn("upstream OAuth: token not found at proxy injection; request forwarded without Authorization",
 						"route", upstreamOAuth.RouteName,
@@ -130,26 +151,35 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 		ModifyResponse: func(resp *http.Response) error {
 			if resp.StatusCode == http.StatusUnauthorized {
 				if upstreamOAuth != nil {
-					// The 401 came from an upstream OAuth route.
-					// Delete the stale token so the next request triggers re-authorization.
-					// Automatic refresh is handled by #118.
-					subject := middleware.IdentityFromContext(resp.Request.Context())
-					if subject == "" {
-						slog.Warn("upstream OAuth: upstream 401; no authenticated subject in context, stale token not deleted",
+					if upstreamOAuth.Refresher != nil {
+						// refreshingTransport already attempted refresh+retry and deleted
+						// the token on permanent failure. A 401 reaching ModifyResponse
+						// means refresh failed; just log and let the 401 propagate.
+						slog.Warn("upstream OAuth: upstream 401 after refresh attempt; re-authorization required",
 							"route", upstreamOAuth.RouteName,
 							"path", resp.Request.URL.Path,
-						)
-					} else if err := upstreamOAuth.TokenStore.Delete(subject, upstreamOAuth.RouteName); err != nil {
-						slog.Warn("upstream OAuth: upstream 401; failed to delete stale token, re-authorization may not trigger",
-							"route", upstreamOAuth.RouteName,
-							"path", resp.Request.URL.Path,
-							"err", err,
 						)
 					} else {
-						slog.Warn("upstream OAuth: upstream 401; token deleted, re-authorization required",
-							"route", upstreamOAuth.RouteName,
-							"path", resp.Request.URL.Path,
-						)
+						// No refresher: delete the stale token so the next request
+						// triggers re-authorization via NewAuthorizeMiddleware.
+						subject := middleware.IdentityFromContext(resp.Request.Context())
+						if subject == "" {
+							slog.Warn("upstream OAuth: upstream 401; no authenticated subject in context, stale token not deleted",
+								"route", upstreamOAuth.RouteName,
+								"path", resp.Request.URL.Path,
+							)
+						} else if err := upstreamOAuth.TokenStore.Delete(subject, upstreamOAuth.RouteName); err != nil {
+							slog.Warn("upstream OAuth: upstream 401; failed to delete stale token, re-authorization may not trigger",
+								"route", upstreamOAuth.RouteName,
+								"path", resp.Request.URL.Path,
+								"err", err,
+							)
+						} else {
+							slog.Warn("upstream OAuth: upstream 401; token deleted, re-authorization required",
+								"route", upstreamOAuth.RouteName,
+								"path", resp.Request.URL.Path,
+							)
+						}
 					}
 				} else if upstreamBearerTokenEnv != "" {
 					// The 401 came from an upstream-credential route.
@@ -175,6 +205,15 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 			)
 			return nil
 		},
+	}
+
+	// When a Refresher is configured, wrap the default transport to intercept
+	// upstream 401 responses and retry with a refreshed token transparently.
+	if upstreamOAuth != nil && upstreamOAuth.Refresher != nil {
+		rp.Transport = &refreshingTransport{
+			base: http.DefaultTransport,
+			opts: upstreamOAuth,
+		}
 	}
 
 	return rp

--- a/internal/proxy/refreshing_transport.go
+++ b/internal/proxy/refreshing_transport.go
@@ -40,6 +40,19 @@ func (t *refreshingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		return resp, nil
 	}
 
+	// Only retry when the body is absent or replayable. Non-replayable streaming
+	// bodies (e.g. SSE, chunked POST) cannot be re-sent after the first read;
+	// attempting to do so would send an empty body and corrupt the upstream call.
+	hasBody := req.Body != nil && req.Body != http.NoBody
+	bodyReplayable := !hasBody || req.GetBody != nil
+	if !bodyReplayable {
+		slog.Warn("upstream OAuth 401 retry: request body is not replayable; returning 401 to caller",
+			"route", t.opts.RouteName,
+			"path", req.URL.Path,
+		)
+		return resp, nil
+	}
+
 	// Close the original 401 body before retrying to avoid connection leaks.
 	_ = resp.Body.Close()
 

--- a/internal/proxy/refreshing_transport.go
+++ b/internal/proxy/refreshing_transport.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/scottlz0310/mcp-gateway/internal/middleware"
+)
+
+// refreshingTransport is an http.RoundTripper that transparently handles
+// upstream 401 responses by refreshing the upstream OAuth token and retrying
+// the original request with the new token. This makes the refresh invisible
+// to the HTTP client (Case A: transparent retry).
+type refreshingTransport struct {
+	base http.RoundTripper
+	opts *UpstreamOAuthOptions
+}
+
+func (t *refreshingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	subject := middleware.IdentityFromContext(req.Context())
+	if subject == "" {
+		slog.Warn("upstream OAuth 401 retry: no authenticated subject in context; skipping refresh",
+			"route", t.opts.RouteName,
+			"path", req.URL.Path,
+		)
+		return resp, nil
+	}
+
+	newRec, ok := t.opts.Refresher.RefreshAfter401(req.Context(), subject, t.opts.RouteName)
+	if !ok {
+		slog.Warn("upstream OAuth 401 retry: refresh failed; returning 401 to caller",
+			"route", t.opts.RouteName,
+			"path", req.URL.Path,
+		)
+		return resp, nil
+	}
+
+	// Close the original 401 body before retrying to avoid connection leaks.
+	_ = resp.Body.Close()
+
+	newReq := req.Clone(req.Context())
+	newReq.Header.Set("Authorization", "Bearer "+newRec.AccessToken)
+	slog.Info("upstream OAuth 401 retry: retrying request with refreshed token",
+		"route", t.opts.RouteName,
+		"path", req.URL.Path,
+	)
+	return t.base.RoundTrip(newReq)
+}

--- a/internal/proxy/refreshing_transport.go
+++ b/internal/proxy/refreshing_transport.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -53,11 +54,31 @@ func (t *refreshingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		return resp, nil
 	}
 
+	// Rewind the request body before closing the 401 response so that, if
+	// GetBody fails, we can still return the original resp without a leak.
+	// Clone shallow-copies Body; GetBody produces a fresh reader for the retry.
+	var newBody io.ReadCloser
+	if hasBody {
+		var err error
+		newBody, err = req.GetBody()
+		if err != nil {
+			slog.Warn("upstream OAuth 401 retry: failed to rewind request body; returning 401 to caller",
+				"route", t.opts.RouteName,
+				"path", req.URL.Path,
+				"err", err,
+			)
+			return resp, nil
+		}
+	}
+
 	// Close the original 401 body before retrying to avoid connection leaks.
 	_ = resp.Body.Close()
 
 	newReq := req.Clone(req.Context())
 	newReq.Header.Set("Authorization", "Bearer "+newRec.AccessToken)
+	if newBody != nil {
+		newReq.Body = newBody
+	}
 	slog.Info("upstream OAuth 401 retry: retrying request with refreshed token",
 		"route", t.opts.RouteName,
 		"path", req.URL.Path,

--- a/internal/proxy/refreshing_transport_test.go
+++ b/internal/proxy/refreshing_transport_test.go
@@ -1,0 +1,325 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/middleware"
+)
+
+// mockRefresher is a test double for UpstreamTokenRefresher.
+type mockRefresher struct {
+	after401Rec auth.UpstreamTokenRecord
+	after401OK  bool
+	freshRec    auth.UpstreamTokenRecord
+	freshOK     bool
+	calls401    int
+}
+
+func (m *mockRefresher) EnsureFreshToken(_ context.Context, _, _ string, rec auth.UpstreamTokenRecord) (auth.UpstreamTokenRecord, bool) {
+	return m.freshRec, m.freshOK
+}
+
+func (m *mockRefresher) RefreshAfter401(_ context.Context, _, _ string) (auth.UpstreamTokenRecord, bool) {
+	m.calls401++
+	return m.after401Rec, m.after401OK
+}
+
+// rtFunc adapts a function to http.RoundTripper.
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// makeResponse constructs a minimal *http.Response with the given status code.
+func makeResponse(code int) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}
+}
+
+func requestWithIdentity(identity string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
+	ctx := context.WithValue(req.Context(), middleware.ContextKeyIdentity, identity)
+	return req.WithContext(ctx)
+}
+
+// ── refreshingTransport unit tests ──────────────────────────────────────────
+
+func TestRefreshingTransport_NonUnauthorizedPassthrough(t *testing.T) {
+	callCount := 0
+	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount++
+		return makeResponse(http.StatusOK), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: &mockRefresher{}},
+	}
+
+	resp, err := rt.RoundTrip(requestWithIdentity("alice"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if callCount != 1 {
+		t.Errorf("base called %d times, want 1", callCount)
+	}
+}
+
+func TestRefreshingTransport_EmptySubjectSkipsRefresh(t *testing.T) {
+	mr := &mockRefresher{}
+	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResponse(http.StatusUnauthorized), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: mr},
+	}
+
+	// Request without identity in context.
+	req := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if mr.calls401 != 0 {
+		t.Errorf("RefreshAfter401 called %d times, want 0", mr.calls401)
+	}
+}
+
+func TestRefreshingTransport_RefreshFailedReturns401(t *testing.T) {
+	mr := &mockRefresher{
+		after401OK: false,
+	}
+	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+		return makeResponse(http.StatusUnauthorized), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: mr},
+	}
+
+	resp, err := rt.RoundTrip(requestWithIdentity("alice"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if mr.calls401 != 1 {
+		t.Errorf("RefreshAfter401 called %d times, want 1", mr.calls401)
+	}
+}
+
+func TestRefreshingTransport_RefreshSuccessRetries(t *testing.T) {
+	mr := &mockRefresher{
+		after401OK:  true,
+		after401Rec: auth.UpstreamTokenRecord{AccessToken: "new-tok"},
+	}
+
+	var capturedAuth string
+	callCount := 0
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		if callCount == 1 {
+			return makeResponse(http.StatusUnauthorized), nil
+		}
+		capturedAuth = req.Header.Get("Authorization")
+		return makeResponse(http.StatusOK), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: mr},
+	}
+
+	resp, err := rt.RoundTrip(requestWithIdentity("alice"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (retry should succeed)", resp.StatusCode, http.StatusOK)
+	}
+	if callCount != 2 {
+		t.Errorf("base called %d times, want 2 (initial + retry)", callCount)
+	}
+	if capturedAuth != "Bearer new-tok" {
+		t.Errorf("retry Authorization = %q, want %q", capturedAuth, "Bearer new-tok")
+	}
+}
+
+// ── NewHandler integration: proactive refresh ────────────────────────────────
+
+func TestProxyUpstreamOAuthProactiveRefreshUpdatesToken(t *testing.T) {
+	// EnsureFreshToken returns a newer token; proxy must inject it.
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("alice@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "ref",
+		ExpiresAt:    time.Now().Add(2 * time.Minute), // within proactive window
+	})
+
+	mr := &mockRefresher{
+		freshOK:  true,
+		freshRec: auth.UpstreamTokenRecord{AccessToken: "refreshed-tok"},
+	}
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+		Refresher:  mr,
+	})
+
+	r := requestWithContext("alice@example.com", "gateway-tok")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if gotAuth != "Bearer refreshed-tok" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer refreshed-tok")
+	}
+}
+
+func TestProxyUpstreamOAuthProactiveRefreshFailureForwardsWithoutAuth(t *testing.T) {
+	// EnsureFreshToken returns ok=false (permanent failure); proxy forwards
+	// the request without an Authorization header.
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("alice@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "ref",
+		ExpiresAt:    time.Now().Add(2 * time.Minute),
+	})
+
+	mr := &mockRefresher{
+		freshOK: false, // permanent failure
+	}
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+		Refresher:  mr,
+	})
+
+	r := requestWithContext("alice@example.com", "gateway-tok")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (proactive refresh failed)", gotAuth)
+	}
+}
+
+func TestProxyUpstreamOAuthRefresherWith401TransparentRetry(t *testing.T) {
+	// End-to-end: upstream returns 401 first, then 200 after retry.
+	// refreshingTransport intercepts the 401, refreshes, and retries.
+	callCount := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("bob@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "ref",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+
+	mr := &mockRefresher{
+		after401OK:  true,
+		after401Rec: auth.UpstreamTokenRecord{AccessToken: "refreshed-tok"},
+		freshOK:     true, // EnsureFreshToken returns existing token unchanged
+	}
+	// Make EnsureFreshToken return the existing record (not near expiry).
+	mr.freshRec = auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "ref",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+		Refresher:  mr,
+	})
+
+	r := requestWithContext("bob@example.com", "gateway-tok")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("final status = %d, want %d (transparent retry should succeed)", w.Code, http.StatusOK)
+	}
+	if callCount != 2 {
+		t.Errorf("upstream called %d times, want 2 (initial 401 + retry)", callCount)
+	}
+}
+
+func TestProxyUpstreamOAuthWith401WhenRefresherNil(t *testing.T) {
+	// Backward compat: when Refresher is nil, 401 still deletes the stale token.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	tokenStore := auth.NewMemUpstreamTokenStore()
+	_ = tokenStore.Save("carol@example.com", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "stale-tok",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	u, _ := url.Parse(upstream.URL)
+	h := NewHandler(u, &mockInvalidator{}, "", "", &UpstreamOAuthOptions{
+		TokenStore: tokenStore,
+		RouteName:  "myroute",
+		Refresher:  nil, // no refresher
+	})
+
+	r := requestWithContext("carol@example.com", "gateway-tok")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	// Token must be deleted (#117 behavior preserved).
+	if _, ok := tokenStore.Lookup("carol@example.com", "myroute"); ok {
+		t.Error("expected stale token to be deleted when Refresher is nil")
+	}
+}

--- a/internal/proxy/refreshing_transport_test.go
+++ b/internal/proxy/refreshing_transport_test.go
@@ -2,9 +2,11 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,6 +125,87 @@ func TestRefreshingTransport_RefreshFailedReturns401(t *testing.T) {
 	}
 	if mr.calls401 != 1 {
 		t.Errorf("RefreshAfter401 called %d times, want 1", mr.calls401)
+	}
+}
+
+func TestRefreshingTransport_NonReplayableBodySkipsRetry(t *testing.T) {
+	// When req.Body is set but GetBody is nil (non-replayable stream), retry
+	// must not be attempted: the body has already been consumed by the first
+	// RoundTrip, so a second RoundTrip would send an empty body.
+	mr := &mockRefresher{
+		after401OK:  true,
+		after401Rec: auth.UpstreamTokenRecord{AccessToken: "new-tok"},
+	}
+
+	callCount := 0
+	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount++
+		return makeResponse(http.StatusUnauthorized), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: mr},
+	}
+
+	req := requestWithIdentity("alice")
+	// Attach a non-replayable body (GetBody == nil).
+	req.Body = io.NopCloser(strings.NewReader(`{"method":"test"}`))
+	req.ContentLength = 18
+	// GetBody is intentionally nil (default for non-buffered readers).
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 401 must be returned as-is; no retry.
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (non-replayable body: retry must be skipped)", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if callCount != 1 {
+		t.Errorf("base called %d times, want 1 (no retry for non-replayable body)", callCount)
+	}
+}
+
+func TestRefreshingTransport_ReplayableBodyRetries(t *testing.T) {
+	// When GetBody is set (replayable), retry must proceed.
+	mr := &mockRefresher{
+		after401OK:  true,
+		after401Rec: auth.UpstreamTokenRecord{AccessToken: "new-tok"},
+	}
+
+	callCount := 0
+	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+		callCount++
+		if callCount == 1 {
+			return makeResponse(http.StatusUnauthorized), nil
+		}
+		return makeResponse(http.StatusOK), nil
+	})
+
+	rt := &refreshingTransport{
+		base: base,
+		opts: &UpstreamOAuthOptions{RouteName: "myroute", Refresher: mr},
+	}
+
+	req := requestWithIdentity("alice")
+	body := `{"method":"test"}`
+	req.Body = io.NopCloser(strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	// Set GetBody so the body is replayable.
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(body)), nil
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (replayable body: retry should succeed)", resp.StatusCode, http.StatusOK)
+	}
+	if callCount != 2 {
+		t.Errorf("base called %d times, want 2 (initial + retry)", callCount)
 	}
 }
 

--- a/internal/proxy/refreshing_transport_test.go
+++ b/internal/proxy/refreshing_transport_test.go
@@ -168,18 +168,28 @@ func TestRefreshingTransport_NonReplayableBodySkipsRetry(t *testing.T) {
 }
 
 func TestRefreshingTransport_ReplayableBodyRetries(t *testing.T) {
-	// When GetBody is set (replayable), retry must proceed.
+	// When GetBody is set (replayable), retry must proceed and the body must be
+	// rewound via GetBody so the second RoundTrip receives the original content.
+	// The first RoundTrip consumes req.Body; without GetBody rewind the retry
+	// would send an empty body and silently corrupt the upstream request.
 	mr := &mockRefresher{
 		after401OK:  true,
 		after401Rec: auth.UpstreamTokenRecord{AccessToken: "new-tok"},
 	}
 
+	const bodyContent = `{"method":"test"}`
+	var capturedRetryBody string
 	callCount := 0
-	base := rtFunc(func(_ *http.Request) (*http.Response, error) {
+	base := rtFunc(func(req *http.Request) (*http.Response, error) {
 		callCount++
 		if callCount == 1 {
+			// Consume the body exactly as a real RoundTripper would.
+			_, _ = io.ReadAll(req.Body)
 			return makeResponse(http.StatusUnauthorized), nil
 		}
+		// On retry: body must have been rewound by GetBody().
+		b, _ := io.ReadAll(req.Body)
+		capturedRetryBody = string(b)
 		return makeResponse(http.StatusOK), nil
 	})
 
@@ -189,12 +199,10 @@ func TestRefreshingTransport_ReplayableBodyRetries(t *testing.T) {
 	}
 
 	req := requestWithIdentity("alice")
-	body := `{"method":"test"}`
-	req.Body = io.NopCloser(strings.NewReader(body))
-	req.ContentLength = int64(len(body))
-	// Set GetBody so the body is replayable.
+	req.Body = io.NopCloser(strings.NewReader(bodyContent))
+	req.ContentLength = int64(len(bodyContent))
 	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(strings.NewReader(body)), nil
+		return io.NopCloser(strings.NewReader(bodyContent)), nil
 	}
 
 	resp, err := rt.RoundTrip(req)
@@ -206,6 +214,9 @@ func TestRefreshingTransport_ReplayableBodyRetries(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("base called %d times, want 2 (initial + retry)", callCount)
+	}
+	if capturedRetryBody != bodyContent {
+		t.Errorf("retry body = %q, want %q (body must be rewound for retry)", capturedRetryBody, bodyContent)
 	}
 }
 

--- a/internal/upstreamoauth/refresher.go
+++ b/internal/upstreamoauth/refresher.go
@@ -127,22 +127,29 @@ func (r *Refresher) doRefresh(ctx context.Context, subject, routeName, refreshTo
 			return sfResult{}, nil
 		}
 
+		// Reject refresh responses without expires_in: saving a zero ExpiresAt would
+		// make UpstreamTokenStore.Lookup treat the refreshed token as permanently valid,
+		// which is inconsistent with callback.go's policy. Keep the existing token instead.
+		if newToken.ExpiresIn <= 0 {
+			slog.Warn("upstream OAuth refresh: response missing expires_in, keeping existing token",
+				"route", routeName)
+			if existing, ok := r.tokenStore.Lookup(subject, routeName); ok {
+				return sfResult{rec: existing, ok: true}, nil
+			}
+			return sfResult{}, nil
+		}
+
 		// Preserve old refresh_token when AS does not rotate it.
 		keepRefreshToken := newToken.RefreshToken
 		if keepRefreshToken == "" {
 			keepRefreshToken = refreshToken
 		}
 
-		var expiresAt time.Time
-		if newToken.ExpiresIn > 0 {
-			expiresAt = time.Now().Add(time.Duration(newToken.ExpiresIn) * time.Second)
-		}
-
 		updated := auth.UpstreamTokenRecord{
 			Issuer:       clientRec.Issuer,
 			AccessToken:  newToken.AccessToken,
 			RefreshToken: keepRefreshToken,
-			ExpiresAt:    expiresAt,
+			ExpiresAt:    time.Now().Add(time.Duration(newToken.ExpiresIn) * time.Second),
 			Scope:        newToken.Scope,
 		}
 		if err := r.tokenStore.Save(subject, routeName, updated); err != nil {

--- a/internal/upstreamoauth/refresher.go
+++ b/internal/upstreamoauth/refresher.go
@@ -1,0 +1,207 @@
+package upstreamoauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+)
+
+const defaultProactiveWindow = 5 * time.Minute
+
+// Refresher handles proactive and 401-triggered upstream OAuth token refresh.
+// Concurrent refresh calls for the same (subject, routeName) pair are coalesced
+// via singleflight so that only one HTTP round-trip to the token endpoint occurs.
+type Refresher struct {
+	tokenStore      auth.UpstreamTokenStore
+	manager         *Manager
+	httpClient      *http.Client
+	sfGroup         singleflight.Group
+	proactiveWindow time.Duration
+}
+
+// NewRefresher creates a Refresher. If httpClient is nil, a client with
+// DefaultHTTPTimeout is used.
+func NewRefresher(tokenStore auth.UpstreamTokenStore, manager *Manager, httpClient *http.Client) *Refresher {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: DefaultHTTPTimeout}
+	}
+	return &Refresher{
+		tokenStore:      tokenStore,
+		manager:         manager,
+		httpClient:      httpClient,
+		proactiveWindow: defaultProactiveWindow,
+	}
+}
+
+// EnsureFreshToken returns a valid token, refreshing proactively when ExpiresAt
+// is within the proactive window and a refresh_token is available.
+//
+// Returns (rec, true) when a valid token is available (unchanged or refreshed).
+// Returns (zero, false) when a permanent refresh failure required deleting the token.
+// Returns (rec, true) when refresh is skipped (no expiry info, no refresh_token, or
+// transient failure); the caller uses the existing token as-is.
+func (r *Refresher) EnsureFreshToken(ctx context.Context, subject, routeName string, rec auth.UpstreamTokenRecord) (auth.UpstreamTokenRecord, bool) {
+	if rec.ExpiresAt.IsZero() {
+		return rec, true
+	}
+	if time.Until(rec.ExpiresAt) > r.proactiveWindow {
+		return rec, true
+	}
+	if rec.RefreshToken == "" {
+		return rec, true
+	}
+	return r.doRefresh(ctx, subject, routeName, rec.RefreshToken, false)
+}
+
+// RefreshAfter401 attempts to refresh the token using the stored refresh_token
+// after an upstream 401. On permanent failure, the token entry is deleted and
+// (zero, false) is returned. On transient failure, returns the existing record
+// and true so the caller can return the 401 to the client rather than deleting
+// a token that might recover later.
+func (r *Refresher) RefreshAfter401(ctx context.Context, subject, routeName string) (auth.UpstreamTokenRecord, bool) {
+	existing, ok := r.tokenStore.Lookup(subject, routeName)
+	if !ok || existing.RefreshToken == "" {
+		_ = r.tokenStore.Delete(subject, routeName)
+		return auth.UpstreamTokenRecord{}, false
+	}
+	return r.doRefresh(ctx, subject, routeName, existing.RefreshToken, true)
+}
+
+// doRefresh executes the refresh grant, coalescing concurrent calls via singleflight.
+// force=true skips the proactive-window re-check so that 401-triggered calls always
+// attempt a network round-trip even when the stored token appears unexpired.
+func (r *Refresher) doRefresh(ctx context.Context, subject, routeName, refreshToken string, force bool) (auth.UpstreamTokenRecord, bool) {
+	sfKey := subject + "\x00" + routeName
+
+	type sfResult struct {
+		rec auth.UpstreamTokenRecord
+		ok  bool
+	}
+
+	v, _, _ := r.sfGroup.Do(sfKey, func() (any, error) {
+		// Re-check: a concurrent goroutine coalesced into this singleflight may
+		// have already refreshed. Skip if the refresh_token rotated (another
+		// goroutine already succeeded) or, for proactive calls only, the token
+		// is now valid with sufficient runway.
+		if latest, ok := r.tokenStore.Lookup(subject, routeName); ok {
+			alreadyRotated := latest.RefreshToken != refreshToken
+			hasRunway := !latest.ExpiresAt.IsZero() && time.Until(latest.ExpiresAt) > r.proactiveWindow
+			if alreadyRotated || (!force && hasRunway) {
+				return sfResult{rec: latest, ok: true}, nil
+			}
+		}
+
+		clientRec, hasClient := r.manager.LoadClient(routeName)
+		if !hasClient || clientRec.TokenEndpoint == "" {
+			slog.Warn("upstream OAuth refresh: no client registration for route", "route", routeName)
+			if existing, ok := r.tokenStore.Lookup(subject, routeName); ok {
+				return sfResult{rec: existing, ok: true}, nil
+			}
+			return sfResult{}, nil
+		}
+
+		newToken, permanent, err := r.callRefreshEndpoint(ctx, clientRec, refreshToken)
+		if err != nil {
+			if permanent {
+				slog.Warn("upstream OAuth refresh: permanent failure, deleting token",
+					"route", routeName, "err", err)
+				_ = r.tokenStore.Delete(subject, routeName)
+				return sfResult{}, nil
+			}
+			slog.Warn("upstream OAuth refresh: transient failure, keeping existing token",
+				"route", routeName, "err", err)
+			if existing, ok := r.tokenStore.Lookup(subject, routeName); ok {
+				return sfResult{rec: existing, ok: true}, nil
+			}
+			return sfResult{}, nil
+		}
+
+		// Preserve old refresh_token when AS does not rotate it.
+		keepRefreshToken := newToken.RefreshToken
+		if keepRefreshToken == "" {
+			keepRefreshToken = refreshToken
+		}
+
+		var expiresAt time.Time
+		if newToken.ExpiresIn > 0 {
+			expiresAt = time.Now().Add(time.Duration(newToken.ExpiresIn) * time.Second)
+		}
+
+		updated := auth.UpstreamTokenRecord{
+			Issuer:       clientRec.Issuer,
+			AccessToken:  newToken.AccessToken,
+			RefreshToken: keepRefreshToken,
+			ExpiresAt:    expiresAt,
+			Scope:        newToken.Scope,
+		}
+		if err := r.tokenStore.Save(subject, routeName, updated); err != nil {
+			slog.Warn("upstream OAuth refresh: failed to save refreshed token",
+				"route", routeName, "err", err)
+		}
+		slog.Info("upstream OAuth: token refreshed", "route", routeName)
+		return sfResult{rec: updated, ok: true}, nil
+	})
+
+	if v == nil {
+		return auth.UpstreamTokenRecord{}, false
+	}
+	result := v.(sfResult)
+	return result.rec, result.ok
+}
+
+// callRefreshEndpoint sends grant_type=refresh_token to the token endpoint.
+// Returns (response, permanent, error).
+// permanent=true indicates the refresh_token is invalid/revoked (4xx except 429),
+// meaning the caller should delete the token entry and require re-authorization.
+func (r *Refresher) callRefreshEndpoint(ctx context.Context, rec ClientRecord, refreshToken string) (*tokenExchangeResponse, bool, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", rec.ClientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rec.TokenEndpoint,
+		bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return nil, false, fmt.Errorf("creating refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if rec.ClientSecret != "" {
+		req.SetBasicAuth(rec.ClientID, rec.ClientSecret)
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("POST %s: %w", rec.TokenEndpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// 4xx (except 429 Too Many Requests) = permanent failure:
+	// the refresh_token is invalid or revoked by the AS.
+	permanent := resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, permanent, fmt.Errorf("token endpoint %s: status %d: %s",
+			rec.TokenEndpoint, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var tr tokenExchangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, false, fmt.Errorf("decoding refresh response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return nil, true, fmt.Errorf("refresh response missing access_token")
+	}
+	return &tr, false, nil
+}

--- a/internal/upstreamoauth/refresher_test.go
+++ b/internal/upstreamoauth/refresher_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -439,5 +441,137 @@ func TestRefreshEndpointSendsGrantTypeRefreshToken(t *testing.T) {
 	}
 	if capturedForm["client_id"] != "my-client-id" {
 		t.Errorf("client_id = %q, want %q", capturedForm["client_id"], "my-client-id")
+	}
+}
+
+func TestEnsureFreshToken_ConcurrentCallsCoalesceToOneEndpointRequest(t *testing.T) {
+	// Verifies the singleflight invariant: N concurrent EnsureFreshToken calls
+	// for the same (subject, routeName) result in exactly 1 token endpoint request.
+	const goroutines = 10
+
+	var endpointCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		endpointCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-tok",
+			"refresh_token": "new-ref",
+			"expires_in":    3600,
+		})
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	var wg sync.WaitGroup
+	results := make([]auth.UpstreamTokenRecord, goroutines)
+	oks := make([]bool, goroutines)
+
+	wg.Add(goroutines)
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			start.Wait() // all goroutines start simultaneously
+			results[idx], oks[idx] = refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+		}(i)
+	}
+	start.Done() // release all goroutines
+	wg.Wait()
+
+	calls := endpointCalls.Load()
+	if calls != 1 {
+		t.Errorf("token endpoint called %d times, want 1 (singleflight coalescing)", calls)
+	}
+	for i, ok := range oks {
+		if !ok {
+			t.Errorf("goroutine %d: expected ok=true", i)
+		}
+		if results[i].AccessToken != "new-tok" {
+			t.Errorf("goroutine %d: AccessToken = %q, want %q", i, results[i].AccessToken, "new-tok")
+		}
+	}
+}
+
+func TestRefreshAfter401_ConcurrentCallsCoalesceToOneEndpointRequest(t *testing.T) {
+	// Verifies the singleflight invariant for RefreshAfter401:
+	// N concurrent calls for the same key result in exactly 1 endpoint request.
+	const goroutines = 10
+
+	var endpointCalls atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		endpointCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-tok",
+			"refresh_token": "new-ref",
+			"expires_in":    3600,
+		})
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    futureExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	var wg sync.WaitGroup
+	results := make([]auth.UpstreamTokenRecord, goroutines)
+	oks := make([]bool, goroutines)
+
+	wg.Add(goroutines)
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			start.Wait()
+			results[idx], oks[idx] = refresher.RefreshAfter401(context.Background(), "user", "myroute")
+		}(i)
+	}
+	start.Done()
+	wg.Wait()
+
+	calls := endpointCalls.Load()
+	if calls != 1 {
+		t.Errorf("token endpoint called %d times, want 1 (singleflight coalescing)", calls)
+	}
+	for i, ok := range oks {
+		if !ok {
+			t.Errorf("goroutine %d: expected ok=true", i)
+		}
+		if results[i].AccessToken != "new-tok" {
+			t.Errorf("goroutine %d: AccessToken = %q, want %q", i, results[i].AccessToken, "new-tok")
+		}
 	}
 }

--- a/internal/upstreamoauth/refresher_test.go
+++ b/internal/upstreamoauth/refresher_test.go
@@ -1,0 +1,443 @@
+package upstreamoauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scottlz0310/mcp-gateway/internal/auth"
+	"github.com/scottlz0310/mcp-gateway/internal/upstreamoauth"
+)
+
+// makeRefresher constructs a Refresher backed by the given token endpoint server.
+func makeRefresher(t *testing.T, clientRecords map[string]upstreamoauth.ClientRecord, tokenStore auth.UpstreamTokenStore, httpClient *http.Client) *upstreamoauth.Refresher {
+	t.Helper()
+	cs := &testClientStore{records: clientRecords}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	return upstreamoauth.NewRefresher(tokenStore, mgr, httpClient)
+}
+
+// futureExpiry returns a time well beyond the proactive window.
+func futureExpiry() time.Time {
+	return time.Now().Add(10 * time.Minute)
+}
+
+// nearExpiry returns a time within the proactive window (5 min default).
+func nearExpiry() time.Time {
+	return time.Now().Add(2 * time.Minute)
+}
+
+func TestEnsureFreshToken_NoExpirySkipsRefresh(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	refresher := makeRefresher(t, nil, store, nil)
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "tok",
+		RefreshToken: "ref",
+		// ExpiresAt zero = permanent / unknown
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "route", rec)
+	if !ok {
+		t.Fatal("expected ok=true when ExpiresAt is zero")
+	}
+	if got.AccessToken != "tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "tok")
+	}
+}
+
+func TestEnsureFreshToken_FutureExpirySkipsRefresh(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	refresher := makeRefresher(t, nil, store, nil)
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "tok",
+		RefreshToken: "ref",
+		ExpiresAt:    futureExpiry(),
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "route", rec)
+	if !ok {
+		t.Fatal("expected ok=true when token is not near expiry")
+	}
+	if got.AccessToken != "tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "tok")
+	}
+}
+
+func TestEnsureFreshToken_NoRefreshTokenSkipsRefresh(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	refresher := makeRefresher(t, nil, store, nil)
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken: "tok",
+		ExpiresAt:   nearExpiry(),
+		// RefreshToken empty
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "route", rec)
+	if !ok {
+		t.Fatal("expected ok=true when no refresh_token available")
+	}
+	if got.AccessToken != "tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "tok")
+	}
+}
+
+func TestEnsureFreshToken_ProactiveRefreshSuccess(t *testing.T) {
+	ts := makeTokenServer(t, map[string]any{
+		"access_token":  "new-tok",
+		"refresh_token": "new-ref",
+		"expires_in":    3600,
+	})
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			Issuer:        "https://upstream.example.com",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "client-id",
+			ClientSecret:  "client-secret",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+	if !ok {
+		t.Fatal("expected ok=true on successful proactive refresh")
+	}
+	if got.AccessToken != "new-tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "new-tok")
+	}
+	if got.RefreshToken != "new-ref" {
+		t.Errorf("RefreshToken = %q, want %q", got.RefreshToken, "new-ref")
+	}
+
+	// Token must be persisted.
+	saved, ok2 := store.Lookup("user", "myroute")
+	if !ok2 {
+		t.Fatal("refreshed token must be saved in store")
+	}
+	if saved.AccessToken != "new-tok" {
+		t.Errorf("saved AccessToken = %q, want %q", saved.AccessToken, "new-tok")
+	}
+}
+
+func TestEnsureFreshToken_ProactiveRefreshPreservesOldRefreshToken(t *testing.T) {
+	// AS does not rotate the refresh_token (omits it in response).
+	ts := makeTokenServer(t, map[string]any{
+		"access_token": "new-tok",
+		"expires_in":   3600,
+		// refresh_token intentionally absent
+	})
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	const oldRefToken = "old-ref"
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: oldRefToken,
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: oldRefToken,
+		ExpiresAt:    nearExpiry(),
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.RefreshToken != oldRefToken {
+		t.Errorf("RefreshToken = %q, want old token %q (AS did not rotate)", got.RefreshToken, oldRefToken)
+	}
+}
+
+func TestEnsureFreshToken_PermanentFailureDeletesToken(t *testing.T) {
+	// Token endpoint returns 401 = permanent failure (invalid refresh_token).
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "bad-ref",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "bad-ref",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	_, ok := refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+	if ok {
+		t.Fatal("expected ok=false on permanent refresh failure")
+	}
+
+	// Token entry must be deleted from the store.
+	if _, found := store.Lookup("user", "myroute"); found {
+		t.Error("token must be deleted after permanent refresh failure")
+	}
+}
+
+func TestEnsureFreshToken_TransientFailureKeepsToken(t *testing.T) {
+	// 429 Too Many Requests = transient.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+	if !ok {
+		t.Fatal("expected ok=true on transient failure (keep existing token)")
+	}
+	if got.AccessToken != "old-tok" {
+		t.Errorf("expected existing token %q, got %q", "old-tok", got.AccessToken)
+	}
+
+	// Token must still be in the store.
+	if _, found := store.Lookup("user", "myroute"); !found {
+		t.Error("token must not be deleted on transient failure")
+	}
+}
+
+func TestEnsureFreshToken_NoClientRegistrationKeepsToken(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "tok",
+		RefreshToken: "ref",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	// No client record registered.
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{}, store, nil)
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "tok",
+		RefreshToken: "ref",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	got, ok := refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+	if !ok {
+		t.Fatal("expected ok=true when no client registration (transient: cannot refresh)")
+	}
+	if got.AccessToken != "tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "tok")
+	}
+}
+
+func TestRefreshAfter401_NoTokenInStore(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	refresher := makeRefresher(t, nil, store, nil)
+
+	_, ok := refresher.RefreshAfter401(context.Background(), "user", "myroute")
+	if ok {
+		t.Fatal("expected ok=false when no token in store")
+	}
+}
+
+func TestRefreshAfter401_NoRefreshToken(t *testing.T) {
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken: "tok",
+		ExpiresAt:   nearExpiry(),
+		// no RefreshToken
+	})
+
+	refresher := makeRefresher(t, nil, store, nil)
+
+	_, ok := refresher.RefreshAfter401(context.Background(), "user", "myroute")
+	if ok {
+		t.Fatal("expected ok=false when no refresh_token available")
+	}
+
+	// Token entry must be deleted (no refresh possible, force re-auth).
+	if _, found := store.Lookup("user", "myroute"); found {
+		t.Error("token must be deleted when no refresh_token is available")
+	}
+}
+
+func TestRefreshAfter401_Success(t *testing.T) {
+	ts := makeTokenServer(t, map[string]any{
+		"access_token":  "new-tok",
+		"refresh_token": "new-ref",
+		"expires_in":    3600,
+	})
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    time.Now().Add(-time.Minute), // already expired
+	})
+
+	// Manually insert an already-expired record; Lookup would reject it, but
+	// RefreshAfter401 reads it to get the refresh_token before it expires in store.
+	// Re-insert with valid expiry so Lookup succeeds for the refresh_token read.
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "old-ref",
+		ExpiresAt:    futureExpiry(), // keep in store long enough for test
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			Issuer:        "https://upstream.example.com",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "client-id",
+			ClientSecret:  "client-secret",
+		},
+	}, store, ts.Client())
+
+	got, ok := refresher.RefreshAfter401(context.Background(), "user", "myroute")
+	if !ok {
+		t.Fatal("expected ok=true on successful 401 refresh")
+	}
+	if got.AccessToken != "new-tok" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "new-tok")
+	}
+}
+
+func TestRefreshAfter401_PermanentFailureDeletesToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // 403 = permanent
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "tok",
+		RefreshToken: "bad-ref",
+		ExpiresAt:    futureExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "cid",
+		},
+	}, store, ts.Client())
+
+	_, ok := refresher.RefreshAfter401(context.Background(), "user", "myroute")
+	if ok {
+		t.Fatal("expected ok=false on permanent failure")
+	}
+	if _, found := store.Lookup("user", "myroute"); found {
+		t.Error("token must be deleted after permanent 401 refresh failure")
+	}
+}
+
+func TestRefreshEndpointSendsGrantTypeRefreshToken(t *testing.T) {
+	var capturedForm map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedForm = map[string]string{
+			"grant_type":    r.FormValue("grant_type"),
+			"refresh_token": r.FormValue("refresh_token"),
+			"client_id":     r.FormValue("client_id"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-tok",
+			"expires_in":   3600,
+		})
+	}))
+	defer ts.Close()
+
+	store := auth.NewMemUpstreamTokenStore()
+	_ = store.Save("user", "myroute", auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "my-refresh-token",
+		ExpiresAt:    nearExpiry(),
+	})
+
+	refresher := makeRefresher(t, map[string]upstreamoauth.ClientRecord{
+		"myroute": {
+			RouteName:     "myroute",
+			TokenEndpoint: ts.URL + "/token",
+			ClientID:      "my-client-id",
+		},
+	}, store, ts.Client())
+
+	rec := auth.UpstreamTokenRecord{
+		AccessToken:  "old-tok",
+		RefreshToken: "my-refresh-token",
+		ExpiresAt:    nearExpiry(),
+	}
+
+	_, _ = refresher.EnsureFreshToken(context.Background(), "user", "myroute", rec)
+
+	if capturedForm["grant_type"] != "refresh_token" {
+		t.Errorf("grant_type = %q, want %q", capturedForm["grant_type"], "refresh_token")
+	}
+	if capturedForm["refresh_token"] != "my-refresh-token" {
+		t.Errorf("refresh_token = %q, want %q", capturedForm["refresh_token"], "my-refresh-token")
+	}
+	if capturedForm["client_id"] != "my-client-id" {
+		t.Errorf("client_id = %q, want %q", capturedForm["client_id"], "my-client-id")
+	}
+}


### PR DESCRIPTION
## Summary

- **`Refresher` 型を新設** (`internal/upstreamoauth/refresher.go`):
  - `EnsureFreshToken`: `ExpiresAt` が 5 分以内なら proactive refresh
  - `RefreshAfter401`: upstream 401 後に `refresh_token` で再取得
  - `singleflight` coalescing（キー: `subject\x00routeName`）でスタンピード防止
  - 4xx（429 除く） = permanent failure → トークン削除 + `(zero, false)` 返却
  - 429 / network error = transient → 既存トークンを保持して続行

- **`UpstreamTokenRefresher` インターフェース** を `proxy` パッケージに追加（テスト容易性のため `upstreamoauth` への依存を逆転させない設計）

- **`refreshingTransport`** (`internal/proxy/refreshing_transport.go`):
  - upstream 401 受信 → `RefreshAfter401` 呼び出し → 新トークンで同一リクエスト retry
  - クライアントには 401 が見えない（Case A: 透過的 retry）
  - refresh 失敗時のみ 401 が `ModifyResponse` に到達

- **`UpstreamOAuthOptions.Refresher` フィールド追加**:
  - `Refresher != nil`: `refreshingTransport` を Transport に設定し、`Rewrite` で proactive refresh
  - `Refresher == nil`: #117 の delete-on-401 動作を完全保持（後方互換）

- **`cmd/server/main.go`**: `upstreamRefresher` を初期化して `UpstreamOAuthOptions` に注入

## Test plan

- [x] `TestEnsureFreshToken_NoExpirySkipsRefresh` — ExpiresAt ゼロは refresh しない
- [x] `TestEnsureFreshToken_FutureExpirySkipsRefresh` — 期限余裕あり → スキップ
- [x] `TestEnsureFreshToken_NoRefreshTokenSkipsRefresh` — refresh_token なし → スキップ
- [x] `TestEnsureFreshToken_ProactiveRefreshSuccess` — proactive refresh 成功・トークン保存
- [x] `TestEnsureFreshToken_ProactiveRefreshPreservesOldRefreshToken` — AS が refresh_token をローテートしない場合は既存を保持
- [x] `TestEnsureFreshToken_PermanentFailureDeletesToken` — 401 → permanent → トークン削除
- [x] `TestEnsureFreshToken_TransientFailureKeepsToken` — 429 → transient → 既存トークン保持
- [x] `TestEnsureFreshToken_NoClientRegistrationKeepsToken` — クライアント未登録 → transient
- [x] `TestRefreshAfter401_NoTokenInStore` — トークンなし → false
- [x] `TestRefreshAfter401_NoRefreshToken` — refresh_token なし → 削除 + false
- [x] `TestRefreshAfter401_Success` — 401 後 refresh 成功
- [x] `TestRefreshAfter401_PermanentFailureDeletesToken` — 403 → permanent → 削除
- [x] `TestRefreshEndpointSendsGrantTypeRefreshToken` — リクエストパラメータ検証
- [x] `TestRefreshingTransport_NonUnauthorizedPassthrough` — 200 は透過
- [x] `TestRefreshingTransport_EmptySubjectSkipsRefresh` — subject 空 → refresh スキップ
- [x] `TestRefreshingTransport_RefreshFailedReturns401` — refresh 失敗 → 401 返却
- [x] `TestRefreshingTransport_RefreshSuccessRetries` — 401 → refresh → retry で 200
- [x] `TestProxyUpstreamOAuthProactiveRefreshUpdatesToken` — proactive refresh でトークン更新
- [x] `TestProxyUpstreamOAuthProactiveRefreshFailureForwardsWithoutAuth` — proactive refresh 失敗 → Authorization なし
- [x] `TestProxyUpstreamOAuthRefresherWith401TransparentRetry` — end-to-end 透過 retry
- [x] `TestProxyUpstreamOAuthWith401WhenRefresherNil` — Refresher=nil で #117 動作保持
- [x] `go test ./...` 全パッケージ通過
- [x] `lefthook pre-push` (vet / lint / build / test) 全通過

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)