### PR TITLE
fix(auth): RFC 8707 URL形式のresourceパラメータをResourceAudienceMapに登録 (#175)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -252,7 +252,7 @@ func main() {
 		CacheTTL:             time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
 		ExpiresIn:            time.Duration(cfg.tokenExpiresInSec) * time.Second,
 		TokenStorePath:       cfg.tokenStorePath,
-		ResourceAudienceMap:  buildResourceAudienceMap(routes),
+		ResourceAudienceMap:  buildResourceAudienceMap(routes, cfg.publicURL),
 		TokenAudienceStrict:  cfg.tokenAudienceStrict,
 		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
 		OIDCPrivateKey:       oidcPrivateKey,
@@ -352,8 +352,8 @@ func main() {
 		if route.NoAuth {
 			wrapped = h
 		} else {
-			// routeResource is the RFC 9728 PRM identifier (URL form) — used
-			// only for discovery metadata, not for JWT aud validation.
+			// routeResource is the RFC 9728 PRM identifier (URL form) used both for
+			// discovery metadata and (via buildResourceAudienceMap) for JWT aud resolution.
 			routeResource := publicURL
 			if route.Prefix != "/" {
 				routeResource = publicURL + route.Prefix
@@ -576,17 +576,29 @@ func splitCSV(value string) []string {
 	return out
 }
 
-// buildResourceAudienceMap builds the map from route name → required_audience
+// buildResourceAudienceMap builds the map from resource identifier → required_audience
 // used by auth.Handler to resolve the resource parameter in /token requests.
+// Each authenticated route is registered under two keys:
+//   - route name (e.g. "cloudflare") for backward compatibility
+//   - full URL form (e.g. "http://127.0.0.1:8080/mcp/cloudflare") matching
+//     the resource value advertised by the per-route PRM endpoint, so that
+//     RFC 8707 compliant clients can pass the PRM resource directly (#175)
+//
 // The "mcp-gateway" default is always reachable via resource=mcp-gateway (or
 // by omitting the resource parameter entirely).
-func buildResourceAudienceMap(routes []router.Route) map[string]string {
-	m := make(map[string]string, len(routes))
+func buildResourceAudienceMap(routes []router.Route, publicURL string) map[string]string {
+	m := make(map[string]string, len(routes)*2)
 	for _, route := range routes {
 		if route.NoAuth {
 			continue
 		}
 		m[route.Name] = route.RequiredAudience
+		// Also register the full URL form advertised by the per-route PRM
+		// (/.well-known/oauth-protected-resource{prefix}) so that RFC 8707
+		// compliant clients can use the PRM resource value as the resource= parameter.
+		if route.Prefix != "/" {
+			m[strings.TrimRight(publicURL, "/")+route.Prefix] = route.RequiredAudience
+		}
 	}
 	return m
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -578,26 +578,37 @@ func splitCSV(value string) []string {
 
 // buildResourceAudienceMap builds the map from resource identifier → required_audience
 // used by auth.Handler to resolve the resource parameter in /token requests.
-// Each authenticated route is registered under two keys:
-//   - route name (e.g. "cloudflare") for backward compatibility
-//   - full URL form (e.g. "http://127.0.0.1:8080/mcp/cloudflare") matching
-//     the resource value advertised by the per-route PRM endpoint, so that
-//     RFC 8707 compliant clients can pass the PRM resource directly (#175)
 //
-// The "mcp-gateway" default is always reachable via resource=mcp-gateway (or
-// by omitting the resource parameter entirely).
+// Three families of keys are registered:
+//   - publicURL (base, no path) → "mcp-gateway" always; overridden by a "/" prefix
+//     route's RequiredAudience when one is present. Covers the gateway-wide PRM
+//     (/.well-known/oauth-protected-resource, no path suffix) that RFC 8707 clients
+//     use to discover resource=<publicURL>.
+//   - route name (e.g. "cloudflare") → route.RequiredAudience, for backward
+//     compatibility with clients that send the short name as the resource.
+//   - publicURL+prefix (e.g. "http://127.0.0.1:8080/mcp/cloudflare") →
+//     route.RequiredAudience, for RFC 8707 clients that use the per-route PRM
+//     resource value directly (#175).
 func buildResourceAudienceMap(routes []router.Route, publicURL string) map[string]string {
-	m := make(map[string]string, len(routes)*2)
+	base := strings.TrimRight(publicURL, "/")
+	m := make(map[string]string, len(routes)*2+1)
+	// Pre-register the gateway-wide resource so resource=<publicURL> always resolves,
+	// even when no "/" prefix route is explicitly configured.
+	m[base] = "mcp-gateway"
 	for _, route := range routes {
 		if route.NoAuth {
 			continue
 		}
 		m[route.Name] = route.RequiredAudience
-		// Also register the full URL form advertised by the per-route PRM
-		// (/.well-known/oauth-protected-resource{prefix}) so that RFC 8707
-		// compliant clients can use the PRM resource value as the resource= parameter.
-		if route.Prefix != "/" {
-			m[strings.TrimRight(publicURL, "/")+route.Prefix] = route.RequiredAudience
+		if route.Prefix == "/" {
+			// "/" prefix: PRM resource is publicURL; override the default entry
+			// with the route's actual required audience.
+			m[base] = route.RequiredAudience
+		} else {
+			// Non-root prefix: also register the full URL form (publicURL+prefix)
+			// as advertised by the per-route PRM, so RFC 8707 clients can pass
+			// the PRM resource value directly as resource= (#175).
+			m[base+route.Prefix] = route.RequiredAudience
 		}
 	}
 	return m

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/scottlz0310/mcp-gateway/internal/router"
+)
+
+func mustURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestBuildResourceAudienceMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		publicURL string
+		routes    []router.Route
+		want      map[string]string
+	}{
+		{
+			name:      "no routes: only gateway-wide baseline registered",
+			publicURL: "http://127.0.0.1:8080",
+			routes:    nil,
+			want: map[string]string{
+				"http://127.0.0.1:8080": "mcp-gateway",
+			},
+		},
+		{
+			name:      "non-root prefix: name form and URL form both registered",
+			publicURL: "http://127.0.0.1:8080",
+			routes: []router.Route{
+				{Name: "cloudflare", Prefix: "/mcp/cloudflare", Upstream: mustURL("https://mcp.cloudflare.com/mcp"), RequiredAudience: "mcp-gateway"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080":                  "mcp-gateway",
+				"cloudflare":                             "mcp-gateway",
+				"http://127.0.0.1:8080/mcp/cloudflare": "mcp-gateway",
+			},
+		},
+		{
+			name:      "URL form resolves RFC 8707 resource from per-route PRM",
+			publicURL: "http://127.0.0.1:8080",
+			routes: []router.Route{
+				{Name: "svc", Prefix: "/mcp/svc", Upstream: mustURL("http://svc:9000"), RequiredAudience: "custom-aud"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080":          "mcp-gateway",
+				"svc":                            "custom-aud",
+				"http://127.0.0.1:8080/mcp/svc": "custom-aud",
+			},
+		},
+		{
+			name:      "root prefix overrides gateway-wide baseline with route audience",
+			publicURL: "http://127.0.0.1:8080",
+			routes: []router.Route{
+				{Name: "default", Prefix: "/", Upstream: mustURL("http://upstream:8000"), RequiredAudience: "custom-aud"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080": "custom-aud",
+				"default":               "custom-aud",
+			},
+		},
+		{
+			name:      "NoAuth routes are excluded from the map",
+			publicURL: "http://127.0.0.1:8080",
+			routes: []router.Route{
+				{Name: "public", Prefix: "/public", Upstream: mustURL("http://public:8000"), NoAuth: true, RequiredAudience: "mcp-gateway"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080": "mcp-gateway",
+			},
+		},
+		{
+			name:      "publicURL trailing slash is normalised",
+			publicURL: "http://127.0.0.1:8080/",
+			routes: []router.Route{
+				{Name: "svc", Prefix: "/mcp/svc", Upstream: mustURL("http://svc:8000"), RequiredAudience: "mcp-gateway"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080":          "mcp-gateway",
+				"svc":                            "mcp-gateway",
+				"http://127.0.0.1:8080/mcp/svc": "mcp-gateway",
+			},
+		},
+		{
+			name:      "mixed auth and no-auth routes: only auth routes registered",
+			publicURL: "http://127.0.0.1:8080",
+			routes: []router.Route{
+				{Name: "secure", Prefix: "/mcp/secure", Upstream: mustURL("http://secure:8000"), RequiredAudience: "mcp-gateway"},
+				{Name: "open", Prefix: "/mcp/open", Upstream: mustURL("http://open:8000"), NoAuth: true, RequiredAudience: "mcp-gateway"},
+			},
+			want: map[string]string{
+				"http://127.0.0.1:8080":             "mcp-gateway",
+				"secure":                            "mcp-gateway",
+				"http://127.0.0.1:8080/mcp/secure": "mcp-gateway",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildResourceAudienceMap(tc.routes, tc.publicURL)
+			if len(got) != len(tc.want) {
+				t.Errorf("map size: got %d, want %d\ngot:  %v\nwant: %v", len(got), len(tc.want), got, tc.want)
+				return
+			}
+			for k, wantV := range tc.want {
+				gotV, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q; full map: %v", k, got)
+					continue
+				}
+				if gotV != wantV {
+					t.Errorf("key %q: got %q, want %q", k, gotV, wantV)
+				}
+			}
+			for k := range got {
+				if _, ok := tc.want[k]; !ok {
+					t.Errorf("unexpected key %q in result", k)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 問題

PRM エンドポイント (`/.well-known/oauth-protected-resource{prefix}`) は RFC 9728 に従い、`resource` として完全 URL（例: `http://127.0.0.1:8080/mcp/cloudflare`）を広告する。

一方 `buildResourceAudienceMap` はルート名（例: `"cloudflare"`）のみをキーとして登録していたため、RFC 8707 準拠クライアント（`antigravity` など）が PRM の `resource` 値をそのまま `/authorize?resource=http://...` に渡すと `resolveRequestedAudience` が `invalid_target` エラーを返していた。

```
{"error":"invalid_target","error_description":"resource \"http://127.0.0.1:8080/mcp/cloudflare\" is not registered with this gateway"}
```

## 修正内容

`buildResourceAudienceMap` に `publicURL string` パラメータを追加し、各認証ルートを **ルート名** と **フル URL** の両キーで登録するよう変更。

- ルート名キー（例: `"cloudflare"`）は後方互換として維持
- フル URL キー（例: `"http://127.0.0.1:8080/mcp/cloudflare"`）を追加することで RFC 8707 クライアントの `resource=` パラメータを正しく解決

ルートプレフィックスが `/` のケースはゲートウェイ全体 PRM（`resource == publicURL`）でカバーされるため、重複登録をスキップ。

## テスト方法

1. `upstream_oauth=auto` ルートを持つ gateway を起動
2. RFC 8707 対応 MCP クライアント（`antigravity`）でルートに初回アクセス
3. `/authorize?resource=http://127.0.0.1:8080/mcp/cloudflare` へのリダイレクトが `invalid_target` なく通過することを確認

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)