### PR TITLE
feat(proxy): upstream_provider_token でプロバイダートークン委任を実装 (#186)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -393,6 +393,17 @@ func main() {
 					publicURL,
 				)(h)
 			}
+			// For routes with upstream_provider_token=true, resolve the subject's
+			// gateway provider access token and inject it as the upstream Bearer token.
+			// Placed between auth middleware and the proxy so that the subject identity
+			// is available in context before the provider token lookup runs.
+			if route.UpstreamProviderToken {
+				providerTokenResourceMetadataURL := ""
+				if route.Prefix != "/" {
+					providerTokenResourceMetadataURL = publicURL + "/.well-known/oauth-protected-resource" + route.Prefix
+				}
+				proxyHandler = proxy.NewProviderTokenMiddleware(oauthHandler, providerTokenResourceMetadataURL, proxyHandler)
+			}
 			wrapped = routeAuth(proxyHandler)
 		}
 		mux.Handle(route.Prefix, wrapped)
@@ -404,6 +415,7 @@ func main() {
 			"auth_required", !route.NoAuth,
 			"upstream_bearer_token_env", route.UpstreamBearerTokenEnv != "",
 			"upstream_oauth", route.UpstreamOAuth != "",
+			"upstream_provider_token", route.UpstreamProviderToken,
 		)
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -398,9 +398,12 @@ func main() {
 			// Placed between auth middleware and the proxy so that the subject identity
 			// is available in context before the provider token lookup runs.
 			if route.UpstreamProviderToken {
-				providerTokenResourceMetadataURL := ""
+				// Always include the resource_metadata URL so MCP clients can discover
+				// the gateway OAuth flow on 401. For "/" prefix routes, use the
+				// gateway-wide PRM URL; for sub-path routes, use the per-route PRM URL.
+				providerTokenResourceMetadataURL := publicURL + "/.well-known/oauth-protected-resource"
 				if route.Prefix != "/" {
-					providerTokenResourceMetadataURL = publicURL + "/.well-known/oauth-protected-resource" + route.Prefix
+					providerTokenResourceMetadataURL += route.Prefix
 				}
 				proxyHandler = proxy.NewProviderTokenMiddleware(oauthHandler, providerTokenResourceMetadataURL, proxyHandler)
 			}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,7 @@ setup:
 | `routes[].upstream_oauth` | Upstream OAuth 委任。`auto`（RFC 9728 + RFC 8414 で AS を自動検出）または絶対 issuer URL（`https://...`）。`upstream_bearer_token_env` および `no_auth` と排他。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
 | `routes[].upstream_oauth_scope` | Upstream AS へのトークンリクエストで要求するスコープ（スペース区切り。カンマ区切りは自動正規化）。`upstream_oauth` が必要。 |
 | `routes[].upstream_oauth_grant` | Upstream トークン取得に使用する OAuth 2.0 グラントタイプ（`authorization_code` または `client_credentials`、デフォルト: `authorization_code`）。`upstream_oauth` が必要。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
+| `routes[].upstream_provider_token` | `true` の場合、ゲートウェイの provider アクセストークン（builtin モードでは GitHub ユーザートークン）を upstream Bearer トークンとして注入する。ゲートウェイ認証が必要（`no_auth` と排他）。`upstream_bearer_token_env` および `upstream_oauth` と排他。[プロバイダートークン委任](#プロバイダートークン委任) を参照。 |
 | `setup.completed` | ゲートウェイが書き込むセットアップウィザード状態。オペレーターが直接編集することは通常ありません。 |
 
 ゲートウェイがシークレット移行またはセットアップ完了時に `config.yaml` を書き直す際、未知の YAML フィールドとコメントは保持されません。
@@ -200,6 +201,7 @@ ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:8083
 | `upstream_oauth` | なし | Upstream OAuth 委任を有効化。`auto`（RFC 9728 + RFC 8414 で AS を自動検出）または絶対 issuer URL（`https://...`）。`upstream_bearer_token_env` と排他。[Upstream OAuth 委任](#upstream-oauth-委任) を参照。 |
 | `upstream_oauth_scope` | なし | Upstream AS へのトークンリクエストで要求するスコープ（スペース区切り。カンマ区切りは自動正規化）。`upstream_oauth` が必要。 |
 | `upstream_oauth_grant` | `authorization_code` | Upstream トークン取得に使用する OAuth 2.0 グラントタイプ。`authorization_code`（ユーザーを認可エンドポイントへリダイレクト）または `client_credentials`（バックグラウンドでトークンを取得、ユーザー操作不要）。`upstream_oauth` が必要。 |
+| `upstream_provider_token` | `false` | `true` の場合、ゲートウェイの provider アクセストークン（builtin モードでは GitHub ユーザートークン）を upstream Bearer トークンとして注入する。ゲートウェイ認証必須（`auth=none` と排他）。`upstream_bearer_token_env` および `upstream_oauth` と排他。[プロバイダートークン委任](#プロバイダートークン委任) を参照。 |
 
 ### Upstream OAuth 委任
 
@@ -251,6 +253,39 @@ routes:
 ```
 
 > **Note**: コールバックエンドポイント `GET /upstream/callback/{routeName}` は `authorization_code` フローの redirect_uri として自動登録されます。`client_credentials` フローでは使用されません。
+
+### プロバイダートークン委任
+
+`upstream_provider_token=true` を設定したルートでは、ゲートウェイが以下を自動実行します。
+
+1. **トークン解決**: `EnsureFreshAccessTokenForSubject` を使って認証済み subject の provider アクセストークンを取得（`builtin` モードでは GitHub ユーザートークン）。
+2. **注入**: 解決したトークンを upstream への `Authorization: Bearer` ヘッダーとして設定。gateway-signed JWT は upstream に転送されない。
+3. **フェールクローズ**: subject が未キャッシュ・トークン失効・rotation 失敗のいずれかで解決不可の場合は 401 を返し、`WWW-Authenticate` ヘッダーで再認証を案内する。
+
+**セキュリティ境界**:
+- opt-in したルート（`upstream_provider_token=true`）のみに provider トークンが転送される。
+- opt-in していないルート（thread-owl、playwright 等）には provider トークンが漏洩しない。
+- `upstream_oauth`（upstream MCP サーバー固有の OAuth フロー）とは独立した概念である。
+
+**設定例**（環境変数）:
+
+```bash
+ROUTE_REVIEW_RAVEN=/mcp/review-raven|http://review-raven:8083|upstream_provider_token=true
+```
+
+**設定例**（config.yaml）:
+
+```yaml
+routes:
+  - name: review-raven
+    prefix: /mcp/review-raven
+    upstream: http://review-raven:8083
+    upstream_provider_token: true
+```
+
+> **Note**: `upstream_provider_token=true` は `OAUTH_PROVIDER=builtin` の場合に最も効果を発揮します。
+> `github` provider モードでは context トークン自体が GitHub トークンですが、
+> `upstream_provider_token` を使うことで明示的なトークン解決・rotation・フェールクローズが有効になります。
 
 ## シークレット暗号化
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,12 @@ type RouteConfig struct {
 	// "client_credentials" (service-to-service, no user interaction required).
 	// Use *string for the same presence-vs-empty reason as UpstreamOAuth.
 	UpstreamOAuthGrant *string `yaml:"upstream_oauth_grant,omitempty" json:"upstream_oauth_grant,omitempty"`
+	// UpstreamProviderToken enables provider access token delegation for this route.
+	// When true, the proxy resolves the authenticated subject's gateway provider token
+	// (e.g. the GitHub user token in builtin mode) via EnsureFreshAccessTokenForSubject
+	// and injects it as the upstream Authorization Bearer header instead of the gateway JWT.
+	// Requires gateway authentication. Incompatible with upstream_bearer_token_env and upstream_oauth.
+	UpstreamProviderToken bool `yaml:"upstream_provider_token,omitempty" json:"upstream_provider_token,omitempty"`
 }
 
 // SetupConfig holds first-run wizard state.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -20,6 +22,16 @@ type TokenInvalidator interface {
 	InvalidateCachedToken(token string)
 }
 
+// ProviderTokenSource resolves the current provider access token for an authenticated subject.
+// Implemented by auth.Handler via EnsureFreshAccessTokenForSubject.
+type ProviderTokenSource interface {
+	EnsureFreshAccessTokenForSubject(ctx context.Context, subject string) (auth.DelegatedAccessResult, error)
+}
+
+// providerTokenContextKey is the context key used to pass a resolved provider access token
+// from NewProviderTokenMiddleware into the proxy Rewrite function and ModifyResponse handler.
+type providerTokenContextKey struct{}
+
 // UpstreamTokenRefresher handles proactive and 401-triggered upstream OAuth
 // token refresh. Implemented by upstreamoauth.Refresher.
 type UpstreamTokenRefresher interface {
@@ -36,6 +48,61 @@ type UpstreamOAuthOptions struct {
 	TokenStore auth.UpstreamTokenStore
 	RouteName  string
 	Refresher  UpstreamTokenRefresher // nil = no proactive/auto refresh
+}
+
+// NewProviderTokenMiddleware returns a handler that resolves the authenticated subject's
+// provider access token (e.g. the GitHub user token in builtin mode) via src, stores it in
+// the request context, and delegates to next. If resolution fails for any reason the request
+// is rejected with a 401 that includes a WWW-Authenticate header pointing to resourceMetadataURL
+// (when non-empty) so that MCP clients can re-authenticate. next is never called on failure.
+//
+// This middleware must be placed after the gateway Auth middleware (which sets the identity in
+// context) and before the proxy handler (which reads the token from context).
+func NewProviderTokenMiddleware(src ProviderTokenSource, resourceMetadataURL string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		subject := middleware.IdentityFromContext(r.Context())
+		if subject == "" {
+			writeProviderTokenUnauthorized(w, "authenticated subject not found in request context", resourceMetadataURL)
+			return
+		}
+		result, err := src.EnsureFreshAccessTokenForSubject(r.Context(), subject)
+		if err != nil {
+			var logMsg string
+			switch {
+			case errors.Is(err, auth.ErrSubjectNotFound):
+				logMsg = "provider token: subject not found; re-authentication required"
+			case errors.Is(err, auth.ErrRotationFailed):
+				logMsg = "provider token: token rotation failed; re-authentication required"
+			default:
+				logMsg = "provider token: resolution failed; re-authentication required"
+			}
+			slog.Warn(logMsg, "path", r.URL.Path)
+			writeProviderTokenUnauthorized(w, "provider access token unavailable; re-authenticate via the gateway OAuth flow", resourceMetadataURL)
+			return
+		}
+		ctx := context.WithValue(r.Context(), providerTokenContextKey{}, result.AccessToken)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// writeProviderTokenUnauthorized writes a 401 response with WWW-Authenticate (RFC 6750 §3.1).
+func writeProviderTokenUnauthorized(w http.ResponseWriter, errDesc, resourceMetadataURL string) {
+	parts := []string{
+		`Bearer realm="mcp-gateway"`,
+		fmt.Sprintf(`error=%q, error_description=%q`, "invalid_token", errDesc),
+	}
+	if resourceMetadataURL != "" {
+		parts = append(parts, fmt.Sprintf(`resource_metadata=%q`, resourceMetadataURL))
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", strings.Join(parts, ", "))
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             "invalid_token",
+		"error_description": errDesc,
+	})
 }
 
 // NewHandler returns an HTTP handler that reverse-proxies authenticated
@@ -134,6 +201,11 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 						"path", pr.Out.URL.Path,
 					)
 				}
+			} else if pt, ok := pr.In.Context().Value(providerTokenContextKey{}).(string); ok && pt != "" {
+				// Provider token delegation: NewProviderTokenMiddleware resolved the subject's
+				// provider access token and stored it in context. Inject it as the upstream Bearer.
+				// This path is only reached when upstream_provider_token=true on the route.
+				pr.Out.Header.Set("Authorization", "Bearer "+pt)
 			} else if token := middleware.TokenFromContext(pr.In.Context()); token != "" {
 				pr.Out.Header.Set("Authorization", "Bearer "+token)
 			}
@@ -195,6 +267,15 @@ func NewHandler(upstream *url.URL, inv TokenInvalidator, upstreamBearerTokenEnv 
 					slog.Warn("upstream rejected upstream credential; check env var token",
 						"path", resp.Request.URL.Path,
 						"env_var", upstreamBearerTokenEnv,
+					)
+				} else if _, usedProviderToken := resp.Request.Context().Value(providerTokenContextKey{}).(string); usedProviderToken {
+					// The 401 came from a provider-token-delegated route.
+					// The provider token may have expired between middleware resolution and
+					// the upstream call. Do NOT invalidate the gateway JWT cache — it is
+					// independent of the provider token lifecycle. The client can retry;
+					// the middleware will attempt a fresh EnsureFreshAccessTokenForSubject.
+					slog.Warn("upstream rejected provider token; provider access token may be stale",
+						"path", resp.Request.URL.Path,
 					)
 				} else if inv != nil {
 					if token := extractBearer(resp.Request); token != "" {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -62,6 +62,12 @@ func NewProviderTokenMiddleware(src ProviderTokenSource, resourceMetadataURL str
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		subject := middleware.IdentityFromContext(r.Context())
 		if subject == "" {
+			// This should not happen when the middleware chain is correctly ordered.
+			// An empty subject indicates a misconfigured handler chain (e.g. provider
+			// token middleware placed before gateway Auth middleware).
+			slog.Error("provider token: authenticated subject missing from context; check middleware ordering",
+				"path", r.URL.Path,
+			)
 			writeProviderTokenUnauthorized(w, "authenticated subject not found in request context", resourceMetadataURL)
 			return
 		}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -678,3 +678,143 @@ func TestProxyUpstreamOAuthDeleteErrorOn401(t *testing.T) {
 		t.Error("token should remain when Delete fails")
 	}
 }
+
+// --- NewProviderTokenMiddleware tests ---
+
+type mockProviderTokenSource struct {
+	token string
+	err   error
+}
+
+func (m *mockProviderTokenSource) EnsureFreshAccessTokenForSubject(_ context.Context, _ string) (auth.DelegatedAccessResult, error) {
+	if m.err != nil {
+		return auth.DelegatedAccessResult{}, m.err
+	}
+	return auth.DelegatedAccessResult{AccessToken: m.token}, nil
+}
+
+func TestProviderTokenMiddlewareInjectsToken(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	src := &mockProviderTokenSource{token: "github-provider-token"}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "gateway-jwt"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// Provider token must win over gateway JWT.
+	if gotAuth != "Bearer github-provider-token" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer github-provider-token")
+	}
+}
+
+func TestProviderTokenMiddlewareFailsCloseOnSubjectNotFound(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusOK)
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	src := &mockProviderTokenSource{err: auth.ErrSubjectNotFound}
+	h := NewProviderTokenMiddleware(src, "https://gw/.well-known/oauth-protected-resource/mcp/rr", proxyH)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "gateway-jwt"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("WWW-Authenticate"), "invalid_token") {
+		t.Errorf("WWW-Authenticate should contain invalid_token: %q", w.Header().Get("WWW-Authenticate"))
+	}
+	if !strings.Contains(w.Header().Get("WWW-Authenticate"), "resource_metadata") {
+		t.Errorf("WWW-Authenticate should contain resource_metadata: %q", w.Header().Get("WWW-Authenticate"))
+	}
+}
+
+func TestProviderTokenMiddlewareFailsCloseOnRotationFailed(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusOK)
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	src := &mockProviderTokenSource{err: auth.ErrRotationFailed}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "gateway-jwt"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestProviderTokenMiddlewareFailsCloseOnEmptySubject(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusOK)
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	src := &mockProviderTokenSource{token: "tok"}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	// Request without identity in context.
+	r := httptest.NewRequest(http.MethodGet, "/mcp/test", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestProxyDoesNotInvalidateGatewayJWTOnProviderToken401(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusUnauthorized)
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	inv := &mockInvalidator{}
+	proxyH := NewHandler(u, inv, "", "", nil)
+	src := &mockProviderTokenSource{token: "github-provider-token"}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "gateway-jwt"))
+
+	// Upstream returned 401 while using provider token.
+	// The gateway JWT cache must NOT be invalidated.
+	if len(inv.tokens) != 0 {
+		t.Errorf("gateway JWT must not be invalidated when provider token is used; invalidated: %v", inv.tokens)
+	}
+}
+
+func TestProxyProviderTokenTakesPriorityOverGatewayJWT(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	src := &mockProviderTokenSource{token: "provider-tok"}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	w := httptest.NewRecorder()
+	// The gateway JWT in context must be replaced by the provider token.
+	h.ServeHTTP(w, requestWithContext("bob", "should-not-be-forwarded"))
+
+	if gotAuth != "Bearer provider-tok" {
+		t.Errorf("Authorization: got %q, want %q", gotAuth, "Bearer provider-tok")
+	}
+}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -758,6 +758,24 @@ func TestProviderTokenMiddlewareFailsCloseOnRotationFailed(t *testing.T) {
 	}
 }
 
+func TestProviderTokenMiddlewareFailsCloseOnGenericError(t *testing.T) {
+	upstream := upstreamWithStatus(http.StatusOK)
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	proxyH := NewHandler(u, &mockInvalidator{}, "", "", nil)
+	// Non-sentinel error exercises the default branch in the switch.
+	src := &mockProviderTokenSource{err: fmt.Errorf("unexpected provider store error")}
+	h := NewProviderTokenMiddleware(src, "", proxyH)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, requestWithContext("alice", "gateway-jwt"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
 func TestProviderTokenMiddlewareFailsCloseOnEmptySubject(t *testing.T) {
 	upstream := upstreamWithStatus(http.StatusOK)
 	defer upstream.Close()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,6 +46,11 @@ type Route struct {
 	// "authorization_code" (interactive, default) or "client_credentials" (non-interactive).
 	// Only meaningful when UpstreamOAuth is non-empty.
 	UpstreamOAuthGrant string
+	// UpstreamProviderToken enables provider access token delegation. When true, the proxy
+	// resolves the subject's gateway provider token (e.g. the GitHub user token in builtin
+	// mode) via EnsureFreshAccessTokenForSubject and injects it as the upstream Bearer token.
+	// Requires gateway authentication. Incompatible with UpstreamBearerTokenEnv and UpstreamOAuth.
+	UpstreamProviderToken bool
 }
 
 // ParseEnv reads ROUTE_<NAME>=<prefix>|<upstream_url>[|opt=val...] environment
@@ -210,6 +215,30 @@ func parseRoutes(env []string) ([]Route, error) {
 			upstreamOAuthGrant = "authorization_code"
 		}
 
+		// upstream_provider_token: inject the subject's gateway provider access token as upstream Bearer.
+		// Requires gateway authentication; incompatible with upstream_bearer_token_env and upstream_oauth.
+		var upstreamProviderToken bool
+		if ptVal, ok := options["upstream_provider_token"]; ok {
+			switch strings.TrimSpace(ptVal) {
+			case "true":
+				upstreamProviderToken = true
+			case "false":
+				// explicit false is valid; feature stays disabled
+			default:
+				return nil, fmt.Errorf("%s: upstream_provider_token must be \"true\" or \"false\" (got %q)", key, ptVal)
+			}
+			delete(options, "upstream_provider_token")
+		}
+		if upstreamProviderToken && noAuth {
+			return nil, fmt.Errorf("%s: upstream_provider_token is incompatible with auth=none; provider token injection requires gateway authentication", key)
+		}
+		if upstreamProviderToken && upstreamBearerTokenEnv != "" {
+			return nil, fmt.Errorf("%s: upstream_provider_token and upstream_bearer_token_env are mutually exclusive", key)
+		}
+		if upstreamProviderToken && upstreamOAuth != "" {
+			return nil, fmt.Errorf("%s: upstream_provider_token and upstream_oauth are mutually exclusive", key)
+		}
+
 		// Reject any unrecognised option keys.
 		if len(options) > 0 {
 			unknown := make([]string, 0, len(options))
@@ -257,6 +286,7 @@ func parseRoutes(env []string) ([]Route, error) {
 			UpstreamOAuth:          upstreamOAuth,
 			UpstreamOAuthScope:     upstreamOAuthScope,
 			UpstreamOAuthGrant:     upstreamOAuthGrant,
+			UpstreamProviderToken:  upstreamProviderToken,
 		})
 	}
 	// Longest prefix first for correct matching order.
@@ -385,6 +415,18 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 		if upstreamOAuth != "" && upstreamOAuthGrant == "" {
 			upstreamOAuthGrant = "authorization_code"
 		}
+		// upstream_provider_token: inject the subject's gateway provider access token as upstream Bearer.
+		// Requires gateway authentication; incompatible with upstream_bearer_token_env and upstream_oauth.
+		upstreamProviderToken := r.UpstreamProviderToken
+		if upstreamProviderToken && r.NoAuth {
+			return nil, fmt.Errorf("route %q: upstream_provider_token is incompatible with no_auth; provider token injection requires gateway authentication", name)
+		}
+		if upstreamProviderToken && upstreamBearerTokenEnv != "" {
+			return nil, fmt.Errorf("route %q: upstream_provider_token and upstream_bearer_token_env are mutually exclusive", name)
+		}
+		if upstreamProviderToken && upstreamOAuth != "" {
+			return nil, fmt.Errorf("route %q: upstream_provider_token and upstream_oauth are mutually exclusive", name)
+		}
 		seen[prefix] = struct{}{}
 		routes = append(routes, Route{
 			Name:                   name,
@@ -396,6 +438,7 @@ func ParseFromConfig(cfgRoutes []appconfig.RouteConfig) ([]Route, error) {
 			UpstreamOAuth:          upstreamOAuth,
 			UpstreamOAuthScope:     upstreamOAuthScope,
 			UpstreamOAuthGrant:     upstreamOAuthGrant,
+			UpstreamProviderToken:  upstreamProviderToken,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -950,3 +950,151 @@ func TestParseFromConfig_UpstreamOAuthGrantNilTreatedAsAbsent(t *testing.T) {
 		t.Errorf("UpstreamOAuthGrant for nil input: got %q, want %q", routes[0].UpstreamOAuthGrant, "authorization_code")
 	}
 }
+
+// --- upstream_provider_token tests ---
+
+func TestParseRoutesUpstreamProviderTokenTrue(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|upstream_provider_token=true"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !routes[0].UpstreamProviderToken {
+		t.Error("UpstreamProviderToken: expected true")
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenFalse(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|upstream_provider_token=false"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamProviderToken {
+		t.Error("UpstreamProviderToken: expected false")
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenDefaultFalse(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083"}
+	routes, err := parseRoutes(env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if routes[0].UpstreamProviderToken {
+		t.Error("UpstreamProviderToken: expected false by default")
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenInvalidValue(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|upstream_provider_token=yes"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error for invalid upstream_provider_token value")
+	}
+	if !strings.Contains(err.Error(), "upstream_provider_token") {
+		t.Errorf("error message should mention upstream_provider_token: %v", err)
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenIncompatibleWithAuthNone(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|auth=none|upstream_provider_token=true"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + auth=none")
+	}
+	if !strings.Contains(err.Error(), "upstream_provider_token") {
+		t.Errorf("error message should mention upstream_provider_token: %v", err)
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenIncompatibleWithBearerTokenEnv(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "tok")
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|upstream_bearer_token_env=SOME_TOKEN|upstream_provider_token=true"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + upstream_bearer_token_env")
+	}
+	if !strings.Contains(err.Error(), "upstream_provider_token") {
+		t.Errorf("error message should mention upstream_provider_token: %v", err)
+	}
+}
+
+func TestParseRoutesUpstreamProviderTokenIncompatibleWithUpstreamOAuth(t *testing.T) {
+	env := []string{"ROUTE_RR=/mcp/review-raven|http://rr:8083|upstream_oauth=auto|upstream_provider_token=true"}
+	_, err := parseRoutes(env)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + upstream_oauth")
+	}
+	if !strings.Contains(err.Error(), "upstream_provider_token") {
+		t.Errorf("error message should mention upstream_provider_token: %v", err)
+	}
+}
+
+func TestParseFromConfigUpstreamProviderToken(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{
+			Name:                  "review-raven",
+			Prefix:                "/mcp/review-raven",
+			Upstream:              "http://rr:8083",
+			UpstreamProviderToken: true,
+		},
+	}
+	routes, err := ParseFromConfig(cfgRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !routes[0].UpstreamProviderToken {
+		t.Error("UpstreamProviderToken: expected true from config")
+	}
+}
+
+func TestParseFromConfigUpstreamProviderTokenIncompatibleWithNoAuth(t *testing.T) {
+	cfgRoutes := []appconfig.RouteConfig{
+		{
+			Name:                  "review-raven",
+			Prefix:                "/mcp/review-raven",
+			Upstream:              "http://rr:8083",
+			NoAuth:                true,
+			UpstreamProviderToken: true,
+		},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + no_auth in config")
+	}
+}
+
+func TestParseFromConfigUpstreamProviderTokenIncompatibleWithBearerTokenEnv(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "tok")
+	cfgRoutes := []appconfig.RouteConfig{
+		{
+			Name:                   "review-raven",
+			Prefix:                 "/mcp/review-raven",
+			Upstream:               "http://rr:8083",
+			UpstreamBearerTokenEnv: "SOME_TOKEN",
+			UpstreamProviderToken:  true,
+		},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + upstream_bearer_token_env in config")
+	}
+}
+
+func TestParseFromConfigUpstreamProviderTokenIncompatibleWithUpstreamOAuth(t *testing.T) {
+	oauthVal := "auto"
+	cfgRoutes := []appconfig.RouteConfig{
+		{
+			Name:                  "review-raven",
+			Prefix:                "/mcp/review-raven",
+			Upstream:              "http://rr:8083",
+			UpstreamOAuth:         &oauthVal,
+			UpstreamProviderToken: true,
+		},
+	}
+	_, err := ParseFromConfig(cfgRoutes)
+	if err == nil {
+		t.Fatal("expected error: upstream_provider_token + upstream_oauth in config")
+	}
+}


### PR DESCRIPTION
## Summary

- `builtin` モード（`OAUTH_PROVIDER=builtin`）で gateway JWT が review-raven に転送されて GitHub API 認証が失敗する問題（#186）を修正
- 新ルートオプション `upstream_provider_token=true` を追加し、`EnsureFreshAccessTokenForSubject` でサブジェクトの provider アクセストークンを解決して upstream に注入
- `upstream_oauth`・`upstream_bearer_token_env`・`auth=none` との排他バリデーションを実装
- provider token 解決失敗時は 401 + `WWW-Authenticate` でフェールクローズ
- upstream 401 時に gateway JWT キャッシュを誤失効させない

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `internal/proxy/handler.go` | `ProviderTokenSource` interface、`NewProviderTokenMiddleware`、Rewrite/ModifyResponse の provider token 対応 |
| `internal/router/router.go` | `Route.UpstreamProviderToken` フィールド追加、`parseRoutes`/`ParseFromConfig` にオプション解析・バリデーション追加 |
| `internal/config/config.go` | `RouteConfig.UpstreamProviderToken` フィールド追加 |
| `cmd/server/main.go` | route loop で `proxy.NewProviderTokenMiddleware` を wiring |
| `internal/proxy/handler_test.go` | provider token injection・fail-close・優先順位・401 handling のテスト追加 |
| `internal/router/router_test.go` | env・config.yaml 両パスの解析・バリデーションテスト追加 |
| `docs/configuration.md` | `upstream_provider_token` オプションのドキュメントと「プロバイダートークン委任」セクションを追加 |

## Token injection priority (変更後)

1. `upstreamOAuth` non-nil → per-user upstream OAuth token（変更なし）
2. `upstreamBearerTokenEnv` non-empty → env var token（変更なし）
3. **`upstream_provider_token=true` → provider access token from context（新規）**
4. fallthrough → gateway client JWT（変更なし）

## Acceptance Criteria 対応状況

- [x] review-ravenへ gateway JWT ではなく当該 subject の provider GitHub access token が注入される
- [x] provider token 委任は route 単位の明示 opt-in
- [x] provider token 未解決・失効・rotation failure が fail-close
- [x] gateway JWT validation cache と GitHub provider token の失効処理を混同しない
- [x] builtin mode・従来 github provider mode・provider token 欠落・非 opt-in route のテストがある
- [x] route 設定と security boundary を docs へ追記
- [ ] Mcp-Docker の `ROUTE_REVIEW_RAVEN` 更新 → follow-up Issue で対応
- [ ] live E2E 確認 → Mcp-Docker 側 follow-up

## 関連

Closes #186
scottlz0310/Mcp-Docker#192 (follow-up: `ROUTE_REVIEW_RAVEN=.../mcp|upstream_provider_token=true` の追加が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)