### PR TITLE
fix(auth): upstream OAuth 未認可時の 302 を 200 JSON-RPC error に変更し再認証ループを防ぐ

### DIFF
--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -151,9 +151,30 @@ func NewAuthorizeMiddleware(
 			q.Set("state", stateKey)
 			authURL.RawQuery = q.Encode()
 
-			http.Redirect(w, r, authURL.String(), http.StatusFound)
+			// Return 200 + JSON-RPC error instead of 302 so MCP clients don't
+			// treat the response as a connection failure and restart the auth flow,
+			// which would overwrite the pending state and cause an infinite loop.
+			writeUpstreamAuthRequired(w, routeName, authURL.String())
 		})
 	}
+}
+
+func writeUpstreamAuthRequired(w http.ResponseWriter, routeName, authorizationURL string) {
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      nil,
+		"error": map[string]any{
+			"code":    -32001,
+			"message": fmt.Sprintf("%s authorization required. Open the URL in 'data.authorization_url' in your browser, then retry.", routeName),
+			"data": map[string]any{
+				"type":              "upstream_authorization_required",
+				"authorization_url": authorizationURL,
+			},
+		},
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
 }
 
 // fetchClientCredentialsToken obtains an access token from rec.TokenEndpoint

--- a/internal/upstreamoauth/flow.go
+++ b/internal/upstreamoauth/flow.go
@@ -160,7 +160,7 @@ func NewAuthorizeMiddleware(
 }
 
 func writeUpstreamAuthRequired(w http.ResponseWriter, routeName, authorizationURL string) {
-	body, _ := json.Marshal(map[string]any{
+	body, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
 		"id":      nil,
 		"error": map[string]any{
@@ -172,6 +172,13 @@ func writeUpstreamAuthRequired(w http.ResponseWriter, routeName, authorizationUR
 			},
 		},
 	})
+	if err != nil {
+		slog.Error("upstream OAuth: failed to marshal upstream_auth_required response", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -96,7 +96,7 @@ func TestAuthorizeMiddleware_RedirectWithPKCE(t *testing.T) {
 		routeName, "https://as.example.com", "read write", "authorization_code", "", mgr, stateStore, tokenStore, publicURL,
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("next handler must not be called when redirect is expected")
+		t.Error("next handler must not be called when upstream auth is required")
 	}))
 
 	req := httptest.NewRequest("GET", "/mcp/myroute/sse", nil)
@@ -104,17 +104,43 @@ func TestAuthorizeMiddleware_RedirectWithPKCE(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusFound {
-		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusFound, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
 	}
 
-	loc := rr.Header().Get("Location")
-	if loc == "" {
-		t.Fatal("expected Location header in redirect response")
+	var resp struct {
+		JSONRPC string `json:"jsonrpc"`
+		Error   struct {
+			Code int    `json:"code"`
+			Data struct {
+				Type             string `json:"type"`
+				AuthorizationURL string `json:"authorization_url"`
+			} `json:"data"`
+		} `json:"error"`
 	}
-	u, err := url.Parse(loc)
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode JSON-RPC response: %v", err)
+	}
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc = %q, want %q", resp.JSONRPC, "2.0")
+	}
+	if resp.Error.Code != -32001 {
+		t.Errorf("error.code = %d, want %d", resp.Error.Code, -32001)
+	}
+	if resp.Error.Data.Type != "upstream_authorization_required" {
+		t.Errorf("error.data.type = %q, want %q", resp.Error.Data.Type, "upstream_authorization_required")
+	}
+
+	authURLStr := resp.Error.Data.AuthorizationURL
+	if authURLStr == "" {
+		t.Fatal("error.data.authorization_url must not be empty")
+	}
+	u, err := url.Parse(authURLStr)
 	if err != nil {
-		t.Fatalf("invalid Location URL: %v", err)
+		t.Fatalf("invalid authorization_url: %v", err)
 	}
 	q := u.Query()
 
@@ -179,11 +205,20 @@ func TestAuthorizeMiddleware_ScopeOmitted(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusFound {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusFound)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
-	loc := rr.Header().Get("Location")
-	u, _ := url.Parse(loc)
+	var resp struct {
+		Error struct {
+			Data struct {
+				AuthorizationURL string `json:"authorization_url"`
+			} `json:"data"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode JSON-RPC response: %v", err)
+	}
+	u, _ := url.Parse(resp.Error.Data.AuthorizationURL)
 	if u.Query().Get("scope") != "" {
 		t.Errorf("scope must be omitted when upstreamOAuthScope is empty, got %q", u.Query().Get("scope"))
 	}
@@ -447,7 +482,7 @@ func TestAuthorizeMiddleware_GrantMismatch_StaleTokenDeleted(t *testing.T) {
 }
 
 func TestAuthorizeMiddleware_DefaultGrant_IsAuthCode(t *testing.T) {
-	// grant="" should default to authorization_code (redirect, not client_credentials fetch).
+	// grant="" should default to authorization_code (JSON-RPC error, not client_credentials fetch).
 	const routeName = "default-grant"
 	cs := &testClientStore{records: map[string]upstreamoauth.ClientRecord{
 		routeName: {
@@ -462,7 +497,7 @@ func TestAuthorizeMiddleware_DefaultGrant_IsAuthCode(t *testing.T) {
 		upstreamoauth.NewStateStore(), auth.NewMemUpstreamTokenStore(), "http://localhost:8080",
 	)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("next handler must not be called: should redirect")
+		t.Error("next handler must not be called: should return JSON-RPC error")
 	}))
 
 	req := httptest.NewRequest("GET", "/mcp/default-grant/sse", nil)
@@ -470,7 +505,10 @@ func TestAuthorizeMiddleware_DefaultGrant_IsAuthCode(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusFound {
-		t.Errorf("status = %d, want %d (empty grant should default to authorization_code)", rr.Code, http.StatusFound)
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (empty grant should default to authorization_code)", rr.Code, http.StatusOK)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
 	}
 }

--- a/internal/upstreamoauth/flow_test.go
+++ b/internal/upstreamoauth/flow_test.go
@@ -218,7 +218,13 @@ func TestAuthorizeMiddleware_ScopeOmitted(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode JSON-RPC response: %v", err)
 	}
-	u, _ := url.Parse(resp.Error.Data.AuthorizationURL)
+	if resp.Error.Data.AuthorizationURL == "" {
+		t.Fatal("error.data.authorization_url must not be empty")
+	}
+	u, err := url.Parse(resp.Error.Data.AuthorizationURL)
+	if err != nil {
+		t.Fatalf("invalid authorization_url: %v", err)
+	}
 	if u.Query().Get("scope") != "" {
 		t.Errorf("scope must be omitted when upstreamOAuthScope is empty, got %q", u.Query().Get("scope"))
 	}


### PR DESCRIPTION
## Summary

- `NewAuthorizeMiddleware` の `authorization_code` フローで upstream トークン未取得時、`302 リダイレクト` の代わりに `200 OK + JSON-RPC error` (-32001) を返すよう変更
- `error.data.authorization_url` に upstream 認可 URL を含めることで、ユーザーがブラウザで直接開いて認可を完了できる
- MCP クライアント (agy 等) が 302 を接続失敗とみなしてセッション削除 → 再認証を繰り返す無限ループを解消

## レスポンス形式

```json
{
  "jsonrpc": "2.0",
  "id": null,
  "error": {
    "code": -32001,
    "message": "cloudflare authorization required. Open the URL in 'data.authorization_url' in your browser, then retry.",
    "data": {
      "type": "upstream_authorization_required",
      "authorization_url": "https://mcp.cloudflare.com/authorize?client_id=...&..."
    }
  }
}
```

## Test plan

- [ ] `TestAuthorizeMiddleware_RedirectWithPKCE`: 200 + JSON-RPC error を検証、authorization_url の PKCE パラメータを確認
- [ ] `TestAuthorizeMiddleware_ScopeOmitted`: scope 省略時も 200 + JSON-RPC error
- [ ] `TestAuthorizeMiddleware_DefaultGrant_IsAuthCode`: grant="" のデフォルト動作が JSON-RPC error
- [ ] 全テスト pass 確認 (`go test ./...`)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)