### PR TITLE
docs: ドキュメントの穴を修正し squirrel-notifier を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -248,7 +248,7 @@ environment:
 | `/device_authorization` | POST | Device Authorization Grant endpoint。 |
 | `/token` | POST | authorization code、device code、refresh token grant。 |
 | `/register` | POST | Dynamic client registration。 |
-| `/upstream/callback/{routeName}` | GET | upstream OAuth authorization code callback（`authorization_code` フロー専用）。 |
+| `/upstream/callback/{routeName}` | GET | upstream OAuth authorization code callback（`authorization_code` フロー専用）。upstream OAuth 有効ルートが 1 つ以上ある場合のみ登録。 |
 | `/setup` | GET/POST | setup mode 中の初回起動 wizard。 |
 | `/health` | GET | 通常モードの health check。 |
 | `/<prefix>` | ANY | マッチした upstream への reverse proxy。 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -146,14 +146,18 @@ mcp-gateway は `github-oauth-proxy` の後継です
 | Repo | 役割 |
 |------|------|
 | **mcp-gateway** | OAuth 2.0 認証、MCP authorization metadata、トークン永続化、ルーティングゲートウェイ。 |
-| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | MCP スタック全体の Docker Compose オーケストレーション。 |
-| [copilot-review-mcp](https://github.com/scottlz0310/copilot-review-mcp) | Copilot コードレビュー MCP サーバー。 |
+| [thread-owl](https://github.com/scottlz0310/thread-owl) | レビュアー側 MCP サーバー: webhook 受信・レビュー候補判定・キュー管理。 |
+| [mcp-resource-subscriber](https://github.com/scottlz0310/mcp-resource-subscriber) | MCP resource 通知のサブスクリプションクライアント兼エージェントワークフロー橋渡し。 |
+| [review-raven](https://github.com/scottlz0310/review-raven) | レビューされる側 MCP: Copilot レビュースレッド取得・返信・解決・再レビュー依頼。 |
+| [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | コンテナオーケストレーション、ゲートウェイルート生成、CLI エージェント設定自動化。 |
+| [squirrel-notifier](https://github.com/scottlz0310/squirrel-notifier) | デスクトップ常駐の通知受信 / AI エージェントランチャー: mcp-gateway 経由で MCP resource 更新を監視し、トースト通知とローカル AI エージェントの起動を担当。 |
 
 ## ドキュメント
 
 | Document | 用途 |
 |----------|------|
 | [docs/README.md](docs/README.md) | ドキュメント index。 |
+| [docs/architecture.md](docs/architecture.md) | レビュープラットフォーム概要、責務境界、設計原則。 |
 | [docs/configuration.md](docs/configuration.md) | 環境変数、`config.yaml`、ルート、トークンストア、リバースプロキシ、エンドポイントの詳細リファレンス。 |
 | [docs/operations.md](docs/operations.md) | 起動停止、ヘルスチェック、構造化ログ、トラブルシュート、移行手順。 |
 | [docs/runbook-e2e-v0.1.0.md](docs/runbook-e2e-v0.1.0.md) | E2E 受け入れランブック。 |
@@ -204,6 +208,7 @@ setup token を消費して終了コード 0 で終了します。その後 supe
 - GitHub OAuth client secret の age X25519 暗号化保存。
 - request、auth、setup、proxy event の構造化 JSON log。
 - TLS 終端 proxy 向け trusted reverse proxy header 処理。
+- **upstream OAuth 委任**: ルート単位で upstream OAuth を設定。`authorization_code`（ユーザー認可フロー）または `client_credentials`（サービス間通信）を選択可能。AS の自動検出（RFC 9728 + RFC 8414）・Dynamic Client Registration・ユーザーごとのトークン永続化・proactive refresh・透過的 401 retry に対応。
 
 ## 主要設定
 
@@ -226,6 +231,8 @@ environment:
 | `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity。安全にバックアップしてください。 |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | token 永続化 path。Docker 環境では環境変数で上書きすること。 |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS のユーザー state 領域。公式 image では `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines。相対 path と Git worktree 配下は拒否されます。 |
+| *(自動生成)* | `{state-dir}/upstream_clients.json` | upstream AS の Dynamic Client Registration 記録（mode 0600）。upstream OAuth ルートへの初回アクセス時に作成。 |
+| *(自動生成)* | `{state-dir}/upstream_tokens.json` | ユーザーごとの upstream OAuth access/refresh token（mode 0600）。初回 upstream OAuth 認可完了時に作成。 |
 
 `{state-dir}` は起動時に解決される OS ユーザー状態ディレクトリです（Windows: `%LOCALAPPDATA%\mcp-gateway`、macOS: `~/Library/Application Support/mcp-gateway`、Linux: `$XDG_STATE_HOME/mcp-gateway` → `~/.local/state/mcp-gateway`）。Docker 環境では必ず環境変数でパスを上書きしてください。詳細は [docs/configuration.md](docs/configuration.md) を参照してください。
 
@@ -241,6 +248,7 @@ environment:
 | `/device_authorization` | POST | Device Authorization Grant endpoint。 |
 | `/token` | POST | authorization code、device code、refresh token grant。 |
 | `/register` | POST | Dynamic client registration。 |
+| `/upstream/callback/{routeName}` | GET | upstream OAuth authorization code callback（`authorization_code` フロー専用）。 |
 | `/setup` | GET/POST | setup mode 中の初回起動 wizard。 |
 | `/health` | GET | 通常モードの health check。 |
 | `/<prefix>` | ANY | マッチした upstream への reverse proxy。 |

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Important paths:
 | `/device_authorization` | POST | Device Authorization Grant endpoint. |
 | `/token` | POST | Authorization code, device code, and refresh token grants. |
 | `/register` | POST | Dynamic client registration. |
-| `/upstream/callback/{routeName}` | GET | Upstream OAuth authorization code callback (authorization_code flow only). |
+| `/upstream/callback/{routeName}` | GET | Upstream OAuth authorization code callback (authorization_code flow only; registered only when at least one upstream OAuth route is configured). |
 | `/setup` | GET/POST | First-run setup wizard, available in setup mode. |
 | `/health` | GET | Health check in normal mode. |
 | `/<prefix>` | ANY | Reverse proxy to the matched upstream. |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ mcp-gateway is the successor to `github-oauth-proxy`
 | [mcp-resource-subscriber](https://github.com/scottlz0310/mcp-resource-subscriber) | Subscription client and agent workflow bridge for MCP resource notifications. |
 | [review-raven](https://github.com/scottlz0310/review-raven) | Reviewed-side MCP: fetch Copilot review threads, reply, resolve, and re-request review. |
 | [mcp-docker](https://github.com/scottlz0310/Mcp-Docker) | Container orchestration, gateway config generation, and CLI agent config automation. |
+| [squirrel-notifier](https://github.com/scottlz0310/squirrel-notifier) | Desktop-resident notification receiver and AI agent launcher: monitors MCP resource updates via mcp-gateway, shows toast notifications, and launches local AI agents with skill directives. |
 
 ## Documentation
 
@@ -214,6 +215,7 @@ Operational details and recovery procedures are in
 - age X25519 encryption for stored GitHub OAuth client secrets.
 - Structured JSON logs with request, auth, setup, and proxy events.
 - Trusted reverse proxy header handling for TLS-terminating proxies.
+- **Upstream OAuth delegation**: per-route upstream OAuth with `authorization_code` (user-interactive) or `client_credentials` (service-to-service) grant, automatic AS discovery (RFC 9728 + RFC 8414), Dynamic Client Registration, per-user token persistence, proactive refresh, and transparent 401 retry.
 
 ## Core Configuration
 
@@ -236,6 +238,8 @@ Important paths:
 | `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity. Back it up securely. |
 | `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | Persistent token store. Docker deployments pin this via env var. |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS user state directory; `/data/mcp-gateway/logs/auth-audit.jsonl` in the official image | Rotating OAuth audit JSON Lines file. Relative paths and Git worktree paths are rejected. |
+| *(auto)* | `{state-dir}/upstream_clients.json` | Upstream AS Dynamic Client Registration records (mode 0600). Created on first upstream OAuth route access. |
+| *(auto)* | `{state-dir}/upstream_tokens.json` | Per-user upstream OAuth access/refresh tokens (mode 0600). Created on first upstream OAuth authorization. |
 
 `{state-dir}` is the OS user state directory resolved at startup (Windows: `%LOCALAPPDATA%\mcp-gateway`, macOS: `~/Library/Application Support/mcp-gateway`, Linux: `$XDG_STATE_HOME/mcp-gateway` → `~/.local/state/mcp-gateway`). Docker deployments always override paths via environment variables. See [docs/configuration.md](docs/configuration.md) for the full reference.
 
@@ -251,6 +255,7 @@ Important paths:
 | `/device_authorization` | POST | Device Authorization Grant endpoint. |
 | `/token` | POST | Authorization code, device code, and refresh token grants. |
 | `/register` | POST | Dynamic client registration. |
+| `/upstream/callback/{routeName}` | GET | Upstream OAuth authorization code callback (authorization_code flow only). |
 | `/setup` | GET/POST | First-run setup wizard, available in setup mode. |
 | `/health` | GET | Health check in normal mode. |
 | `/<prefix>` | ANY | Reverse proxy to the matched upstream. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,30 +1,31 @@
 # アーキテクチャ: レビュープラットフォーム MCP ゲートウェイとしての mcp-gateway
 
-このドキュメントは、レビュープラットフォーム内における mcp-gateway の役割、責務境界、および 5 リポジトリ構成の他コンポーネントとの関係を定義します。
+このドキュメントは、レビュープラットフォーム内における mcp-gateway の役割、責務境界、および 6 リポジトリ構成の他コンポーネントとの関係を定義します。
 
 ## レビュープラットフォーム概要
 
-半自動 PR レビュープラットフォームは、それぞれ独立した責務境界を持つ 5 つのリポジトリで構成されています。
+半自動 PR レビュープラットフォームは、それぞれ独立した責務境界を持つ 6 つのリポジトリで構成されています。
 
 ```text
 CLI エージェント / デスクトップクライアント
-  ↓ 単一の安定した MCP エンドポイント
-mcp-gateway
-  ├─ /mcp/thread-owl     -> thread-owl MCP サーバー
-  ├─ /mcp/review-raven   -> review-raven MCP サーバー
-  ├─ /mcp/github         -> github-mcp または互換サーバー
-  └─ /mcp/...            -> 追加の MCP サーバー
-                ↑
-        mcp-docker がコンテナ・ゲートウェイ設定・CLI エージェント設定を管理
+  ↑ (トースト通知からのユーザー操作により起動)
+squirrel-notifier (デスクトップ常駐 / AI エージェントランチャー)
+  ↓ config/token
+mcp-gateway (routing & auth boundary)
+  ↓ routes
+thread-owl / review-raven / github-mcp / 追加 MCP サーバー
+          ↑
+  mcp-docker が container / gateway route / agent config を管理
 ```
 
-| # | リポジトリ | 役割 | 責務 |
+| # | リポジトリ | 立場 | 責務 |
 |---|-----------|------|------|
-| 1 | **thread-owl** | レビュアー / subscribe ターゲット | GitHub App 認証、webhook 処理、レビュー候補判定、キュー管理、MCP tools/resources |
-| 2 | **mcp-resource-subscriber** | サブスクリプションクライアント / エージェントワークフロー橋渡し | `resources/subscribe` → `notifications/resources/updated` 待機 → `resources/read` → 構造化出力 |
-| 3 | **review-raven** | レビューされる側 | Copilot レビュースレッドの取得・返信・解決・再レビュー依頼 |
-| 4 | **mcp-gateway** | MCP リバースプロキシ / ルーティングゲートウェイ / 認証境界 | MCP サーバー群のルーティングと認証境界 |
-| 5 | **mcp-docker** | MCP コンテナオーケストレーション | コンテナ管理、ゲートウェイルート生成、CLI エージェント設定自動化 |
+| 1 | **thread-owl** | review する側 / subscribe される側 | GitHub App 認証・webhook 受信・review candidate 判定・queue 管理・MCP tools/resources 提供 |
+| 2 | **mcp-resource-subscriber** | subscribe する側 / agent workflow bridge | `resources/subscribe` → `notifications/resources/updated` 待機 → `resources/read` → 構造化出力 |
+| 3 | **review-raven** | review を受けて直す側 | Copilot レビュースレッド取得・返信・resolve・再レビュー依頼 |
+| 4 | **mcp-gateway** | MCP reverse proxy / routing gateway / auth boundary | MCP server 群への routing と認証境界 |
+| 5 | **mcp-docker** | MCP container orchestration | container 管理・gateway route 生成・CLI agent 設定自動化 |
+| 6 | **squirrel-notifier** | 通知受信 / AI エージェントランチャー | mcp-gateway 経由で MCP resource 更新（レビュー更新イベント等）を監視してトースト通知。トースト通知からローカルの AI エージェントを skill 指定で起動 |
 
 ## mcp-gateway の責務
 
@@ -35,6 +36,7 @@ mcp-gateway は CLI エージェントおよびデスクトップクライアン
 - OAuth / 呼び出し元認証 / トークン仲介の境界を提供
 - upstream MCP サーバーをプライベート / 内部エンドポイントとして扱えるようにする
 - ゲートウェイパスで各レビュープラットフォーム MCP サーバーを識別する
+- upstream OAuth 委任（`authorization_code` / `client_credentials`）によって upstream AS との token lifecycle を管理する
 - ルート設定・ヘルス・whoami・トークンソース等の運用 API を提供（一部将来実装）
 
 ## mcp-gateway が担当しないこと
@@ -51,6 +53,7 @@ mcp-gateway は CLI エージェントおよびデスクトップクライアン
 | 長命 resource subscription 待機 CLI | mcp-resource-subscriber |
 | MCP サーバーコンテナのライフサイクル管理 | mcp-docker |
 | CLI エージェント設定ファイル生成 | mcp-docker |
+| トースト通知・AI エージェント起動 | squirrel-notifier |
 
 ## ルート例
 
@@ -68,6 +71,13 @@ environment:
   ROUTE_THREAD_OWL:   /mcp/thread-owl|http://thread-owl:8081
   ROUTE_REVIEW_RAVEN: /mcp/review-raven|http://review-raven:8083
   ROUTE_GITHUB:       /mcp/github|http://github-mcp:8082
+```
+
+upstream AS が独自 OAuth を要求する場合は `upstream_oauth` を追加します。
+
+```yaml
+environment:
+  ROUTE_CLOUDFLARE: /mcp/cf|https://cf-mcp.example.com/mcp|upstream_oauth=auto|upstream_oauth_scope=read
 ```
 
 ## mcp-docker との関係
@@ -88,6 +98,18 @@ mcp-gateway
 
 ゲートウェイ設定は mcp-docker が生成することも手書きで記述することも可能です。両方をサポートしていますが、mcp-docker による生成が推奨の運用パスです。
 
+## squirrel-notifier との関係
+
+squirrel-notifier はデスクトップ常駐プロセスとして、mcp-gateway を経由して MCP resource 更新イベントを監視します。mcp-gateway は squirrel-notifier に対して通常の MCP クライアントと同様の認証境界を提供します。squirrel-notifier は mcp-gateway の内部実装に依存せず、公開エンドポイントのみを使用します。
+
+```text
+squirrel-notifier
+  ├─ mcp-resource-subscriber を子プロセスとして呼び出し
+  ├─ mcp-gateway 経由で thread-owl の resource を subscribe
+  ├─ 更新イベントを受信してトースト通知を表示
+  └─ ユーザー操作に応じてローカル AI エージェントを skill 指定で起動
+```
+
 ## 設計原則
 
 - 多数の個別 MCP サーバーをエージェントに直接登録することを避ける
@@ -96,3 +118,4 @@ mcp-gateway
 - ゲートウェイはルーティングと認証に集中し、レビュードメインロジックを持たない
 - ゲートウェイはコンテナのライフサイクルを管理しない（それは mcp-docker の責務）
 - ゲートウェイ設定は手書き形式と mcp-docker 生成形式の両方をサポートする
+- 各コンポーネントは独立して開発・更新・置き換えできる責務境界を持つ

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -334,6 +334,7 @@ MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 | パス | メソッド | 説明 |
 |------|---------|------|
 | `/.well-known/oauth-authorization-server` | GET | RFC 8414 authorization server メタデータ。 |
+| `/.well-known/openid-configuration` | GET | OIDC Discovery ドキュメント（gateway が OIDC Provider として動作する場合）。 |
 | `/.well-known/oauth-protected-resource` | GET | ゲートウェイ全体の RFC 9728 Protected Resource Metadata。ルートプレフィックスルートもカバー。 |
 | `/.well-known/oauth-protected-resource/<prefix>` | GET | 認証済み非ルートルートのルート単位 Protected Resource Metadata。例: `/.well-known/oauth-protected-resource/mcp/github`。 |
 | `/authorize` | GET | OAuth 2.0 authorization エンドポイント。 |
@@ -341,6 +342,9 @@ MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 | `/device_authorization` | POST | Device Authorization Grant エンドポイント（RFC 8628）。 |
 | `/token` | POST | authorization code + PKCE・device code・refresh token grant 用トークンエンドポイント。 |
 | `/register` | POST | RFC 7591 形式の動的クライアント登録。 |
+| `/jwks` | GET | JSON Web Key Set（gateway が OIDC Provider として動作する場合）。 |
+| `/userinfo` | GET | OIDC UserInfo エンドポイント。 |
+| `/upstream/callback/{routeName}` | GET | upstream OAuth の authorization code コールバック。`authorization_code` フロー有効ルートに自動登録。`client_credentials` フローでは未使用。 |
 | `/setup` | GET/POST | 初回起動セットアップウィザードエンドポイント（セットアップモード時のみ利用可能）。 |
 | `/health` | GET | 通常モードのヘルスチェック。 |
 | `/<prefix>` | ANY | マッチした upstream へのリバースプロキシ。`auth=none` が設定されていない限り Bearer 検証が行われます。 |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -346,6 +346,43 @@ export MCP_GATEWAY_KEY_PATH=/your/writable/path/gateway.key
 
 - `MCP_GATEWAY_TRUSTED_PROXIES` のすべてのエントリまたは `gateway.trusted_proxies` の各項目が `127.0.0.1/32` や `10.0.0.0/8` などの有効な CIDR 形式であることを確認してください。
 
+### Upstream OAuth トークンが取得できない
+
+症状:
+
+- upstream OAuth ルートへのアクセスで、upstream 認可エンドポイントへのリダイレクトが繰り返される。
+- ログに `upstream OAuth: no token for user, redirecting to authorize` が出続ける。
+
+原因と対処:
+
+1. **`authorization_code` フロー**: ブラウザが `/upstream/callback/{routeName}` に正常に戻れているか確認する。`MCP_GATEWAY_PUBLIC_URL` が OAuth コールバックとして登録された URL と一致していることを確認すること。
+2. **`client_credentials` フロー**: upstream AS が `client_credentials` グラントをサポートしているか確認する。ログの `upstream OAuth: client_credentials token fetch failed` と upstream AS のエラー詳細を確認する。
+3. **DCR 失敗**: `upstream_clients.json` が存在しないまたは空の場合、ゲートウェイが upstream AS への Dynamic Client Registration に失敗している可能性がある。ログの `dynamic client registration for route` エラーを確認する。
+
+### Upstream OAuth トークンリフレッシュが失敗する
+
+症状:
+
+- upstream ルートへのリクエストが断続的に 401 を返す。
+- ログに `upstream OAuth refresh: permanent failure, deleting token` がある。
+
+原因と対処:
+
+1. **恒久失敗（refresh_token 失効）**: upstream AS が refresh_token を失効させた（ユーザーがアクセスを取り消すなど）。該当ユーザーは upstream OAuth を再認可する必要がある（`upstream_tokens.json` から該当エントリを削除し、再アクセスで再フローを開始）。
+2. **一時的失敗**: ログに `upstream OAuth refresh: transient failure, keeping existing token` がある場合、次回リクエストで自動的に再試行される。
+3. **`expires_in` なしレスポンス**: upstream AS がトークンレスポンスに `expires_in` を返さない場合、proactive refresh が動作しない。ログに `upstream OAuth refresh: response missing expires_in` が出る場合は upstream AS の設定を確認する。
+
+### `upstream_clients.json` が壊れた / リセットしたい
+
+対処:
+
+```bash
+# gateway を停止してファイルを削除する（次回起動時に DCR が再実行される）
+rm {state-dir}/upstream_clients.json
+```
+
+DCR は再実行されるが、既存のユーザートークン（`upstream_tokens.json`）は影響を受けない。新しい `client_id` で取得されたトークンは旧 `client_id` と互換性がない場合があるため、必要に応じて `upstream_tokens.json` も削除して全ユーザーに再認可を促す。
+
 ### トークン audience 不一致
 
 症状:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -351,7 +351,7 @@ export MCP_GATEWAY_KEY_PATH=/your/writable/path/gateway.key
 症状:
 
 - upstream OAuth ルートへのアクセスで、upstream 認可エンドポイントへのリダイレクトが繰り返される。
-- ログに `upstream OAuth: no token for user, redirecting to authorize` が出続ける。
+- ログに `upstream OAuth: token not found at proxy injection; request forwarded without Authorization` が出続ける。
 
 原因と対処:
 
@@ -368,16 +368,16 @@ export MCP_GATEWAY_KEY_PATH=/your/writable/path/gateway.key
 
 原因と対処:
 
-1. **恒久失敗（refresh_token 失効）**: upstream AS が refresh_token を失効させた（ユーザーがアクセスを取り消すなど）。該当ユーザーは upstream OAuth を再認可する必要がある（`upstream_tokens.json` から該当エントリを削除し、再アクセスで再フローを開始）。
+1. **恒久失敗（refresh_token 失効）**: upstream AS が refresh_token を失効させた（ユーザーがアクセスを取り消すなど）。この場合、ゲートウェイが自動的に `upstream_tokens.json` から該当エントリを削除する（`permanent failure, deleting token` ログ）。次回 upstream リソースにアクセスすると自動的に再認可フローが開始される。
 2. **一時的失敗**: ログに `upstream OAuth refresh: transient failure, keeping existing token` がある場合、次回リクエストで自動的に再試行される。
-3. **`expires_in` なしレスポンス**: upstream AS がトークンレスポンスに `expires_in` を返さない場合、proactive refresh が動作しない。ログに `upstream OAuth refresh: response missing expires_in` が出る場合は upstream AS の設定を確認する。
+3. **`expires_in` なしレスポンス**: upstream AS がトークンレスポンスに `expires_in` を返さない場合、proactive refresh が動作しない。ログに `upstream OAuth refresh: response missing expires_in, keeping existing token` が出る場合は upstream AS の設定を確認する。
 
 ### `upstream_clients.json` が壊れた / リセットしたい
 
 対処:
 
 ```bash
-# gateway を停止してファイルを削除する（次回起動時に DCR が再実行される）
+# gateway を停止してファイルを削除する（upstream OAuth ルートへの次回アクセス時に DCR が再実行される）
 rm {state-dir}/upstream_clients.json
 ```
 


### PR DESCRIPTION
## Summary

監査で発見したドキュメントの穴をすべて修正し、新メンバー squirrel-notifier を追加。

### 機能ドキュメントの穴（実装済みなのに未記載だったもの）

- **README.md / README.ja.md**: Key Features に upstream OAuth 委任を追加（`authorization_code` / `client_credentials`、proactive refresh、401 retry）
- **README.md / README.ja.md**: エンドポイント表に `/upstream/callback/{routeName}` を追加
- **README.md / README.ja.md**: 重要パス表に `upstream_clients.json` / `upstream_tokens.json` を追加
- **docs/configuration.md**: エンドポイント表に `/upstream/callback/{routeName}` と OIDC 系エンドポイント（`/jwks`、`/userinfo`、`/.well-known/openid-configuration`）を追加
- **docs/operations.md**: upstream OAuth のトラブルシュートセクションを新設（トークン取得失敗・リフレッシュ失敗・upstream_clients.json リセット）

### 不整合の修正

- **README.ja.md**: リポジトリ構成を README.md に合わせて更新（thread-owl / mcp-resource-subscriber / review-raven を追加、旧 copilot-review-mcp を削除）
- **README.ja.md**: ドキュメント一覧に `architecture.md` を追加（英語版には存在していたが日本語版に欠落）

### 新メンバー追加: squirrel-notifier

- **README.md / README.ja.md**: リポジトリ構成表に squirrel-notifier を追加
- **docs/architecture.md**: 5本立て → 6本立てへ更新
  - コンポーネント表に squirrel-notifier (#6) を追加
  - データフロー図を更新（squirrel-notifier → mcp-gateway の流れを追加）
  - 「mcp-gateway が担当しないこと」表にトースト通知・AI エージェント起動を追加
  - squirrel-notifier との関係セクションを新設
  - 設計原則に「各コンポーネントは独立した責務境界を持つ」を追加

## Test plan

- [x] ドキュメントのみの変更（コード変更なし）
- [x] すべての内部リンクが有効なファイルを指していることを確認
- [x] lefthook pre-commit（vet）pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)