### PR TITLE
feat(upstreamoauth): upstream_oauth_grant で client_credentials フロー選択を実装 (#166)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -385,6 +385,7 @@ func main() {
 					route.Name,
 					route.UpstreamOAuth,
 					route.UpstreamOAuthScope,
+					route.UpstreamOAuthGrant,
 					route.Upstream.String(),
 					upstreamManager,
 					upstreamStateStore,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,12 @@ setup:
 | `routes[].name` | ルート名。空でない必要があります。 |
 | `routes[].prefix` | URL パスプレフィックス。`/` で始まる必要があります。末尾スラッシュは `/` を除いて除去されます。 |
 | `routes[].upstream` | 絶対 `http` または `https` upstream URL。 |
-| `routes[].no_auth` | true の場合、このルートの Bearer 検証をスキップします。 |
+| `routes[].no_auth` | `true` の場合、このルートの Bearer 検証をスキップします。`upstream_oauth` と同時設定不可。 |
+| `routes[].upstream_bearer_token_env` | ゲートウェイ→upstream の Bearer トークンを取得する環境変数名。起動時に env var が未設定または空の場合は起動失敗（フェールクローズ）。`upstream_oauth` と排他。 |
+| `routes[].required_audience` | アクセストークンの `aud` クレームに要求する値（デフォルト: `mcp-gateway`）。クライアントは `/token` に `resource=<name>` を渡してこの audience のトークンを取得する。 |
+| `routes[].upstream_oauth` | Upstream OAuth 委任。`auto`（RFC 9728 + RFC 8414 で AS を自動検出）または絶対 issuer URL（`https://...`）。`upstream_bearer_token_env` および `no_auth` と排他。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
+| `routes[].upstream_oauth_scope` | Upstream AS へのトークンリクエストで要求するスコープ（スペース区切り。カンマ区切りは自動正規化）。`upstream_oauth` が必要。 |
+| `routes[].upstream_oauth_grant` | Upstream トークン取得に使用する OAuth 2.0 グラントタイプ（`authorization_code` または `client_credentials`、デフォルト: `authorization_code`）。`upstream_oauth` が必要。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
 | `setup.completed` | ゲートウェイが書き込むセットアップウィザード状態。オペレーターが直接編集することは通常ありません。 |
 
 ゲートウェイがシークレット移行またはセットアップ完了時に `config.yaml` を書き直す際、未知の YAML フィールドとコメントは保持されません。
@@ -164,7 +169,7 @@ setup:
 環境変数によるルート設定:
 
 ```bash
-ROUTE_<NAME>=<prefix>|<upstream_url>
+ROUTE_<NAME>=<prefix>|<upstream_url>[|option=value...]
 ```
 
 例:
@@ -183,13 +188,69 @@ ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:8083
 - 重複プレフィックスは拒否されます。
 - ルートは最長プレフィックス優先でソートされます。
 
-ルートの認証を無効にするには `|auth=none` を追加します:
+### ルートオプション
+
+パイプ区切りで追加指定できます。未知のオプションキーは起動時に拒否されます（フェールクローズ）。
+
+| オプション | デフォルト | 説明 |
+|-----------|----------|------|
+| `auth` | `oauth` | `oauth`（Bearer 検証あり）または `none`（認証スキップ）。`upstream_oauth` と `none` は排他。 |
+| `upstream_bearer_token_env` | なし | ゲートウェイ→upstream の Bearer トークンを取得する環境変数名。起動時に env var が未設定または空の場合は起動失敗（フェールクローズ）。`upstream_oauth` と排他。 |
+| `required_audience` | `mcp-gateway` | アクセストークンに必要な `aud` クレーム値。クライアントは `/token` に `resource=<name>` を渡してこの audience のトークンを取得する。 |
+| `upstream_oauth` | なし | Upstream OAuth 委任を有効化。`auto`（RFC 9728 + RFC 8414 で AS を自動検出）または絶対 issuer URL（`https://...`）。`upstream_bearer_token_env` と排他。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
+| `upstream_oauth_scope` | なし | Upstream AS へのトークンリクエストで要求するスコープ（スペース区切り。カンマ区切りは自動正規化）。`upstream_oauth` が必要。 |
+| `upstream_oauth_grant` | `authorization_code` | Upstream トークン取得に使用する OAuth 2.0 グラントタイプ。`authorization_code`（ユーザーを認可エンドポイントへリダイレクト）または `client_credentials`（バックグラウンドでトークンを取得、ユーザー操作不要）。`upstream_oauth` が必要。 |
+
+### Upstream OAuth 委任
+
+`upstream_oauth` を設定したルートでは、ゲートウェイが以下を自動実行します。
+
+1. **Discovery + DCR**（初回アクセス時のみ）: upstream AS のメタデータを検出し、Dynamic Client Registration（RFC 7591）でクライアントを登録。登録情報は `{state-dir}/upstream_clients.json` にキャッシュ。
+2. **トークン取得**: `upstream_oauth_grant` で指定されたフローでトークンを取得。
+3. **トークン注入**: `Authorization: Bearer <upstream-token>` として upstream リクエストに付与。
+4. **リフレッシュ**: トークン期限切れ前にプロアクティブにリフレッシュ、または upstream からの 401 レスポンス時に透過的にリフレッシュして再試行。
+
+#### `authorization_code` フロー（デフォルト）
+
+ユーザーを upstream AS の認可エンドポイントへリダイレクトします（PKCE あり）。初回アクセス時にユーザーの同意が必要です。取得したトークンはユーザーごとに `{state-dir}/upstream_tokens.json` へ保存されます。
 
 ```bash
-ROUTE_PUBLIC=/public|http://public-svc:8083|auth=none
+ROUTE_SVC=/mcp/svc|https://svc.example.com/mcp|upstream_oauth=auto|upstream_oauth_scope=read write
 ```
 
-`auth=oauth` は明示的に指定する必要がある場合のみ使用します。デフォルトです。
+`config.yaml` の場合:
+
+```yaml
+routes:
+  - name: svc
+    prefix: /mcp/svc
+    upstream: https://svc.example.com/mcp
+    upstream_oauth: auto
+    upstream_oauth_scope: read write
+    # upstream_oauth_grant は省略時 authorization_code がデフォルト
+```
+
+#### `client_credentials` フロー
+
+ユーザー操作なしでバックグラウンドにトークンを取得します（サービス間通信向け）。upstream AS が `client_credentials` グラントをサポートしている必要があります。
+
+```bash
+ROUTE_SVC=/mcp/svc|https://svc.example.com/mcp|upstream_oauth=auto|upstream_oauth_grant=client_credentials|upstream_oauth_scope=api:read
+```
+
+`config.yaml` の場合:
+
+```yaml
+routes:
+  - name: svc
+    prefix: /mcp/svc
+    upstream: https://svc.example.com/mcp
+    upstream_oauth: auto
+    upstream_oauth_grant: client_credentials
+    upstream_oauth_scope: api:read
+```
+
+> **Note**: コールバックエンドポイント `GET /upstream/callback/{routeName}` は `authorization_code` フローの redirect_uri として自動登録されます。`client_credentials` フローでは使用されません。
 
 ## シークレット暗号化
 

--- a/internal/auth/tokenstore_upstream.go
+++ b/internal/auth/tokenstore_upstream.go
@@ -19,6 +19,7 @@ import (
 type UpstreamTokenRecord struct {
 	Subject      string    // in-memory only; not written to disk
 	RouteName    string    // in-memory only; not written to disk
+	Grant        string    // "authorization_code" or "client_credentials"; empty = "authorization_code"
 	Issuer       string
 	AccessToken  string
 	RefreshToken string
@@ -51,6 +52,7 @@ func upstreamTokenKey(subject, routeName string) string {
 // token record. Subject and RouteName are intentionally absent from the JSON
 // so that raw identity information is never written to disk.
 type upstreamTokenFileEntry struct {
+	Grant        string     `json:"grant,omitempty"`
 	Issuer       string     `json:"issuer"`
 	AccessToken  string     `json:"access_token"`
 	RefreshToken string     `json:"refresh_token,omitempty"`
@@ -189,6 +191,7 @@ func (s *fileUpstreamTokenStore) Save(subject, routeName string, record Upstream
 		expiresAt = &t
 	}
 	s.entries[key] = upstreamTokenFileEntry{
+		Grant:        record.Grant,
 		Issuer:       record.Issuer,
 		AccessToken:  record.AccessToken,
 		RefreshToken: record.RefreshToken,
@@ -220,6 +223,7 @@ func (s *fileUpstreamTokenStore) Lookup(subject, routeName string) (UpstreamToke
 	return UpstreamTokenRecord{
 		Subject:      subject,
 		RouteName:    routeName,
+		Grant:        entry.Grant,
 		Issuer:       entry.Issuer,
 		AccessToken:  entry.AccessToken,
 		RefreshToken: entry.RefreshToken,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ type RouteConfig struct {
 	// space-separated internally.
 	// Use *string for the same presence-vs-empty reason as UpstreamOAuth.
 	UpstreamOAuthScope *string `yaml:"upstream_oauth_scope,omitempty" json:"upstream_oauth_scope,omitempty"`
+	// UpstreamOAuthGrant is the OAuth 2.0 grant type used for upstream token acquisition.
+	// Valid values: "authorization_code" (user-interactive, default) or
+	// "client_credentials" (service-to-service, no user interaction required).
+	// Use *string for the same presence-vs-empty reason as UpstreamOAuth.
+	UpstreamOAuthGrant *string `yaml:"upstream_oauth_grant,omitempty" json:"upstream_oauth_grant,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -42,6 +42,10 @@ type Route struct {
 	// UpstreamOAuthScope is the space-separated OAuth scope string requested from
 	// the upstream authorization server.
 	UpstreamOAuthScope string
+	// UpstreamOAuthGrant is the OAuth 2.0 grant type for upstream token acquisition.
+	// "authorization_code" (interactive, default) or "client_credentials" (non-interactive).
+	// Only meaningful when UpstreamOAuth is non-empty.
+	UpstreamOAuthGrant string
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
@@ -183,6 +187,29 @@ func parseRoutes(env []string) ([]Route, error) {
 			delete(options, "upstream_oauth_scope")
 		}
 
+		// upstream_oauth_grant: OAuth 2.0 grant type for upstream token acquisition.
+		// Valid values: "authorization_code" (default) or "client_credentials".
+		// Requires upstream_oauth to be set.
+		var upstreamOAuthGrant string
+		if grantVal, ok := options["upstream_oauth_grant"]; ok {
+			if upstreamOAuth == "" {
+				return nil, fmt.Errorf("%s: upstream_oauth_grant requires upstream_oauth to be set", key)
+			}
+			grantVal = strings.TrimSpace(grantVal)
+			switch grantVal {
+			case "authorization_code", "client_credentials":
+				upstreamOAuthGrant = grantVal
+			case "":
+				return nil, fmt.Errorf("%s: upstream_oauth_grant value must not be empty", key)
+			default:
+				return nil, fmt.Errorf("%s: upstream_oauth_grant must be \"authorization_code\" or \"client_credentials\" (got %q)", key, grantVal)
+			}
+			delete(options, "upstream_oauth_grant")
+		}
+		if upstreamOAuth != "" && upstreamOAuthGrant == "" {
+			upstreamOAuthGrant = "authorization_code"
+		}
+
 		// Reject any unrecognised option keys.
 		if len(options) > 0 {
 			unknown := make([]string, 0, len(options))
@@ -229,6 +256,7 @@ func parseRoutes(env []string) ([]Route, error) {
 			RequiredAudience:       requiredAudience,
 			UpstreamOAuth:          upstreamOAuth,
 			UpstreamOAuthScope:     upstreamOAuthScope,
+			UpstreamOAuthGrant:     upstreamOAuthGrant,
 		})
 	}
 	// Longest prefix first for correct matching order.
@@ -337,6 +365,26 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			upstreamOAuthScope = strings.ReplaceAll(upstreamOAuthScope, ",", " ")
 			upstreamOAuthScope = strings.Join(strings.Fields(upstreamOAuthScope), " ")
 		}
+		// upstream_oauth_grant: OAuth 2.0 grant type for upstream token acquisition.
+		// RouteConfig.UpstreamOAuthGrant is *string for the same presence-vs-empty reason.
+		var upstreamOAuthGrant string
+		if r.UpstreamOAuthGrant != nil {
+			if upstreamOAuth == "" {
+				return nil, fmt.Errorf("route %q: upstream_oauth_grant requires upstream_oauth to be set", name)
+			}
+			upstreamOAuthGrant = strings.TrimSpace(*r.UpstreamOAuthGrant)
+			switch upstreamOAuthGrant {
+			case "authorization_code", "client_credentials":
+				// valid
+			case "":
+				return nil, fmt.Errorf("route %q: upstream_oauth_grant value must not be empty", name)
+			default:
+				return nil, fmt.Errorf("route %q: upstream_oauth_grant must be \"authorization_code\" or \"client_credentials\" (got %q)", name, upstreamOAuthGrant)
+			}
+		}
+		if upstreamOAuth != "" && upstreamOAuthGrant == "" {
+			upstreamOAuthGrant = "authorization_code"
+		}
 		seen[prefix] = struct{}{}
 		routes = append(routes, Route{
 			Name:                   name,
@@ -347,6 +395,7 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			RequiredAudience:       requiredAudience,
 			UpstreamOAuth:          upstreamOAuth,
 			UpstreamOAuthScope:     upstreamOAuthScope,
+			UpstreamOAuthGrant:     upstreamOAuthGrant,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -801,3 +801,152 @@ func TestParseFromConfig_UpstreamOAuthWithAuthRequiredIsValid(t *testing.T) {
 		t.Errorf("expected valid route with upstream_oauth=auto")
 	}
 }
+
+// upstream_oauth_grant テスト群
+
+func TestParseRoutesUpstreamOAuthGrantDefault(t *testing.T) {
+	// upstream_oauth_grant を省略した場合のデフォルトは "authorization_code"
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "authorization_code" {
+		t.Errorf("UpstreamOAuthGrant: got %q, want %q", routes[0].UpstreamOAuthGrant, "authorization_code")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantAuthCode(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_grant=authorization_code"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "authorization_code" {
+		t.Errorf("UpstreamOAuthGrant: got %q, want %q", routes[0].UpstreamOAuthGrant, "authorization_code")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantClientCredentials(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_grant=client_credentials"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "client_credentials" {
+		t.Errorf("UpstreamOAuthGrant: got %q, want %q", routes[0].UpstreamOAuthGrant, "client_credentials")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantInvalidRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_grant=implicit"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for invalid upstream_oauth_grant value")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantEmptyRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth=auto|upstream_oauth_grant="}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for empty upstream_oauth_grant value")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantWithoutOAuthRejected(t *testing.T) {
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp|upstream_oauth_grant=client_credentials"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth_grant without upstream_oauth")
+	}
+}
+
+func TestParseRoutesUpstreamOAuthGrantNoOAuthRouteIsEmpty(t *testing.T) {
+	// upstream_oauth が設定されていないルートは UpstreamOAuthGrant が空文字列
+	env := []string{"ROUTE_CF=/mcp/cf|https://mcp.cloudflare.com/mcp"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "" {
+		t.Errorf("UpstreamOAuthGrant should be empty when upstream_oauth is not set, got %q", routes[0].UpstreamOAuthGrant)
+	}
+}
+
+// ParseFromConfig upstream_oauth_grant テスト群
+
+func TestParseFromConfig_UpstreamOAuthGrantDefault(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp", UpstreamOAuth: strPtr("auto")},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "authorization_code" {
+		t.Errorf("UpstreamOAuthGrant default: got %q, want %q", routes[0].UpstreamOAuthGrant, "authorization_code")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthGrantClientCredentials(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthGrant: strPtr("client_credentials")},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamOAuthGrant != "client_credentials" {
+		t.Errorf("UpstreamOAuthGrant: got %q, want %q", routes[0].UpstreamOAuthGrant, "client_credentials")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthGrantInvalidRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthGrant: strPtr("implicit")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for invalid upstream_oauth_grant value")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthGrantEmptyStringRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthGrant: strPtr("")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for explicit empty upstream_oauth_grant value")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthGrantWithoutOAuthRejected(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuthGrant: strPtr("client_credentials")},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error for upstream_oauth_grant without upstream_oauth")
+	}
+}
+
+func TestParseFromConfig_UpstreamOAuthGrantNilTreatedAsAbsent(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{Name: "cf", Prefix: "/mcp/cf", Upstream: "https://mcp.cloudflare.com/mcp",
+			UpstreamOAuth: strPtr("auto"), UpstreamOAuthGrant: nil},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// nil → absent → default "authorization_code"
+	if routes[0].UpstreamOAuthGrant != "authorization_code" {
+		t.Errorf("UpstreamOAuthGrant for nil input: got %q, want %q", routes[0].UpstreamOAuthGrant, "authorization_code")
+	}
+}

--- a/internal/upstreamoauth/callback.go
+++ b/internal/upstreamoauth/callback.go
@@ -124,6 +124,7 @@ func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
 	if err := h.tokenStore.Save(state.Subject, routeName, auth.UpstreamTokenRecord{
+		Grant:        "authorization_code",
 		Issuer:       rec.Issuer,
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,

--- a/internal/upstreamoauth/clientstore.go
+++ b/internal/upstreamoauth/clientstore.go
@@ -14,6 +14,7 @@ import (
 // for a single gateway route.
 type ClientRecord struct {
 	RouteName             string    `json:"route_name"`
+	Grant                 string    `json:"grant,omitempty"`
 	Issuer                string    `json:"issuer"`
 	AuthorizationEndpoint string    `json:"authorization_endpoint"`
 	TokenEndpoint         string    `json:"token_endpoint"`

--- a/internal/upstreamoauth/dcr.go
+++ b/internal/upstreamoauth/dcr.go
@@ -12,7 +12,7 @@ import (
 
 // DCRRequest is the RFC 7591 §2 client metadata registration request body.
 type DCRRequest struct {
-	RedirectURIs            []string `json:"redirect_uris"`
+	RedirectURIs            []string `json:"redirect_uris,omitempty"`
 	ClientName              string   `json:"client_name,omitempty"`
 	GrantTypes              []string `json:"grant_types,omitempty"`
 	ResponseTypes           []string `json:"response_types,omitempty"`

--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -61,9 +61,13 @@ func NewAuthorizeMiddleware(
 				return
 			}
 
-			if _, ok := tokenStore.Lookup(subject, routeName); ok {
-				next.ServeHTTP(w, r)
-				return
+			if rec, ok := tokenStore.Lookup(subject, routeName); ok {
+				if grantMatches(rec.Grant, grant) {
+					next.ServeHTTP(w, r)
+					return
+				}
+				// grant mismatch: delete stale token and fall through to re-acquisition
+				_ = tokenStore.Delete(subject, routeName)
 			}
 
 			rec, err := manager.EnsureClient(r.Context(), routeName, upstreamOAuth, resourceURL, grant)
@@ -88,6 +92,7 @@ func NewAuthorizeMiddleware(
 				}
 				expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 				if err := tokenStore.Save(subject, routeName, auth.UpstreamTokenRecord{
+					Grant:       "client_credentials",
 					Issuer:      rec.Issuer,
 					AccessToken: tokenResp.AccessToken,
 					ExpiresAt:   expiresAt,

--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -74,8 +74,7 @@ func NewAuthorizeMiddleware(
 			}
 
 			if grant == "client_credentials" {
-				h := &http.Client{Timeout: DefaultHTTPTimeout}
-				tokenResp, err := fetchClientCredentialsToken(r.Context(), h, rec, upstreamOAuthScope)
+				tokenResp, err := fetchClientCredentialsToken(r.Context(), manager.httpClient, rec, upstreamOAuthScope)
 				if err != nil {
 					slog.Error("upstream OAuth: client_credentials token fetch failed", "route", routeName, "err", err)
 					http.Error(w, "upstream OAuth error", http.StatusBadGateway)

--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -1,9 +1,13 @@
 package upstreamoauth
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -24,8 +28,13 @@ func generateStateKey() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// NewAuthorizeMiddleware returns middleware that redirects authenticated users
-// to the upstream authorization endpoint when they have no valid upstream token.
+// NewAuthorizeMiddleware returns middleware that acquires an upstream token for
+// authenticated users that do not yet have one.
+//
+// When grant is "client_credentials", the token is fetched directly from the
+// upstream token endpoint without user interaction. When grant is
+// "authorization_code" (or empty, which defaults to "authorization_code"), the
+// user is redirected to the upstream authorization endpoint via PKCE.
 //
 // The middleware must sit between the gateway Auth middleware (which sets the
 // identity in context) and the proxy handler.
@@ -33,6 +42,7 @@ func NewAuthorizeMiddleware(
 	routeName string,
 	upstreamOAuth string,
 	upstreamOAuthScope string,
+	grant string,
 	resourceURL string,
 	manager *Manager,
 	stateStore StateStore,
@@ -40,6 +50,9 @@ func NewAuthorizeMiddleware(
 	publicURL string,
 ) func(http.Handler) http.Handler {
 	trimmedPublicURL := strings.TrimRight(publicURL, "/")
+	if grant == "" {
+		grant = "authorization_code"
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			subject := middleware.IdentityFromContext(r.Context())
@@ -53,13 +66,44 @@ func NewAuthorizeMiddleware(
 				return
 			}
 
-			rec, err := manager.EnsureClient(r.Context(), routeName, upstreamOAuth, resourceURL)
+			rec, err := manager.EnsureClient(r.Context(), routeName, upstreamOAuth, resourceURL, grant)
 			if err != nil {
 				slog.Error("upstream OAuth: EnsureClient failed", "route", routeName, "err", err)
 				http.Error(w, "upstream OAuth configuration error", http.StatusBadGateway)
 				return
 			}
 
+			if grant == "client_credentials" {
+				h := &http.Client{Timeout: DefaultHTTPTimeout}
+				tokenResp, err := fetchClientCredentialsToken(r.Context(), h, rec, upstreamOAuthScope)
+				if err != nil {
+					slog.Error("upstream OAuth: client_credentials token fetch failed", "route", routeName, "err", err)
+					http.Error(w, "upstream OAuth error", http.StatusBadGateway)
+					return
+				}
+				if tokenResp.ExpiresIn <= 0 {
+					slog.Error("upstream OAuth: client_credentials token missing required expires_in",
+						"route", routeName, "token_endpoint", rec.TokenEndpoint)
+					http.Error(w, "upstream token missing required expiry", http.StatusBadGateway)
+					return
+				}
+				expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+				if err := tokenStore.Save(subject, routeName, auth.UpstreamTokenRecord{
+					Issuer:      rec.Issuer,
+					AccessToken: tokenResp.AccessToken,
+					ExpiresAt:   expiresAt,
+					Scope:       tokenResp.Scope,
+				}); err != nil {
+					slog.Error("upstream OAuth: failed to save client_credentials token", "route", routeName, "err", err)
+					http.Error(w, "failed to save token", http.StatusInternalServerError)
+					return
+				}
+				slog.Info("upstream OAuth: client_credentials token acquired", "route", routeName)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// authorization_code flow: redirect user to upstream authorization endpoint.
 			codeVerifier, err := GenerateCodeVerifier()
 			if err != nil {
 				slog.Error("upstream OAuth: code_verifier generation failed", "err", err)
@@ -106,4 +150,48 @@ func NewAuthorizeMiddleware(
 			http.Redirect(w, r, authURL.String(), http.StatusFound)
 		})
 	}
+}
+
+// fetchClientCredentialsToken obtains an access token from rec.TokenEndpoint
+// using the client_credentials grant type. The returned response is never nil
+// when err is nil, and AccessToken is guaranteed to be non-empty.
+func fetchClientCredentialsToken(ctx context.Context, httpClient *http.Client, rec ClientRecord, scope string) (*tokenExchangeResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	form.Set("client_id", rec.ClientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rec.TokenEndpoint,
+		bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating client_credentials request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if rec.ClientSecret != "" {
+		req.SetBasicAuth(rec.ClientID, rec.ClientSecret)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", rec.TokenEndpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("token endpoint %s: unexpected status %d: %s",
+			rec.TokenEndpoint, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var tr tokenExchangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("decoding token response from %s: %w", rec.TokenEndpoint, err)
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("token response from %s missing access_token", rec.TokenEndpoint)
+	}
+	return &tr, nil
 }

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -250,6 +250,7 @@ func TestAuthorizeMiddleware_ClientCredentials_Success(t *testing.T) {
 	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
 		routeName: {
 			RouteName:     routeName,
+			Grant:         "client_credentials",
 			Issuer:        tokenSrv.URL,
 			TokenEndpoint: tokenSrv.URL + "/token",
 			ClientID:      "svc-client",

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -365,6 +365,87 @@ func TestAuthorizeMiddleware_ClientCredentials_MissingExpiresIn(t *testing.T) {
 	}
 }
 
+func TestAuthorizeMiddleware_GrantMismatch_StaleTokenDeleted(t *testing.T) {
+	// authorization_code トークンが保存済みの状態で client_credentials リクエストが来た場合、
+	// 旧トークンが削除されて client_credentials フローへ進むことを確認する。
+	const (
+		routeName   = "switch-grant"
+		publicURL   = "http://localhost:8080"
+		subject     = "svc@example.com"
+		newToken    = "cc-token-after-switch"
+	)
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "client_credentials" {
+			http.Error(w, "wrong grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": newToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:     routeName,
+			Grant:         "client_credentials",
+			Issuer:        tokenSrv.URL,
+			TokenEndpoint: tokenSrv.URL + "/token",
+			ClientID:      "svc-client",
+			ClientSecret:  "svc-secret",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, publicURL)
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	// authorization_code トークンを事前に保存（旧 grant）
+	_ = tokenStore.Save(subject, routeName, auth.UpstreamTokenRecord{
+		Grant:       "authorization_code",
+		AccessToken: "stale-user-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	})
+
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		routeName, tokenSrv.URL, "read", "client_credentials", "", mgr,
+		upstreamoauth.NewStateStore(), tokenStore, publicURL,
+	)
+	nextCalled := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/switch-grant/sse", nil)
+	req = withIdentity(req, subject)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called after grant-switch token acquisition")
+	}
+
+	// 新しい client_credentials トークンが保存されていること
+	rec, ok := tokenStore.Lookup(subject, routeName)
+	if !ok {
+		t.Fatal("expected new token to be stored after grant switch")
+	}
+	if rec.AccessToken != newToken {
+		t.Errorf("AccessToken = %q, want %q", rec.AccessToken, newToken)
+	}
+}
+
 func TestAuthorizeMiddleware_DefaultGrant_IsAuthCode(t *testing.T) {
 	// grant="" should default to authorization_code (redirect, not client_credentials fetch).
 	const routeName = "default-grant"

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -2,6 +2,7 @@ package upstreamoauth_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,7 +22,7 @@ func TestAuthorizeMiddleware_Unauthenticated(t *testing.T) {
 	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
 	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
 	mw := upstreamoauth.NewAuthorizeMiddleware(
-		"myroute", "https://as.example.com", "", "", mgr,
+		"myroute", "https://as.example.com", "", "authorization_code", "", mgr,
 		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func TestAuthorizeMiddleware_ValidToken_PassThrough(t *testing.T) {
 	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
 	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
 	mw := upstreamoauth.NewAuthorizeMiddleware(
-		"myroute", "https://as.example.com", "", "", mgr,
+		"myroute", "https://as.example.com", "", "authorization_code", "", mgr,
 		upstreamoauth.NewStateStore(), tokenStore, "http://localhost:8080",
 	)
 	nextCalled := false
@@ -92,7 +93,7 @@ func TestAuthorizeMiddleware_RedirectWithPKCE(t *testing.T) {
 	tokenStore := auth.NewMemUpstreamTokenStore()
 
 	mw := upstreamoauth.NewAuthorizeMiddleware(
-		routeName, "https://as.example.com", "read write", "", mgr, stateStore, tokenStore, publicURL,
+		routeName, "https://as.example.com", "read write", "authorization_code", "", mgr, stateStore, tokenStore, publicURL,
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("next handler must not be called when redirect is expected")
@@ -168,7 +169,7 @@ func TestAuthorizeMiddleware_ScopeOmitted(t *testing.T) {
 	}}
 	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
 	mw := upstreamoauth.NewAuthorizeMiddleware(
-		routeName, "https://as.example.com", "", "", mgr,
+		routeName, "https://as.example.com", "", "authorization_code", "", mgr,
 		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -198,7 +199,7 @@ func TestAuthorizeMiddleware_EnsureClientError(t *testing.T) {
 	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{}}
 	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
 	mw := upstreamoauth.NewAuthorizeMiddleware(
-		"myroute", ts.URL, "", "", mgr,
+		"myroute", ts.URL, "", "authorization_code", "", mgr,
 		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -212,5 +213,182 @@ func TestAuthorizeMiddleware_EnsureClientError(t *testing.T) {
 
 	if rr.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+	}
+}
+
+func TestAuthorizeMiddleware_ClientCredentials_Success(t *testing.T) {
+	const (
+		routeName   = "cc-route"
+		publicURL   = "http://localhost:8080"
+		subject     = "svc@example.com"
+		accessToken = "cc-access-token"
+	)
+
+	// Fake token endpoint that returns a client_credentials token.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("grant_type") != "client_credentials" {
+			http.Error(w, "wrong grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": accessToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:     routeName,
+			Issuer:        tokenSrv.URL,
+			TokenEndpoint: tokenSrv.URL + "/token",
+			ClientID:      "svc-client",
+			ClientSecret:  "svc-secret",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, publicURL)
+	tokenStore := auth.NewMemUpstreamTokenStore()
+
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		routeName, tokenSrv.URL, "read", "client_credentials", "", mgr,
+		upstreamoauth.NewStateStore(), tokenStore, publicURL,
+	)
+	nextCalled := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/cc-route/sse", nil)
+	req = withIdentity(req, subject)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called after client_credentials token acquired")
+	}
+
+	// Verify the token was stored.
+	rec, ok := tokenStore.Lookup(subject, routeName)
+	if !ok {
+		t.Fatal("expected token to be stored in tokenStore")
+	}
+	if rec.AccessToken != accessToken {
+		t.Errorf("AccessToken = %q, want %q", rec.AccessToken, accessToken)
+	}
+}
+
+func TestAuthorizeMiddleware_ClientCredentials_TokenEndpointError(t *testing.T) {
+	// Token endpoint returns 500.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server error", http.StatusInternalServerError)
+	}))
+	defer tokenSrv.Close()
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		"cc-err": {
+			RouteName:     "cc-err",
+			TokenEndpoint: tokenSrv.URL + "/token",
+			ClientID:      "cid",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		"cc-err", tokenSrv.URL, "", "client_credentials", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called when token endpoint returns error")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/cc-err/sse", nil)
+	req = withIdentity(req, "svc@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+	}
+}
+
+func TestAuthorizeMiddleware_ClientCredentials_MissingExpiresIn(t *testing.T) {
+	// Token endpoint returns token without expires_in.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "no-expiry-token",
+			"token_type":   "Bearer",
+			// expires_in absent → zero value
+		})
+	}))
+	defer tokenSrv.Close()
+
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		"cc-noexp": {
+			RouteName:     "cc-noexp",
+			TokenEndpoint: tokenSrv.URL + "/token",
+			ClientID:      "cid",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		"cc-noexp", tokenSrv.URL, "", "client_credentials", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called when expires_in is missing")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/cc-noexp/sse", nil)
+	req = withIdentity(req, "svc@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+	}
+}
+
+func TestAuthorizeMiddleware_DefaultGrant_IsAuthCode(t *testing.T) {
+	// grant="" should default to authorization_code (redirect, not client_credentials fetch).
+	const routeName = "default-grant"
+	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
+		routeName: {
+			RouteName:             routeName,
+			AuthorizationEndpoint: "https://as.example.com/authorize",
+			ClientID:              "cid",
+		},
+	}}
+	mgr := upstreamoauth.NewManager(cs, "http://localhost:8080")
+	mw := upstreamoauth.NewAuthorizeMiddleware(
+		routeName, "https://as.example.com", "", "", "", mgr,
+		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
+	)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler must not be called: should redirect")
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/default-grant/sse", nil)
+	req = withIdentity(req, "user@example.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d (empty grant should default to authorization_code)", rr.Code, http.StatusFound)
 	}
 }

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -52,10 +52,12 @@ func NewManager(store ClientStore, publicURL string) *Manager {
 //     issuer URL (RFC 8414 one-step).
 //   - resourceURL: the upstream URL for "auto" discovery (e.g.
 //     "https://mcp.example.com/sse"). Ignored when upstreamOAuth is an issuer URL.
+//   - grant: "authorization_code" or "client_credentials". Controls which grant
+//     type is registered via DCR. Empty string defaults to "authorization_code".
 //
 // Concurrent calls for the same routeName are coalesced via singleflight so
 // that discovery + DCR + store.Save only executes once.
-func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, resourceURL string) (ClientRecord, error) {
+func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, resourceURL, grant string) (ClientRecord, error) {
 	if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
 		return rec, nil
 	}
@@ -77,13 +79,22 @@ func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, re
 			return nil, fmt.Errorf("upstream AS for route %q does not expose a registration_endpoint; Dynamic Client Registration is required", routeName)
 		}
 
-		redirectURI := m.publicURL + "/upstream/callback/" + url.PathEscape(routeName)
-		dcrReq := DCRRequest{
-			RedirectURIs:            []string{redirectURI},
-			ClientName:              "mcp-gateway/" + routeName,
-			GrantTypes:              []string{"authorization_code"},
-			ResponseTypes:           []string{"code"},
-			TokenEndpointAuthMethod: "client_secret_basic",
+		var dcrReq DCRRequest
+		if grant == "client_credentials" {
+			dcrReq = DCRRequest{
+				ClientName:              "mcp-gateway/" + routeName,
+				GrantTypes:              []string{"client_credentials"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+			}
+		} else {
+			redirectURI := m.publicURL + "/upstream/callback/" + url.PathEscape(routeName)
+			dcrReq = DCRRequest{
+				RedirectURIs:            []string{redirectURI},
+				ClientName:              "mcp-gateway/" + routeName,
+				GrantTypes:              []string{"authorization_code"},
+				ResponseTypes:           []string{"code"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+			}
 		}
 		dcrResp, err := RegisterClient(ctx, m.httpClient, meta.RegistrationEndpoint, dcrReq)
 		if err != nil {

--- a/internal/upstreamoauth/manager.go
+++ b/internal/upstreamoauth/manager.go
@@ -57,16 +57,30 @@ func NewManager(store ClientStore, publicURL string) *Manager {
 //
 // Concurrent calls for the same routeName are coalesced via singleflight so
 // that discovery + DCR + store.Save only executes once.
+// grantMatches reports whether stored matches the requested grant.
+// An empty stored grant is treated as "authorization_code" for backward
+// compatibility with records saved before this field existed.
+func grantMatches(stored, requested string) bool {
+	if stored == "" {
+		stored = "authorization_code"
+	}
+	if requested == "" {
+		requested = "authorization_code"
+	}
+	return stored == requested
+}
+
 func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, resourceURL, grant string) (ClientRecord, error) {
-	if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
+	if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" && grantMatches(rec.Grant, grant) {
 		return rec, nil
 	}
 
 	type sfResult struct{ record ClientRecord }
-	v, err, _ := m.sfGroup.Do(routeName, func() (any, error) {
+	sfKey := routeName + "|" + grant
+	v, err, _ := m.sfGroup.Do(sfKey, func() (any, error) {
 		// Re-check inside the singleflight critical section so that the follower
 		// goroutines skip DCR when the leader already persisted the record.
-		if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" {
+		if rec, ok := m.store.Load(routeName); ok && rec.ClientID != "" && grantMatches(rec.Grant, grant) {
 			return sfResult{record: rec}, nil
 		}
 
@@ -101,8 +115,13 @@ func (m *Manager) EnsureClient(ctx context.Context, routeName, upstreamOAuth, re
 			return nil, fmt.Errorf("dynamic client registration for route %q: %w", routeName, err)
 		}
 
+		effectiveGrant := grant
+		if effectiveGrant == "" {
+			effectiveGrant = "authorization_code"
+		}
 		record := ClientRecord{
 			RouteName:             routeName,
+			Grant:                 effectiveGrant,
 			Issuer:                meta.Issuer,
 			AuthorizationEndpoint: meta.AuthorizationEndpoint,
 			TokenEndpoint:         meta.TokenEndpoint,

--- a/internal/upstreamoauth/manager_test.go
+++ b/internal/upstreamoauth/manager_test.go
@@ -63,7 +63,7 @@ func TestManager_EnsureClient_FullFlow(t *testing.T) {
 
 	m.httpClient = asSrv.Client()
 
-	rec, err := m.EnsureClient(context.Background(), "route1", asSrv.URL, "")
+	rec, err := m.EnsureClient(context.Background(), "route1", asSrv.URL, "", "authorization_code")
 	if err != nil {
 		t.Fatalf("EnsureClient: %v", err)
 	}
@@ -88,12 +88,12 @@ func TestManager_EnsureClient_CacheHit(t *testing.T) {
 	m.httpClient = asSrv.Client()
 
 	// 1 回目: discovery + DCR
-	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, ""); err != nil {
+	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, "", "authorization_code"); err != nil {
 		t.Fatalf("EnsureClient (first): %v", err)
 	}
 
 	// 2 回目: store から即返却（network call なし）
-	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, ""); err != nil {
+	if _, err := m.EnsureClient(context.Background(), "route-cache", asSrv.URL, "", "authorization_code"); err != nil {
 		t.Fatalf("EnsureClient (second): %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestManager_EnsureClient_SkipDCRWhenClientIDExists(t *testing.T) {
 	defer asSrv.Close()
 	m.httpClient = asSrv.Client()
 
-	rec, err := m.EnsureClient(context.Background(), "pre-registered", asSrv.URL, "")
+	rec, err := m.EnsureClient(context.Background(), "pre-registered", asSrv.URL, "", "authorization_code")
 	if err != nil {
 		t.Fatalf("EnsureClient: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestManager_EnsureClient_MissingRegistrationEndpoint(t *testing.T) {
 
 	m.httpClient = asSrv.Client()
 
-	_, err := m.EnsureClient(context.Background(), "no-dcr-route", asSrv.URL, "")
+	_, err := m.EnsureClient(context.Background(), "no-dcr-route", asSrv.URL, "", "authorization_code")
 	if err == nil {
 		t.Fatal("expected error for missing registration_endpoint, got nil")
 	}
@@ -207,7 +207,7 @@ func TestManager_EnsureClient_Auto_TwoStep(t *testing.T) {
 	// auto 検索: httpClient は両サーバーに接続できる必要がある（どちらも plain HTTP）
 	m.httpClient = prmSrv.Client()
 
-	rec, err := m.EnsureClient(context.Background(), "auto-route", "auto", prmSrv.URL+"/sse")
+	rec, err := m.EnsureClient(context.Background(), "auto-route", "auto", prmSrv.URL+"/sse", "authorization_code")
 	if err != nil {
 		t.Fatalf("EnsureClient (auto): %v", err)
 	}
@@ -243,7 +243,7 @@ func TestManager_EnsureClient_SaveFailureReturnsError(t *testing.T) {
 	defer asSrv.Close()
 	m.httpClient = asSrv.Client()
 
-	_, err := m.EnsureClient(context.Background(), "save-fail-route", asSrv.URL, "")
+	_, err := m.EnsureClient(context.Background(), "save-fail-route", asSrv.URL, "", "authorization_code")
 	if err == nil {
 		t.Fatal("expected error when store.Save fails, got nil")
 	}

--- a/internal/upstreamoauth/manager_test.go
+++ b/internal/upstreamoauth/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -255,6 +256,77 @@ type alwaysFailClientStore struct{}
 func (s *alwaysFailClientStore) Load(_ string) (ClientRecord, bool) { return ClientRecord{}, false }
 func (s *alwaysFailClientStore) Save(_ ClientRecord) error           { return fmt.Errorf("disk full") }
 func (s *alwaysFailClientStore) All() []ClientRecord                 { return nil }
+
+func TestManager_EnsureClient_ClientCredentials_DCRBody(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var capturedBody []byte
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                srv.URL,
+				AuthorizationEndpoint: srv.URL + "/authorize",
+				TokenEndpoint:         srv.URL + "/token",
+				RegistrationEndpoint:  srv.URL + "/register",
+			})
+		case "/register":
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(DCRResponse{ClientID: "cc-client", ClientSecret: "cc-secret"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	m.httpClient = srv.Client()
+
+	if _, err := m.EnsureClient(context.Background(), "cc-dcr-route", srv.URL, "", "client_credentials"); err != nil {
+		t.Fatalf("EnsureClient: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(capturedBody, &body); err != nil {
+		t.Fatalf("invalid DCR body JSON: %v", err)
+	}
+	if _, ok := body["redirect_uris"]; ok {
+		t.Error("redirect_uris must not be present in client_credentials DCR request")
+	}
+	if _, ok := body["response_types"]; ok {
+		t.Error("response_types must not be present in client_credentials DCR request")
+	}
+	grantTypes, _ := body["grant_types"].([]any)
+	if len(grantTypes) != 1 || grantTypes[0] != "client_credentials" {
+		t.Errorf("grant_types = %v, want [\"client_credentials\"]", grantTypes)
+	}
+}
+
+func TestManager_EnsureClient_GrantChangeTriggersDCR(t *testing.T) {
+	m := newTestManager(t, "https://gateway.example.com")
+
+	var dcrCalls atomic.Int32
+	asSrv := setupASAndDCR(t, "cid-grant", &dcrCalls)
+	defer asSrv.Close()
+	m.httpClient = asSrv.Client()
+
+	// 1 回目: authorization_code
+	if _, err := m.EnsureClient(context.Background(), "grant-change", asSrv.URL, "", "authorization_code"); err != nil {
+		t.Fatalf("EnsureClient (auth_code): %v", err)
+	}
+	if dcrCalls.Load() != 1 {
+		t.Errorf("DCR calls after auth_code: got %d, want 1", dcrCalls.Load())
+	}
+
+	// 2 回目: 同じ routeName で client_credentials → 再 DCR が走ること
+	if _, err := m.EnsureClient(context.Background(), "grant-change", asSrv.URL, "", "client_credentials"); err != nil {
+		t.Fatalf("EnsureClient (client_credentials): %v", err)
+	}
+	if dcrCalls.Load() != 2 {
+		t.Errorf("DCR calls after grant change: got %d, want 2 (grant change must trigger re-DCR)", dcrCalls.Load())
+	}
+}
 
 func TestManager_discoverCached_NoSecondNetworkCall(t *testing.T) {
 	m := newTestManager(t, "https://gateway.example.com")


### PR DESCRIPTION
## Summary

- `upstream_oauth_grant: authorization_code | client_credentials` を設定として追加（ISSUE#166 の client_credentials フロー要件）
- `client_credentials` を選択したルートでは、ユーザーリダイレクト不要でバックグラウンドにトークンを取得して upstream に注入する
- 省略時のデフォルトは `authorization_code`（後方互換性を維持）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/config/config.go` | `RouteConfig.UpstreamOAuthGrant *string` フィールド追加 |
| `internal/router/router.go` | `Route.UpstreamOAuthGrant string` + `parseRoutes` / `ParseFromConfig` のパース・バリデーション |
| `internal/upstreamoauth/manager.go` | `EnsureClient(grant string)` 追加 — `client_credentials` では `redirect_uri`/`response_type` を含まない DCR リクエストを送信 |
| `internal/upstreamoauth/flow.go` | `NewAuthorizeMiddleware(grant string)` 追加 — `client_credentials` フローでは token endpoint に直接 POST、`fetchClientCredentialsToken` ヘルパー追加 |
| `cmd/server/main.go` | `NewAuthorizeMiddleware` 呼び出しに `route.UpstreamOAuthGrant` を渡す |

## 設定例

```yaml
# config.yaml
routes:
  - name: myservice
    prefix: /mcp/myservice
    upstream: https://myservice.example.com/mcp
    upstream_oauth: https://myservice.example.com
    upstream_oauth_grant: client_credentials   # ← 新規
    upstream_oauth_scope: read write

# 環境変数でも指定可能
# ROUTE_SVC=/mcp/svc|https://svc.example.com/mcp|upstream_oauth=auto|upstream_oauth_grant=client_credentials
```

## Test plan

- [x] `go test ./...` 全パス
- [x] `client_credentials` 成功・token endpoint エラー・`expires_in` 欠落のテスト追加
- [x] デフォルト（空文字列）が `authorization_code` になることをテストで確認
- [x] `router_test.go` に env / config.yaml 両パスのバリデーションテスト追加

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)