### PR TITLE
fix(auth): builtin mode で GitHub provider トークンを JWT に紐付けて保存する

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -11,7 +11,7 @@
   - `TokenRecord.ProviderAccessToken` — キャッシュエントリに紐づく provider アクセストークンを保持する新フィールド。authorization-code フロー・device フローの両方で設定され、`refresh_token` grant でも引き継がれる（refresh token の猶予期間が、それと共に発行された access-token キャッシュエントリの寿命より長く続く可能性があるため、refresh token ストア経由で引き継ぐ）。
   - `TokenStore.SaveProviderAccessToken` / `RefreshTokenStore.SaveProviderAccessToken` + `LookupProviderAccessToken` — 新規ストアメソッド（mem・file・SQLite の `RefreshTokenStore` 実装すべてに対応）。
   - `ValidateToken` は builtin mode ではキャッシュヒット時に非 builtin 用の GitHub rotation 経路を呼ばなくなった。将来 builtin mode の rotation 対応が入った際に顕在化しうるトークン漏洩リスクを事前に塞ぐもの（rotation 自体は follow-up として未実装 — `builtinProvider.RefreshToken` は引き続き `ErrRefreshNotSupported` を返す）。
-  - `docs/configuration.md` — builtin mode では `github_refresh_enabled` の設定に関わらず、GitHub アクセストークンが常に `tokens.json` / refresh token ストアに永続化される旨を追記。
+  - `docs/configuration.md` — builtin mode では `github_refresh_enabled` の設定に関わらず、GitHub アクセストークンが常に `tokens.json` / refresh token ストアに永続化される旨を追記。また builtin mode の delegated access には永続トークンストアが実質必須である旨を制限事項に追記（in-memory ストア構成では JWT に紐付けた GitHub アクセストークンがトークンキャッシュ TTL 経過または再起動で失われ、JWT が有効なまま delegated access だけが再認証を要求し続けるため）。
 
 ## [0.7.0] - 2026-06-21
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### 修正
+
+- `EnsureFreshAccessTokenForSubject`（Phase B delegated access）が builtin mode（`OAUTH_PROVIDER=builtin`）で gateway 発行の JWT ではなく GitHub provider アクセストークンを返すよう修正。従来は OAuth token 交換時に取得した GitHub アクセストークンが identity 解決にのみ使われて破棄され、トークンストアには gateway JWT しか残らなかった。そのため delegated access の呼び出し元（review-raven の `upstream_provider_token=true` ルートや `/internal/v1/whoami` エンドポイントなど）は gateway JWT を利用可能な GitHub bearer トークンとして受け取ってしまい、ユーザーの GitHub セッションが実際には有効なままでも、以降のすべての GitHub API 呼び出しが `401 Unauthorized` で失敗していた。（[#188](https://github.com/scottlz0310/mcp-gateway/issues/188)）
+  - `TokenRecord.ProviderAccessToken` — キャッシュエントリに紐づく provider アクセストークンを保持する新フィールド。authorization-code フロー・device フローの両方で設定され、`refresh_token` grant でも引き継がれる（refresh token の猶予期間が、それと共に発行された access-token キャッシュエントリの寿命より長く続く可能性があるため、refresh token ストア経由で引き継ぐ）。
+  - `TokenStore.SaveProviderAccessToken` / `RefreshTokenStore.SaveProviderAccessToken` + `LookupProviderAccessToken` — 新規ストアメソッド（mem・file・SQLite の `RefreshTokenStore` 実装すべてに対応）。
+  - `ValidateToken` は builtin mode ではキャッシュヒット時に非 builtin 用の GitHub rotation 経路を呼ばなくなった。将来 builtin mode の rotation 対応が入った際に顕在化しうるトークン漏洩リスクを事前に塞ぐもの（rotation 自体は follow-up として未実装 — `builtinProvider.RefreshToken` は引き続き `ErrRefreshNotSupported` を返す）。
+  - `docs/configuration.md` — builtin mode では `github_refresh_enabled` の設定に関わらず、GitHub アクセストークンが常に `tokens.json` / refresh token ストアに永続化される旨を追記。
+
 ## [0.7.0] - 2026-06-21
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `EnsureFreshAccessTokenForSubject` (Phase B delegated access) now returns the GitHub provider access token in builtin mode (`OAUTH_PROVIDER=builtin`), instead of the gateway-issued JWT. Previously, the GitHub access token obtained during the OAuth token exchange was used only for identity resolution and then discarded; the token store held only the gateway JWT, which delegated-access callers (e.g. review-raven's `upstream_provider_token=true` route and the `/internal/v1/whoami` endpoint) received as if it were a usable GitHub bearer token, causing every downstream GitHub API call to fail with `401 Unauthorized` regardless of whether the user's GitHub session was actually still valid. ([#188](https://github.com/scottlz0310/mcp-gateway/issues/188))
+  - `TokenRecord.ProviderAccessToken` — new field recording the provider access token associated with a cached entry; populated across the authorization-code flow, the device flow, and carried forward on `refresh_token` grant (via the refresh-token store, since a refresh token's grace period can outlive the access-token cache entry it was issued alongside).
+  - `TokenStore.SaveProviderAccessToken` / `RefreshTokenStore.SaveProviderAccessToken` + `LookupProviderAccessToken` — new store methods (mem, file, and SQLite `RefreshTokenStore` backends).
+  - `ValidateToken` no longer runs the non-builtin GitHub rotation path on a cache hit in builtin mode, closing a token-leak risk that would otherwise surface once builtin-mode rotation support lands (tracked as a follow-up; not yet implemented — `builtinProvider.RefreshToken` still returns `ErrRefreshNotSupported`).
+  - `docs/configuration.md` — documented that builtin mode always persists the GitHub access token in `tokens.json`/the refresh-token store, independent of `github_refresh_enabled`.
+
 ### Added
 
 - `Mcp-Session-Id` 双方向透過の回帰テストと診断ログ・トラブルシュート手順を追加 ([#182](https://github.com/scottlz0310/mcp-gateway/issues/182))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and versioning follows [Semantic Versioning](https://semver.org/).
   - `TokenRecord.ProviderAccessToken` — new field recording the provider access token associated with a cached entry; populated across the authorization-code flow, the device flow, and carried forward on `refresh_token` grant (via the refresh-token store, since a refresh token's grace period can outlive the access-token cache entry it was issued alongside).
   - `TokenStore.SaveProviderAccessToken` / `RefreshTokenStore.SaveProviderAccessToken` + `LookupProviderAccessToken` — new store methods (mem, file, and SQLite `RefreshTokenStore` backends).
   - `ValidateToken` no longer runs the non-builtin GitHub rotation path on a cache hit in builtin mode, closing a token-leak risk that would otherwise surface once builtin-mode rotation support lands (tracked as a follow-up; not yet implemented — `builtinProvider.RefreshToken` still returns `ErrRefreshNotSupported`).
-  - `docs/configuration.md` — documented that builtin mode always persists the GitHub access token in `tokens.json`/the refresh-token store, independent of `github_refresh_enabled`.
+  - `docs/configuration.md` — documented that builtin mode always persists the GitHub access token in `tokens.json`/the refresh-token store, independent of `github_refresh_enabled`, and that builtin-mode delegated access effectively requires a persistent token store (with an in-memory store, the bound GitHub access token is lost after the token-cache TTL or a gateway restart while the JWT stays valid, so delegated access keeps demanding re-authentication).
 
 ### Added
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -469,6 +469,7 @@ gateway:
 ### 制限事項
 
 - `MCP_GATEWAY_TOKEN_STORE_PATH` が未設定の場合、ゲートウェイ再起動時にリフレッシュトークンが失われます。再起動をまたいでローテーションを継続するにはトークン状態をディスクに永続化してください。
+- builtin mode（`OAUTH_PROVIDER=builtin`）の delegated access（`EnsureFreshAccessTokenForSubject`、`upstream_provider_token=true` ルート、`/internal/v1/whoami`）には永続トークンストアが実質必須です。`MCP_GATEWAY_TOKEN_STORE_PATH` を空値に設定した in-memory 構成では、JWT に紐付けた GitHub アクセストークンがトークンキャッシュ TTL（`TOKEN_CACHE_TTL_MIN`、既定 30 分）の経過またはゲートウェイ再起動で失われます。JWT 自体は有効期限（90 日）まで検証に成功し続けるため、プロキシ転送は正常に動作したまま delegated access だけが再認証を要求し続ける、原因に気づきにくい状態になります。
 - ローテーションリードタイムは約 5 分に固定されています。上流操作が著しく長いオペレーターは、リードタイムを拡大するより Phase B（委任バックグラウンドアクセス）を検討してください。
 - ローテーションには `gateway.github_client_secret` が必要です。GitHub のリフレッシュエンドポイントが初回交換と同様にローテーションリクエストを認証するためです。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,6 +344,8 @@ MCP_GATEWAY_TOKEN_STORE_PATH=
 - コンテナイメージやスナップショットにいずれのファイルも含めないこと。
 - 再起動をまたいだローテーションが不要な場合は `github_refresh_enabled` を無効にしてください。リフレッシュトークンはディスクに書き込まれません。
 
+**builtin mode（`OAUTH_PROVIDER=builtin`）の追加事項:** builtin mode ではクライアントに渡すアクセストークンはゲートウェイ署名の JWT であり、GitHub アクセストークン自体ではありません。ただし Phase B delegated access（`EnsureFreshAccessTokenForSubject`、`upstream_provider_token=true` ルートおよび `/internal/v1/whoami` が使用）が upstream サービスへ GitHub トークンを引き渡せるようにするため、GitHub アクセストークンは JWT に紐付けて `tokens.json`（および `github_refresh_enabled` 無効時でも常に）と、そのリフレッシュトークンストア（file-backed 構成では `tokens.json.refresh`、`MCP_GATEWAY_TOKEN_STORE_PATH` が SQLite バックエンドを指す場合は同 DB 内）の両方に**平文で常に**保存されます。`github_refresh_enabled` はリフレッシュトークン自体の保存有無のみを制御し、GitHub アクセストークンの保存有無は制御しません。したがって上記の「`tokens.json` の読者はログイン済みユーザーの GitHub セッションを乗っ取れる」というリスクは、`github_refresh_enabled` の設定に関わらず builtin mode にも同様に適用されます。
+
 ## リバースプロキシヘッダー
 
 mcp-gateway の前で TLS を終端する場合:

--- a/internal/auth/delegated_access_test.go
+++ b/internal/auth/delegated_access_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -468,5 +470,79 @@ func TestRotationPermanentlyFailedSurvivesRestart(t *testing.T) {
 	_, err = h2.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
 	if !errors.Is(err, ErrSubjectNotFound) {
 		t.Fatalf("EnsureFresh after restart: err=%v want ErrSubjectNotFound (dead bearer must not be returned)", err)
+	}
+}
+
+// newDelegatedBuiltinTestHandler builds a builtin-mode Handler (gateway issues
+// its own RS256 JWTs; the Mock provider's Name() is "builtin") for exercising
+// EnsureFreshAccessTokenForSubject's builtin branch. ghExchangeAccessToken is
+// the GitHub access token ExchangeCode returns during the OAuth callback.
+func newDelegatedBuiltinTestHandler(t *testing.T, ghExchangeAccessToken string) *Handler {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	p := &provider.Mock{
+		NameValue:     "builtin",
+		ClientIDValue: "builtin-client-id",
+		ScopesValue:   "read:user,user:email",
+		ExchangeCodeFunc: func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghExchangeAccessToken}, nil
+		},
+		ValidateFunc: func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	}
+	h, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		CacheTTL:       5 * time.Minute,
+		ExpiresIn:      90 * 24 * time.Hour,
+		OIDCPrivateKey: key,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h
+}
+
+// TestEnsureFreshAccessTokenForSubject_BuiltinReturnsProviderTokenNotJWT is
+// the direct regression test for scottlz0310/mcp-gateway#188: in builtin
+// mode, EnsureFreshAccessTokenForSubject must return the GitHub access token
+// recorded at token-exchange time, never the gateway-issued JWT the client
+// was handed.
+func TestEnsureFreshAccessTokenForSubject_BuiltinReturnsProviderTokenNotJWT(t *testing.T) {
+	const ghAccessToken = "gho_realgithubtoken"
+	h := newDelegatedBuiltinTestHandler(t, ghAccessToken)
+	_, jwt := runBuiltinFullFlow(t, h, "alice")
+	if jwt == "" {
+		t.Fatal("runBuiltinFullFlow: empty access_token in token response")
+	}
+
+	res, err := h.EnsureFreshAccessTokenForSubject(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("EnsureFreshAccessTokenForSubject: %v", err)
+	}
+	if res.AccessToken != ghAccessToken {
+		t.Errorf("access token: got %q, want provider token %q", res.AccessToken, ghAccessToken)
+	}
+	if res.AccessToken == jwt {
+		t.Fatal("regression: EnsureFreshAccessTokenForSubject leaked the gateway JWT instead of the GitHub access token")
+	}
+}
+
+// TestEnsureFreshAccessTokenForSubject_BuiltinLegacyRecordWithoutProviderToken
+// verifies the safe-fallback behavior for a JWT cached before this fix existed
+// (ProviderAccessToken empty): EnsureFreshAccessTokenForSubject must return
+// ErrSubjectNotFound (forcing re-authentication) rather than falling through
+// to the non-builtin logic, which would otherwise hand back the raw JWT.
+func TestEnsureFreshAccessTokenForSubject_BuiltinLegacyRecordWithoutProviderToken(t *testing.T) {
+	h := newDelegatedBuiltinTestHandler(t, "gho_unused")
+	h.store.CacheToken("legacy-jwt-no-provider-token", "bob", "http://localhost:8080")
+
+	_, err := h.EnsureFreshAccessTokenForSubject(context.Background(), "bob")
+	if !errors.Is(err, ErrSubjectNotFound) {
+		t.Fatalf("err: got %v, want ErrSubjectNotFound (force re-auth for pre-fix JWTs)", err)
 	}
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -590,9 +590,11 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.isBuiltinMode() {
-		// builtin mode: discard GitHub access token, issue gateway-signed JWT instead.
-		// GitHub token was used only for identity resolution in Callback(); it must not
-		// reach the client.
+		// builtin mode: the client never sees the GitHub access token — it is
+		// issued a gateway-signed JWT instead. The GitHub token itself is kept
+		// server-side, indexed under the JWT, so that EnsureFreshAccessTokenForSubject
+		// (Phase B delegated access) can still hand it to authorized background
+		// workers. See scottlz0310/mcp-gateway#188.
 		gatewayToken, genErr := h.generateGatewayAccessToken(result.Subject, result.Audience)
 		if genErr != nil {
 			h.auditFailure("token_exchange", "server_error", "gateway access token generation failed", genErr, http.StatusInternalServerError, "")
@@ -601,6 +603,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.CacheToken(gatewayToken, result.Subject, result.Audience)
+		h.store.RecordProviderAccessToken(gatewayToken, result.AccessToken)
 		h.store.SaveTokenNonce(gatewayToken, result.Nonce)
 		familyID, fidErr := generateCode()
 		if fidErr != nil {
@@ -612,6 +615,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("failed to create refresh token", "err", rtErr)
 		}
 		h.store.SaveRefreshTokenNonce(refreshToken, result.Nonce)
+		h.store.SaveRefreshTokenProviderAccessToken(refreshToken, result.AccessToken)
 		h.writeTokenResponse(w, gatewayToken, result.Scope, refreshToken, result.Subject, result.Nonce, result.ClientID)
 		h.auditSuccess("token_exchange", "authorization code exchange completed (builtin)", http.StatusOK)
 		return
@@ -692,6 +696,13 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		h.store.CacheToken(token, completed.Subject, completed.Audience)
+		if h.isBuiltinMode() {
+			// See the equivalent comment in tokenAuthCode: the GitHub access
+			// token is kept server-side, indexed under the gateway JWT, so
+			// EnsureFreshAccessTokenForSubject can still hand it to
+			// authorized background workers.
+			h.store.RecordProviderAccessToken(token, completed.AccessToken)
+		}
 		h.persistProviderRefresh(completed.AccessToken, completed.ProviderRefreshToken, completed.ProviderAccessExpiry)
 		familyID, fidErr := generateCode()
 		if fidErr != nil {
@@ -701,6 +712,9 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 		refreshToken, rtErr := h.store.CreateRefreshToken(token, completed.Audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
 			slog.Warn("failed to create refresh token (device)", "err", rtErr)
+		}
+		if h.isBuiltinMode() {
+			h.store.SaveRefreshTokenProviderAccessToken(refreshToken, completed.AccessToken)
 		}
 		h.writeTokenResponse(w, token, completed.Scope, refreshToken, completed.Subject, "", completed.ClientID)
 		h.auditSuccess("token_exchange", "device token exchange completed", http.StatusOK)
@@ -772,6 +786,12 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	// original authentication request. We key on the refresh token (not the
 	// access token) so the nonce remains available past the access-token TTL.
 	nonce := h.store.LookupRefreshTokenNonce(rt)
+	// Likewise, recover the provider access token (builtin mode) from the
+	// refresh token before it is soft-revoked. The access-token TokenStore
+	// entry (a gateway JWT) can already be swept by the time this grant runs
+	// — refresh tokens carry a 30-day grace period beyond the access token
+	// TTL — so the refresh token is the only reliable place to read it from.
+	providerAccessToken := h.store.LookupRefreshTokenProviderAccessToken(rt)
 
 	// Atomically reserve (remove) the token. Concurrent callers presenting the
 	// same token will fail here, preventing double-rotation.
@@ -835,6 +855,9 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.CacheToken(newGatewayToken, sub, audience)
+		if providerAccessToken != "" {
+			h.store.RecordProviderAccessToken(newGatewayToken, providerAccessToken)
+		}
 		h.store.SaveTokenNonce(newGatewayToken, nonce)
 		// Propagate the same familyID so the token lineage remains traceable.
 		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
@@ -846,6 +869,9 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.store.SaveRefreshTokenNonce(newRT, nonce)
+		if providerAccessToken != "" {
+			h.store.SaveRefreshTokenProviderAccessToken(newRT, providerAccessToken)
+		}
 		h.writeTokenResponse(w, newGatewayToken, "", newRT, sub, nonce, r.FormValue("client_id"))
 		h.auditSuccess("refresh", "refresh token exchange completed (builtin)", http.StatusOK)
 		return
@@ -1104,8 +1130,19 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 		if err := h.validateAudience(token, record, audience); err != nil {
 			return "", "", err
 		}
-		if rotated, newSubject, ok := h.tryGitHubRotation(ctx, token, record, audience); ok {
-			return newSubject, rotated, nil
+		// tryGitHubRotation assumes the cache key IS the provider access
+		// token (true for non-builtin mode) and, on success, hands the
+		// rotated provider token back as rotatedToken for proxy forwarding.
+		// In builtin mode the cache key is a gateway JWT, so rotating it
+		// this way would either be meaningless or — once a provider refresh
+		// token is attached to the JWT's record (scottlz0310/mcp-gateway#188
+		// follow-up) — leak a raw GitHub access token to any route that
+		// forwards ContextKeyToken, regardless of upstream_provider_token.
+		// Builtin mode must never take this path.
+		if !h.isBuiltinMode() {
+			if rotated, newSubject, ok := h.tryGitHubRotation(ctx, token, record, audience); ok {
+				return newSubject, rotated, nil
+			}
 		}
 		if record.Subject != "" {
 			if !record.RotationPermanentlyFailed {
@@ -1420,6 +1457,17 @@ var ErrRotationFailed = errors.New("auth: rotation failed for delegated access")
 // delegated-access internal API so background workers (e.g. an upstream MCP
 // watcher) can pull a fresh bearer without re-authenticating the user.
 //
+// In builtin mode the cache key (rawToken) is a gateway-issued JWT, not a
+// provider access token — callers must never receive the JWT here, since it
+// is meaningless to an upstream API and its whole purpose is to stay
+// server-side. This function returns record.ProviderAccessToken instead (see
+// scottlz0310/mcp-gateway#188), and returns ErrSubjectNotFound when that
+// field is empty (e.g. a JWT issued before this field existed) rather than
+// falling through to the non-builtin logic below, which would leak the JWT.
+// Builtin mode does not yet support rotation (tracked as a follow-up); the
+// returned AccessToken/ProviderAccessExpiry reflect whatever was recorded at
+// token-issuance or refresh time.
+//
 // Returns ErrSubjectNotFound when no cached token exists for subject (including
 // after a permanent rotation failure: MarkRotationPermanentlyFailed removes the
 // token from the subject index so this function never reaches the lenient branch
@@ -1439,6 +1487,16 @@ func (h *Handler) EnsureFreshAccessTokenForSubject(ctx context.Context, subject 
 	rawToken, record, ok := h.store.LatestBySubject(subject)
 	if !ok {
 		return DelegatedAccessResult{}, ErrSubjectNotFound
+	}
+	if h.isBuiltinMode() {
+		if record.ProviderAccessToken == "" {
+			return DelegatedAccessResult{}, ErrSubjectNotFound
+		}
+		return DelegatedAccessResult{
+			AccessToken:          record.ProviderAccessToken,
+			ProviderAccessExpiry: record.ProviderAccessExpiry,
+			Scopes:               parseScopes(h.provider.Scopes()),
+		}, nil
 	}
 	// Choose a representative audience: prefer one already on the record
 	// (so HasAudience semantics in tryGitHubRotation hit cache), otherwise

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1488,12 +1488,18 @@ func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, string, time
 func (d *deleteFailRefreshStore) LookupAny(rt string) (string, string, string, time.Time, bool, bool) {
 	return d.inner.LookupAny(rt)
 }
-func (d *deleteFailRefreshStore) Revoke(_ string) error            { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) RevokeFamily(fid string) error    { return d.inner.RevokeFamily(fid) }
-func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error     { return d.inner.SaveNonce(rt, n) }
-func (d *deleteFailRefreshStore) LookupNonce(rt string) string     { return d.inner.LookupNonce(rt) }
-func (d *deleteFailRefreshStore) Delete(_ string) error            { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) Sweep() error                     { return d.inner.Sweep() }
+func (d *deleteFailRefreshStore) Revoke(_ string) error         { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) RevokeFamily(fid string) error { return d.inner.RevokeFamily(fid) }
+func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error  { return d.inner.SaveNonce(rt, n) }
+func (d *deleteFailRefreshStore) LookupNonce(rt string) string  { return d.inner.LookupNonce(rt) }
+func (d *deleteFailRefreshStore) SaveProviderAccessToken(rt, pat string) error {
+	return d.inner.SaveProviderAccessToken(rt, pat)
+}
+func (d *deleteFailRefreshStore) LookupProviderAccessToken(rt string) string {
+	return d.inner.LookupProviderAccessToken(rt)
+}
+func (d *deleteFailRefreshStore) Delete(_ string) error { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) Sweep() error          { return d.inner.Sweep() }
 
 // TestTokenRefreshDeleteFailed503 verifies that when the refresh token store
 // fails to delete the token during rotation (ErrRefreshTokenDeleteFailed),
@@ -4095,5 +4101,252 @@ func TestDeviceCallbackApproveDeviceFails(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status: got %d, want 400", w.Code)
+	}
+}
+
+// ── scottlz0310/mcp-gateway#188 regression tests ───────────────────────────
+//
+// These verify that builtin mode retains the GitHub provider access token
+// (indexed under the gateway JWT) across the authorization-code flow, the
+// device flow, and refresh_token rotation, and that ValidateToken never
+// leaks a raw provider token through the non-builtin rotation path.
+
+// TestBuiltinTokenAuthCodePersistsProviderAccessToken verifies that
+// tokenAuthCode's builtin branch records the GitHub access token obtained
+// during ExchangeCode, indexed under the issued gateway JWT.
+func TestBuiltinTokenAuthCodePersistsProviderAccessToken(t *testing.T) {
+	const ghAccessToken = "gho_authcode_provider_tok"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "grace"}, nil
+		},
+	)
+
+	_, jwt := runBuiltinFullFlow(t, h, "grace")
+	if jwt == "" {
+		t.Fatal("runBuiltinFullFlow: empty access_token in token response")
+	}
+
+	rec, ok := h.store.LookupToken(jwt)
+	if !ok {
+		t.Fatal("LookupToken: expected cache hit for issued JWT")
+	}
+	if rec.ProviderAccessToken != ghAccessToken {
+		t.Errorf("ProviderAccessToken: got %q, want %q", rec.ProviderAccessToken, ghAccessToken)
+	}
+}
+
+// TestBuiltinDeviceGrantPersistsProviderAccessToken verifies that
+// tokenDeviceGrant's builtin branch records the GitHub access token approved
+// via the device flow, indexed under the issued gateway JWT (not under the
+// GitHub token itself, which is never cached in builtin mode).
+func TestBuiltinDeviceGrantPersistsProviderAccessToken(t *testing.T) {
+	const ghAccessToken = "gho_device_provider_tok"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "heidi"}, nil
+		},
+	)
+
+	deviceCode, err := h.store.CreateDevice("DEVI-0001", time.Now().Add(10*time.Minute), "mcp-gateway", "")
+	if err != nil {
+		t.Fatalf("CreateDevice: %v", err)
+	}
+	if !h.store.ApproveDevice(deviceCode, ghAccessToken, "read:user", "heidi", "", time.Time{}) {
+		t.Fatal("ApproveDevice failed")
+	}
+
+	body := fmt.Sprintf("grant_type=urn:ietf%%3Aparams%%3Aoauth%%3Agrant-type%%3Adevice_code&device_code=%s", deviceCode)
+	r := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("token exchange: got %d want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	jwt, _ := resp["access_token"].(string)
+	if jwt == "" {
+		t.Fatal("device token response: empty access_token")
+	}
+	if jwt == ghAccessToken {
+		t.Fatal("device token response leaked the raw GitHub access token instead of a gateway JWT")
+	}
+
+	rec, ok := h.store.LookupToken(jwt)
+	if !ok {
+		t.Fatal("LookupToken: expected cache hit for issued JWT")
+	}
+	if rec.ProviderAccessToken != ghAccessToken {
+		t.Errorf("ProviderAccessToken: got %q, want %q", rec.ProviderAccessToken, ghAccessToken)
+	}
+}
+
+// TestBuiltinTokenRefreshCarriesForwardProviderAccessToken verifies that
+// tokenRefresh's builtin branch carries the provider access token forward to
+// the newly-issued gateway JWT.
+func TestBuiltinTokenRefreshCarriesForwardProviderAccessToken(t *testing.T) {
+	const ghAccessToken = "gho_refresh_provider_tok"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "ivan"}, nil
+		},
+	)
+
+	tokenResp, firstJWT := runBuiltinFullFlow(t, h, "ivan")
+	refreshToken, _ := tokenResp["refresh_token"].(string)
+	if refreshToken == "" {
+		t.Fatal("missing refresh_token in initial response")
+	}
+
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("refresh: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+	var refreshResp map[string]any
+	_ = json.NewDecoder(refreshRec.Body).Decode(&refreshResp)
+	newJWT, _ := refreshResp["access_token"].(string)
+	if newJWT == "" || newJWT == firstJWT {
+		t.Fatalf("refresh must issue a new JWT: got %q (first was %q)", newJWT, firstJWT)
+	}
+
+	rec, ok := h.store.LookupToken(newJWT)
+	if !ok {
+		t.Fatal("LookupToken: expected cache hit for refreshed JWT")
+	}
+	if rec.ProviderAccessToken != ghAccessToken {
+		t.Errorf("ProviderAccessToken after refresh: got %q, want %q", rec.ProviderAccessToken, ghAccessToken)
+	}
+}
+
+// TestBuiltinTokenRefreshCarriesForwardAfterOldRecordSwept is the direct
+// regression test for the refresh-token grace-period gap identified during
+// the #188 investigation: refresh tokens outlive the access-token TokenStore
+// entry by design (30-day grace period beyond the access token TTL), so by
+// the time a client refreshes, the old JWT's TokenRecord may already be gone.
+// The provider access token must still be recoverable via the refresh token
+// itself, not via the old JWT's (possibly-swept) record.
+func TestBuiltinTokenRefreshCarriesForwardAfterOldRecordSwept(t *testing.T) {
+	const ghAccessToken = "gho_swept_provider_tok"
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: ghAccessToken}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "judy"}, nil
+		},
+	)
+
+	tokenResp, firstJWT := runBuiltinFullFlow(t, h, "judy")
+	refreshToken, _ := tokenResp["refresh_token"].(string)
+	if refreshToken == "" {
+		t.Fatal("missing refresh_token in initial response")
+	}
+
+	// Simulate the old JWT's TokenStore entry having already been swept
+	// (e.g. it hit its CacheTTL before the client got around to refreshing).
+	h.InvalidateCachedToken(firstJWT)
+	if _, ok := h.store.LookupToken(firstJWT); ok {
+		t.Fatal("setup: expected old JWT to be evicted from the token store")
+	}
+
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("refresh: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+	var refreshResp map[string]any
+	_ = json.NewDecoder(refreshRec.Body).Decode(&refreshResp)
+	newJWT, _ := refreshResp["access_token"].(string)
+	if newJWT == "" {
+		t.Fatal("refresh response missing access_token")
+	}
+
+	rec, ok := h.store.LookupToken(newJWT)
+	if !ok {
+		t.Fatal("LookupToken: expected cache hit for refreshed JWT")
+	}
+	if rec.ProviderAccessToken != ghAccessToken {
+		t.Errorf("ProviderAccessToken recovered via refresh token after old record sweep: got %q, want %q",
+			rec.ProviderAccessToken, ghAccessToken)
+	}
+}
+
+// TestValidateToken_BuiltinModeDoesNotRotateOnCacheHit is the security
+// regression test for the ValidateToken cache-hit guard: even if a builtin
+// JWT's TokenRecord somehow carries GitHub-style rotation metadata
+// (ProviderRefreshToken/ProviderAccessExpiry), ValidateToken must never
+// invoke the non-builtin rotation path for it, which would otherwise return
+// a raw GitHub access token as rotatedToken — leaking it via ContextKeyToken
+// to any route that forwards the bearer, not just upstream_provider_token
+// routes. See scottlz0310/mcp-gateway#188.
+func TestValidateToken_BuiltinModeDoesNotRotateOnCacheHit(t *testing.T) {
+	var refreshCalled bool
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	p := &provider.Mock{
+		NameValue:     "builtin",
+		ClientIDValue: "builtin-client-id",
+		ScopesValue:   "read:user,user:email",
+		RefreshTokenFunc: func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			refreshCalled = true
+			return provider.TokenResponse{AccessToken: "gho_leaked_via_rotation"}, nil
+		},
+	}
+	h, err := NewHandler(Config{
+		BaseURL:              "http://localhost:8080",
+		SessionTTL:           10 * time.Minute,
+		CacheTTL:             5 * time.Minute,
+		ExpiresIn:            90 * 24 * time.Hour,
+		OIDCPrivateKey:       key,
+		GitHubRefreshEnabled: true,
+		GitHubRefreshLeeway:  time.Hour, // wide leeway so any expiry in the past triggers rotation
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	jwt, err := h.generateGatewayAccessToken("kevin", "http://localhost:8080")
+	if err != nil {
+		t.Fatalf("generateGatewayAccessToken: %v", err)
+	}
+	h.store.CacheToken(jwt, "kevin", "http://localhost:8080")
+	// Force rotation preconditions to be satisfied: known subject, refresh
+	// metadata present, expiry already within (in fact past) the leeway window.
+	h.store.RecordProviderRefresh(jwt, "gh-refresh-should-not-be-used", time.Now().Add(-time.Minute))
+
+	sub, rotated, err := h.ValidateToken(context.Background(), jwt, "")
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if sub != "kevin" {
+		t.Errorf("subject: got %q, want %q", sub, "kevin")
+	}
+	if rotated != "" {
+		t.Fatalf("regression: ValidateToken returned a rotated token in builtin mode: %q (must be empty)", rotated)
+	}
+	if refreshCalled {
+		t.Fatal("regression: provider.RefreshToken was invoked for a builtin-mode JWT on cache hit")
 	}
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -21,19 +21,19 @@ var ErrRefreshTokenDeleteFailed = errors.New("refresh token delete failed")
 
 // Session holds OAuth flow state between /authorize and /token.
 type Session struct {
-	State                 string
-	RedirectURI           string
-	CodeChallenge         string
-	Audience              string
-	Nonce                 string    // OIDC Core §3.1.3.7: forwarded to id_token if provided
-	ClientID              string    // OIDC Core §2: client_id of the relying party; used as id_token aud
-	InternalCode          string
-	AccessToken           string
-	Scope                 string
-	ExpiresAt             time.Time
-	ProviderRefreshToken  string    // optional GitHub refresh token (expiring tokens)
-	ProviderAccessExpiry  time.Time // optional GitHub access-token expiry (zero = no expiry hint)
-	Subject               string    // resolved subject
+	State                string
+	RedirectURI          string
+	CodeChallenge        string
+	Audience             string
+	Nonce                string // OIDC Core §3.1.3.7: forwarded to id_token if provided
+	ClientID             string // OIDC Core §2: client_id of the relying party; used as id_token aud
+	InternalCode         string
+	AccessToken          string
+	Scope                string
+	ExpiresAt            time.Time
+	ProviderRefreshToken string    // optional GitHub refresh token (expiring tokens)
+	ProviderAccessExpiry time.Time // optional GitHub access-token expiry (zero = no expiry hint)
+	Subject              string    // resolved subject
 }
 
 type deviceStatus int
@@ -47,7 +47,7 @@ const (
 // DeviceSession tracks a Device Authorization Grant (RFC 8628) flow and its current status.
 type DeviceSession struct {
 	InternalCode         string
-	UserCode             string    // XXXX-XXXX format shown to the user at /activate
+	UserCode             string // XXXX-XXXX format shown to the user at /activate
 	ExpiresAt            time.Time
 	Interval             int // minimum seconds between client polls (RFC 8628 §3.5)
 	AccessToken          string
@@ -131,13 +131,13 @@ func NewStore(sessionTTL, tokensTTL time.Duration, ts TokenStore, opts ...StoreO
 		ts = NewMemTokenStore()
 	}
 	s := &Store{
-		sessions:     make(map[string]*Session),
-		codes:        make(map[string]*Session),
-		devices:      make(map[string]*DeviceSession),
-		ttl:          sessionTTL,
-		tokens:       ts,
-		tokensTTL:    tokensTTL,
-		refreshStore: NewMemRefreshTokenStore(),
+		sessions:       make(map[string]*Session),
+		codes:          make(map[string]*Session),
+		devices:        make(map[string]*DeviceSession),
+		ttl:            sessionTTL,
+		tokens:         ts,
+		tokensTTL:      tokensTTL,
+		refreshStore:   NewMemRefreshTokenStore(),
 		subjectIndex:   make(map[string][]subjectIndexEntry),
 		rotationFailed: make(map[string]struct{}),
 		stopCh:         make(chan struct{}),
@@ -219,11 +219,11 @@ type ExchangeCodeResult struct {
 	AccessToken          string
 	Scope                string
 	Audience             string
-	Nonce                string    // OIDC Core §3.1.3.7: forwarded to id_token if provided
-	ClientID             string    // OIDC Core §2: client_id of the relying party; used as id_token aud
+	Nonce                string // OIDC Core §3.1.3.7: forwarded to id_token if provided
+	ClientID             string // OIDC Core §2: client_id of the relying party; used as id_token aud
 	ProviderRefreshToken string
 	ProviderAccessExpiry time.Time
-	Subject              string    // resolved subject
+	Subject              string // resolved subject
 }
 
 // ExchangeCode validates PKCE and returns the access token, granted scope, and
@@ -385,7 +385,6 @@ func (s *Store) DenyDevice(internalCode string) {
 		d.Status = deviceDenied
 	}
 }
-
 
 // CreateRefreshToken generates a gateway-issued refresh token for the given
 // accessToken and stores it with the supplied TTL. The refresh token is an
@@ -722,6 +721,19 @@ func (s *Store) RecordProviderRefresh(token, providerRefreshToken string, provid
 	// is no separate index hint to update here.
 }
 
+// RecordProviderAccessToken attaches the upstream provider's access token
+// (e.g. a GitHub token) to an already-cached token entry. Unlike
+// RecordProviderRefresh, this is unconditional: builtin mode relies on it to
+// make the provider token recoverable at all (the cache key is a
+// gateway-issued JWT, not the provider token itself), so there is no
+// "refresh not configured" gate to check. No-op when the underlying cache
+// entry is missing (CacheToken has not yet run for this token).
+func (s *Store) RecordProviderAccessToken(token, providerAccessToken string) {
+	if err := s.tokens.SaveProviderAccessToken(token, providerAccessToken); err != nil {
+		slog.Warn("token store provider access token save failed", "err", err)
+	}
+}
+
 // SaveTokenNonce attaches the OIDC nonce to an existing token entry so it can
 // be forwarded in the id_token on refresh (OIDC Core §12.2). An empty nonce
 // clears any previously stored value, ensuring stale nonces from a prior grant
@@ -746,6 +758,27 @@ func (s *Store) SaveRefreshTokenNonce(refreshToken, nonce string) {
 // by ReserveRefreshToken) so the nonce remains readable during the rotation.
 func (s *Store) LookupRefreshTokenNonce(refreshToken string) string {
 	return s.refreshStore.LookupNonce(refreshToken)
+}
+
+// SaveRefreshTokenProviderAccessToken attaches the upstream provider's access
+// token to a refresh-token entry so it survives past the access token's TTL.
+// Builtin mode's access-token TokenStore entry (a gateway JWT) can be swept
+// before its refresh token expires (refresh tokens carry a 30-day grace
+// period beyond the access token TTL); this is the durable place tokenRefresh
+// recovers the provider token from during that gap. No-op when entry is
+// absent or expired.
+func (s *Store) SaveRefreshTokenProviderAccessToken(refreshToken, providerAccessToken string) {
+	if err := s.refreshStore.SaveProviderAccessToken(refreshToken, providerAccessToken); err != nil {
+		slog.Warn("refresh token store provider access token save failed", "err", err)
+	}
+}
+
+// LookupRefreshTokenProviderAccessToken returns the provider access token
+// stored for refreshToken, or "" when absent, expired, or never set. Reads
+// even soft-revoked entries (already rotated by ReserveRefreshToken) so the
+// value remains readable during the rotation, mirroring LookupRefreshTokenNonce.
+func (s *Store) LookupRefreshTokenProviderAccessToken(refreshToken string) string {
+	return s.refreshStore.LookupProviderAccessToken(refreshToken)
 }
 
 // ClearProviderRefresh drops the provider refresh metadata for token (sets

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -234,11 +234,14 @@ func (e *errTokenStore) Save(_, _ string, _ []string, _ time.Time) error {
 func (e *errTokenStore) SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error {
 	return e.mem.SaveProviderRefresh(token, providerRefreshToken, providerAccessExpiry)
 }
-func (e *errTokenStore) Lookup(token string) (TokenRecord, bool)  { return e.mem.Lookup(token) }
-func (e *errTokenStore) SaveNonce(token, nonce string) error       { return e.mem.SaveNonce(token, nonce) }
-func (e *errTokenStore) MarkRotationFailed(_ string) error         { return nil }
-func (e *errTokenStore) Delete(_ string) error                     { return fmt.Errorf("injected delete error") }
-func (e *errTokenStore) Sweep() error                              { return e.mem.Sweep() }
+func (e *errTokenStore) SaveProviderAccessToken(token, providerAccessToken string) error {
+	return e.mem.SaveProviderAccessToken(token, providerAccessToken)
+}
+func (e *errTokenStore) Lookup(token string) (TokenRecord, bool) { return e.mem.Lookup(token) }
+func (e *errTokenStore) SaveNonce(token, nonce string) error     { return e.mem.SaveNonce(token, nonce) }
+func (e *errTokenStore) MarkRotationFailed(_ string) error       { return nil }
+func (e *errTokenStore) Delete(_ string) error                   { return fmt.Errorf("injected delete error") }
+func (e *errTokenStore) Sweep() error                            { return e.mem.Sweep() }
 
 // TestNewStoreNilTokenStore verifies that a nil TokenStore defaults to memTokenStore.
 func TestNewStoreNilTokenStore(t *testing.T) {

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -16,6 +16,13 @@ import (
 // TokenRecord is the cached metadata for an access token. Audiences is empty
 // for legacy entries written before per-route audience metadata existed.
 //
+// ProviderAccessToken is the upstream OAuth provider's access token (e.g. a
+// GitHub token) associated with this entry. In builtin mode the token map key
+// is a gateway-issued JWT, not the provider token itself, so this field is the
+// only place the provider token is recoverable from — used by
+// EnsureFreshAccessTokenForSubject (Phase B delegated access). Empty for
+// non-builtin mode, where the map key IS the provider access token already.
+//
 // ProviderRefreshToken and ProviderAccessExpiry are populated when the upstream
 // OAuth provider issues short-lived (expiring) tokens. ProviderAccessExpiry is
 // zero when the provider did not advertise an expiry hint; in that case the
@@ -34,6 +41,7 @@ type TokenRecord struct {
 	Subject                   string
 	Audiences                 []string
 	ExpiresAt                 time.Time
+	ProviderAccessToken       string
 	ProviderRefreshToken      string
 	ProviderAccessExpiry      time.Time
 	RotationPermanentlyFailed bool
@@ -63,6 +71,12 @@ type TokenStore interface {
 	// must already exist (created by Save); otherwise the call is a no-op.
 	// Passing an empty providerRefreshToken clears the metadata.
 	SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error
+	// SaveProviderAccessToken attaches the upstream provider's access token
+	// (e.g. a GitHub token) to an existing entry, without disturbing any other
+	// field. The entry must already exist (created by Save); otherwise the
+	// call is a no-op. Used by builtin mode, where the map key is a
+	// gateway-issued JWT rather than the provider token itself.
+	SaveProviderAccessToken(token, providerAccessToken string) error
 	// Lookup returns metadata for a non-expired token, or (zero, false).
 	Lookup(token string) (TokenRecord, bool)
 	// SaveNonce attaches the OIDC nonce to an existing entry so it can be
@@ -93,6 +107,7 @@ type memEntry struct {
 	subject                   string
 	audiences                 []string
 	expiresAt                 time.Time
+	providerAccessToken       string
 	providerRefreshToken      string
 	providerAccessExpiry      time.Time
 	rotationPermanentlyFailed bool
@@ -144,6 +159,22 @@ func (m *memTokenStore) SaveProviderRefresh(token, providerRefreshToken string, 
 	return nil
 }
 
+// SaveProviderAccessToken attaches the provider access token to an existing
+// entry. If no entry exists (or it has expired), the call is a no-op so we
+// never resurrect a swept token by side effect.
+func (m *memTokenStore) SaveProviderAccessToken(token, providerAccessToken string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := m.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+	entry.providerAccessToken = providerAccessToken
+	m.entries[key] = entry
+	return nil
+}
+
 func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -155,6 +186,7 @@ func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 		Subject:                   e.subject,
 		Audiences:                 cloneStrings(e.audiences),
 		ExpiresAt:                 e.expiresAt,
+		ProviderAccessToken:       e.providerAccessToken,
 		ProviderRefreshToken:      e.providerRefreshToken,
 		ProviderAccessExpiry:      e.providerAccessExpiry,
 		RotationPermanentlyFailed: e.rotationPermanentlyFailed,
@@ -223,6 +255,7 @@ type fileEntry struct {
 	Subject              string    `json:"s"`
 	Audiences            []string  `json:"aud,omitempty"`
 	ExpiresAt            time.Time `json:"e"`
+	ProviderAccessToken  string    `json:"pat,omitempty"`
 	ProviderRefreshToken string    `json:"prt,omitempty"`
 	ProviderAccessExpiry time.Time `json:"pae,omitempty"`
 	RotationFailed       bool      `json:"rf,omitempty"`
@@ -338,6 +371,28 @@ func (f *fileTokenStore) SaveProviderRefresh(token, providerRefreshToken string,
 	return nil
 }
 
+// SaveProviderAccessToken updates the provider access token on an existing
+// entry. If the entry is missing or expired the call is a no-op and the file
+// is NOT rewritten. Failure to flush rolls back the in-memory mutation so
+// disk and memory remain consistent.
+func (f *fileTokenStore) SaveProviderAccessToken(token, providerAccessToken string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.ProviderAccessToken = providerAccessToken
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
+}
+
 func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -349,6 +404,7 @@ func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 		Subject:                   e.Subject,
 		Audiences:                 cloneStrings(e.Audiences),
 		ExpiresAt:                 e.ExpiresAt,
+		ProviderAccessToken:       e.ProviderAccessToken,
 		ProviderRefreshToken:      e.ProviderRefreshToken,
 		ProviderAccessExpiry:      e.ProviderAccessExpiry,
 		RotationPermanentlyFailed: e.RotationFailed,
@@ -514,6 +570,20 @@ type RefreshTokenStore interface {
 	// absent, expired, or nonce was never set. Returns the nonce even for
 	// soft-revoked (already-rotated) entries so it can be read after ReserveRefreshToken.
 	LookupNonce(refreshToken string) string
+	// SaveProviderAccessToken attaches the upstream provider's access token
+	// (e.g. a GitHub token) to an existing refresh-token entry, so it survives
+	// past the access token's TTL. The access-token TokenStore entry (builtin
+	// mode: a gateway JWT) can be swept before its refresh token expires
+	// (refresh tokens carry a 30-day grace period beyond the access token
+	// TTL), so this is the only reliable place to recover the provider token
+	// when tokenRefresh runs during that gap. No-op when entry is absent or
+	// expired.
+	SaveProviderAccessToken(refreshToken, providerAccessToken string) error
+	// LookupProviderAccessToken returns the provider access token stored for
+	// refreshToken, or "" when absent, expired, or never set. Returns the
+	// value even for soft-revoked (already-rotated) entries so it can be read
+	// after ReserveRefreshToken, mirroring LookupNonce.
+	LookupProviderAccessToken(refreshToken string) string
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
 	Sweep() error
 }
@@ -521,12 +591,13 @@ type RefreshTokenStore interface {
 // ── in-memory RefreshTokenStore ───────────────────────────────────────────────
 
 type memRTEntry struct {
-	accessToken string
-	audience    string
-	familyID    string
-	expiresAt   time.Time
-	revoked     bool
-	nonce       string
+	accessToken         string
+	audience            string
+	familyID            string
+	expiresAt           time.Time
+	revoked             bool
+	nonce               string
+	providerAccessToken string
 }
 
 type memRefreshTokenStore struct {
@@ -620,6 +691,29 @@ func (m *memRefreshTokenStore) LookupNonce(refreshToken string) string {
 	return e.nonce
 }
 
+func (m *memRefreshTokenStore) SaveProviderAccessToken(refreshToken, providerAccessToken string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(refreshToken)
+	e, ok := m.entries[key]
+	if !ok || time.Now().After(e.expiresAt) {
+		return nil
+	}
+	e.providerAccessToken = providerAccessToken
+	m.entries[key] = e
+	return nil
+}
+
+func (m *memRefreshTokenStore) LookupProviderAccessToken(refreshToken string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.expiresAt) {
+		return ""
+	}
+	return e.providerAccessToken
+}
+
 func (m *memRefreshTokenStore) Delete(refreshToken string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -646,12 +740,13 @@ func (m *memRefreshTokenStore) Sweep() error {
 // appear in the file. The plaintext access token is stored as the value because
 // the gateway must re-present it to the upstream provider on token refresh.
 type fileRTEntry struct {
-	AccessToken string    `json:"a"`
-	Audience    string    `json:"aud,omitempty"`
-	FamilyID    string    `json:"fid,omitempty"`
-	ExpiresAt   time.Time `json:"e"`
-	Revoked     bool      `json:"rv,omitempty"`
-	Nonce       string    `json:"n,omitempty"`
+	AccessToken         string    `json:"a"`
+	Audience            string    `json:"aud,omitempty"`
+	FamilyID            string    `json:"fid,omitempty"`
+	ExpiresAt           time.Time `json:"e"`
+	Revoked             bool      `json:"rv,omitempty"`
+	Nonce               string    `json:"n,omitempty"`
+	ProviderAccessToken string    `json:"pat,omitempty"`
 }
 
 type fileRefreshTokenStore struct {
@@ -811,6 +906,34 @@ func (f *fileRefreshTokenStore) LookupNonce(refreshToken string) string {
 		return ""
 	}
 	return e.Nonce
+}
+
+func (f *fileRefreshTokenStore) SaveProviderAccessToken(refreshToken, providerAccessToken string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(refreshToken)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.ProviderAccessToken = providerAccessToken
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
+}
+
+func (f *fileRefreshTokenStore) LookupProviderAccessToken(refreshToken string) string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	e, ok := f.entries[tokenKey(refreshToken)]
+	if !ok || time.Now().After(e.ExpiresAt) {
+		return ""
+	}
+	return e.ProviderAccessToken
 }
 
 func (f *fileRefreshTokenStore) Delete(refreshToken string) error {

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 	family_id    TEXT    NOT NULL DEFAULT '',
 	expires_at   INTEGER NOT NULL,
 	revoked      INTEGER NOT NULL DEFAULT 0,
-	nonce        TEXT    NOT NULL DEFAULT ''
+	nonce        TEXT    NOT NULL DEFAULT '',
+	provider_access_token TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_rt_family  ON refresh_tokens (family_id) WHERE revoked = 0;
 CREATE INDEX IF NOT EXISTS idx_rt_expires ON refresh_tokens (expires_at);
@@ -42,10 +43,12 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("initialising SQLite refresh token store schema: %w", err)
 	}
-	// Add nonce column to existing databases created before this field was introduced.
-	// ALTER TABLE ADD COLUMN is idempotent in SQLite when the column already exists
-	// (returns "duplicate column name" which we intentionally ignore).
+	// Add nonce/provider_access_token columns to existing databases created before
+	// these fields were introduced. ALTER TABLE ADD COLUMN is idempotent in SQLite
+	// when the column already exists (returns "duplicate column name" which we
+	// intentionally ignore).
 	_, _ = db.Exec(`ALTER TABLE refresh_tokens ADD COLUMN nonce TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE refresh_tokens ADD COLUMN provider_access_token TEXT NOT NULL DEFAULT ''`)
 	if path != ":memory:" {
 		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
 			slog.Warn("SQLite refresh token store chmod failed", "path", path, "err", err)
@@ -146,6 +149,26 @@ func (s *sqliteRefreshTokenStore) LookupNonce(refreshToken string) string {
 		tokenKey(refreshToken), time.Now().Unix(),
 	).Scan(&nonce)
 	return nonce
+}
+
+func (s *sqliteRefreshTokenStore) SaveProviderAccessToken(refreshToken, providerAccessToken string) error {
+	_, err := s.db.Exec(
+		`UPDATE refresh_tokens SET provider_access_token = ? WHERE token_hash = ? AND expires_at > ?`,
+		providerAccessToken, tokenKey(refreshToken), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving refresh token provider access token: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteRefreshTokenStore) LookupProviderAccessToken(refreshToken string) string {
+	var providerAccessToken string
+	_ = s.db.QueryRow(
+		`SELECT provider_access_token FROM refresh_tokens WHERE token_hash = ? AND expires_at > ?`,
+		tokenKey(refreshToken), time.Now().Unix(),
+	).Scan(&providerAccessToken)
+	return providerAccessToken
 }
 
 func (s *sqliteRefreshTokenStore) Delete(refreshToken string) error {

--- a/internal/auth/tokenstore_sqlite_migrate.go
+++ b/internal/auth/tokenstore_sqlite_migrate.go
@@ -40,6 +40,10 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 
 	// Wrap all inserts in a single transaction: atomic and significantly faster
 	// than one fsync per row when the entry count is large.
+	//
+	// provider_access_token is intentionally omitted from the column list below:
+	// legacy fileRTEntry never had this field, and the schema's
+	// DEFAULT '' fills it in automatically for every migrated row.
 	tx, err := sq.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return fmt.Errorf("beginning migration transaction: %w", err)

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -1,11 +1,14 @@
 package auth
 
 import (
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func tempSQLitePath(t *testing.T) string {
@@ -64,6 +67,89 @@ func TestSQLiteRefreshTokenStorePersistence(t *testing.T) {
 	}
 	if at != "at-persist" || aud != "aud" || fid != "fid-p" {
 		t.Errorf("Lookup after reopen: got at=%q aud=%q fid=%q", at, aud, fid)
+	}
+}
+
+// TestSQLiteRefreshTokenStoreProviderAccessTokenPersists verifies that the
+// provider access token (builtin mode's GitHub token, recovered via
+// SaveProviderAccessToken/LookupProviderAccessToken) survives a store reopen.
+func TestSQLiteRefreshTokenStoreProviderAccessTokenPersists(t *testing.T) {
+	path := tempSQLitePath(t)
+	exp := time.Now().Add(time.Hour)
+
+	rts1, err := NewSQLiteRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := rts1.Save("rt-pat-persist", "jwt-persist", "aud", "fid-pat", exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := rts1.SaveProviderAccessToken("rt-pat-persist", "gho_persist1"); err != nil {
+		t.Fatalf("SaveProviderAccessToken: %v", err)
+	}
+	rts1.(*sqliteRefreshTokenStore).Close() //nolint — close before reopening
+
+	rts2, err := NewSQLiteRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	closeSQLiteStore(t, rts2)
+	if got := rts2.LookupProviderAccessToken("rt-pat-persist"); got != "gho_persist1" {
+		t.Errorf("LookupProviderAccessToken after reopen: got %q, want %q", got, "gho_persist1")
+	}
+}
+
+// TestSQLiteRefreshTokenStoreProviderAccessTokenColumnMigration verifies that
+// opening a database created before the provider_access_token column existed
+// does not fail, and that the column becomes usable afterward (idempotent
+// ALTER TABLE ADD COLUMN).
+func TestSQLiteRefreshTokenStoreProviderAccessTokenColumnMigration(t *testing.T) {
+	path := tempSQLitePath(t)
+
+	// Simulate a pre-migration database: create the table without the
+	// provider_access_token column (as it existed before scottlz0310/mcp-gateway#188).
+	preSchema := `
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+	token_hash   TEXT    PRIMARY KEY,
+	access_token TEXT    NOT NULL,
+	audience     TEXT    NOT NULL DEFAULT '',
+	family_id    TEXT    NOT NULL DEFAULT '',
+	expires_at   INTEGER NOT NULL,
+	revoked      INTEGER NOT NULL DEFAULT 0,
+	nonce        TEXT    NOT NULL DEFAULT ''
+);`
+	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("opening raw sqlite db: %v", err)
+	}
+	if _, err := db.Exec(preSchema); err != nil {
+		t.Fatalf("creating pre-migration schema: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO refresh_tokens (token_hash, access_token, expires_at) VALUES (?, ?, ?)`,
+		tokenKey("rt-premigration"), "jwt-premigration", time.Now().Add(time.Hour).Unix(),
+	); err != nil {
+		t.Fatalf("inserting pre-migration row: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing raw sqlite db: %v", err)
+	}
+
+	// NewSQLiteRefreshTokenStore must migrate the schema without error and
+	// leave the pre-existing row's provider_access_token as the column default.
+	rts, err := NewSQLiteRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteRefreshTokenStore on pre-migration db: %v", err)
+	}
+	closeSQLiteStore(t, rts)
+	if got := rts.LookupProviderAccessToken("rt-premigration"); got != "" {
+		t.Errorf("pre-migration row provider_access_token: got %q, want empty default", got)
+	}
+	if err := rts.SaveProviderAccessToken("rt-premigration", "gho_postmigration"); err != nil {
+		t.Fatalf("SaveProviderAccessToken after migration: %v", err)
+	}
+	if got := rts.LookupProviderAccessToken("rt-premigration"); got != "gho_postmigration" {
+		t.Errorf("post-migration write: got %q, want %q", got, "gho_postmigration")
 	}
 }
 

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -81,6 +81,7 @@ func TestSQLiteRefreshTokenStoreProviderAccessTokenPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open 1: %v", err)
 	}
+	closeSQLiteStore(t, rts1)
 	if err := rts1.Save("rt-pat-persist", "jwt-persist", "aud", "fid-pat", exp); err != nil {
 		t.Fatalf("Save: %v", err)
 	}

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -101,6 +101,30 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 	if err := ts.SaveNonce("tok-expired-nonce", "nonce-xyz"); err != nil {
 		t.Fatalf("SaveNonce on expired token returned error: %v", err)
 	}
+
+	// SaveProviderAccessToken attaches the provider token to an existing entry;
+	// Lookup returns it.
+	if err := ts.Save("tok-pat", "frank", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save tok-pat: %v", err)
+	}
+	if err := ts.SaveProviderAccessToken("tok-pat", "gho_abc123"); err != nil {
+		t.Fatalf("SaveProviderAccessToken: %v", err)
+	}
+	recPAT, okPAT := ts.Lookup("tok-pat")
+	if !okPAT {
+		t.Fatal("Lookup tok-pat: expected hit after SaveProviderAccessToken")
+	}
+	if recPAT.ProviderAccessToken != "gho_abc123" {
+		t.Errorf("SaveProviderAccessToken: ProviderAccessToken got %q, want %q", recPAT.ProviderAccessToken, "gho_abc123")
+	}
+
+	// SaveProviderAccessToken on absent token is a no-op (no error, no entry created).
+	if err := ts.SaveProviderAccessToken("no-such-token", "gho_ghost"); err != nil {
+		t.Fatalf("SaveProviderAccessToken on absent token returned error: %v", err)
+	}
+	if _, ok := ts.Lookup("no-such-token"); ok {
+		t.Error("SaveProviderAccessToken must not create an entry for an unknown token")
+	}
 }
 
 // ── memTokenStore ─────────────────────────────────────────────────────────────
@@ -366,6 +390,36 @@ func TestFileTokenStoreSaveProviderRefreshFlushFailureRollsBack(t *testing.T) {
 	}
 }
 
+// TestFileTokenStoreProviderAccessTokenRoundTrip verifies that the provider
+// access token persisted via SaveProviderAccessToken survives a reload of the
+// FileTokenStore. This is the on-disk contract EnsureFreshAccessTokenForSubject
+// relies on to recover a builtin-mode GitHub token after a gateway restart.
+func TestFileTokenStoreProviderAccessTokenRoundTrip(t *testing.T) {
+	path := tempStorePath(t)
+	ts1, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("initial NewFileTokenStore: %v", err)
+	}
+	if err := ts1.Save("jwt-host", "alice", []string{"https://gw.example/mcp"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ts1.SaveProviderAccessToken("jwt-host", "gho_alice1"); err != nil {
+		t.Fatalf("SaveProviderAccessToken: %v", err)
+	}
+
+	ts2, err := NewFileTokenStore(path)
+	if err != nil {
+		t.Fatalf("reloaded NewFileTokenStore: %v", err)
+	}
+	rec, ok := ts2.Lookup("jwt-host")
+	if !ok {
+		t.Fatal("after reload: expected cache hit for jwt-host")
+	}
+	if rec.ProviderAccessToken != "gho_alice1" {
+		t.Errorf("provider access token after reload: got %q, want %q", rec.ProviderAccessToken, "gho_alice1")
+	}
+}
+
 // TestFileTokenStoreExpiredNotLoaded verifies that expired entries written before
 // a reload do not surface after the reload's startup sweep.
 func TestFileTokenStoreExpiredNotLoaded(t *testing.T) {
@@ -567,6 +621,41 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	}
 	if got := rts.LookupNonce("rt-nonce-exp"); got != "" {
 		t.Errorf("LookupNonce on expired: got %q, want empty", got)
+	}
+
+	// SaveProviderAccessToken attaches a provider token to an existing RT
+	// entry; LookupProviderAccessToken returns it.
+	if err := rts.Save("rt-pat", "access-tok-pat", "", "fid-pat", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-pat: %v", err)
+	}
+	if err := rts.SaveProviderAccessToken("rt-pat", "gho_pat1"); err != nil {
+		t.Fatalf("SaveProviderAccessToken: %v", err)
+	}
+	if got := rts.LookupProviderAccessToken("rt-pat"); got != "gho_pat1" {
+		t.Errorf("LookupProviderAccessToken: got %q, want %q", got, "gho_pat1")
+	}
+	// LookupProviderAccessToken returns "" for unknown token.
+	if got := rts.LookupProviderAccessToken("no-such-rt"); got != "" {
+		t.Errorf("LookupProviderAccessToken on absent: got %q, want empty", got)
+	}
+	// SaveProviderAccessToken on absent token is a no-op (no error).
+	if err := rts.SaveProviderAccessToken("no-such-rt", "gho_ghost"); err != nil {
+		t.Fatalf("SaveProviderAccessToken on absent returned error: %v", err)
+	}
+	// LookupProviderAccessToken remains readable after soft-revocation (Revoke),
+	// mirroring LookupNonce: tokenRefresh reads it via ReserveRefreshToken,
+	// which soft-revokes rather than deletes.
+	if err := rts.Save("rt-pat-revoked", "access-tok-rev", "", "fid-rev", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-pat-revoked: %v", err)
+	}
+	if err := rts.SaveProviderAccessToken("rt-pat-revoked", "gho_rev1"); err != nil {
+		t.Fatalf("SaveProviderAccessToken rt-pat-revoked: %v", err)
+	}
+	if err := rts.Revoke("rt-pat-revoked"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if got := rts.LookupProviderAccessToken("rt-pat-revoked"); got != "gho_rev1" {
+		t.Errorf("LookupProviderAccessToken after Revoke: got %q, want %q (soft-revoked entries must remain readable)", got, "gho_rev1")
 	}
 }
 
@@ -779,12 +868,14 @@ func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, string, time.
 func (f *alwaysFailRefreshStore) LookupAny(_ string) (string, string, string, time.Time, bool, bool) {
 	return "", "", "", time.Time{}, false, false
 }
-func (f *alwaysFailRefreshStore) Revoke(_ string) error          { return nil }
-func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error    { return nil }
-func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error    { return nil }
-func (f *alwaysFailRefreshStore) LookupNonce(_ string) string    { return "" }
-func (f *alwaysFailRefreshStore) Delete(_ string) error          { return errInjectedStoreFailure }
-func (f *alwaysFailRefreshStore) Sweep() error                   { return nil }
+func (f *alwaysFailRefreshStore) Revoke(_ string) error                     { return nil }
+func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error               { return nil }
+func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error               { return nil }
+func (f *alwaysFailRefreshStore) LookupNonce(_ string) string               { return "" }
+func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error { return nil }
+func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string { return "" }
+func (f *alwaysFailRefreshStore) Delete(_ string) error                     { return errInjectedStoreFailure }
+func (f *alwaysFailRefreshStore) Sweep() error                              { return nil }
 
 // testRefreshTokenStoreReuseDetection exercises LookupAny and RevokeFamily on
 // the given RefreshTokenStore.  It is shared across in-memory and file-backed


### PR DESCRIPTION
## 概要

review-raven#87 の spike 調査（[review-raven#88](https://github.com/scottlz0310/review-raven/pull/88)）で特定された根本原因の修正。

builtin mode（`OAUTH_PROVIDER=builtin`、GitHub ソーシャルログイン + gateway 自身が RS256 JWT を発行するモード）では、token 交換時に GitHub provider アクセストークンが identity 解決にのみ使われて破棄され、トークンストアには gateway 発行 JWT しか残っていなかった。

その結果 Phase B delegated-access の中核 `EnsureFreshAccessTokenForSubject`（`upstream_provider_token=true` ルートと `/internal/v1/whoami` の両方が依存）が「provider トークン」として **gateway JWT を返してしまい**、review-raven 等の upstream がそれを GitHub API にそのまま渡して 401 を受け、利用者に無関係な「再認証してください」を報告していた。GitHub 側の認証は一度も失効していない。

## 変更内容

- `TokenRecord.ProviderAccessToken` を追加し、auth-code / device / refresh の各 grant で GitHub アクセストークンを gateway JWT に紐付けて保存・引き継ぐ
- `refresh_token` grant は 30 日の猶予期間が access-token キャッシュの TTL を超えて生存する設計のため、refresh token ストア側にも provider アクセストークンを保存し、旧 JWT の record が既に sweep 済みでも復元可能にする（既存の OIDC nonce と同じパターン）
- `ValidateToken` のキャッシュヒット分岐で builtin mode の場合は非 builtin 用 rotation を呼ばないようガードを追加。将来 rotation を実装した際に GitHub トークンが `upstream_provider_token` 未設定の通常ルートにまで漏洩しうる経路を事前に塞ぐ安全網
- `EnsureFreshAccessTokenForSubject` は builtin mode で `record.ProviderAccessToken` を返す。空の場合（本 PR 適用前に発行された JWT）は `ErrSubjectNotFound` で安全側に倒す
- `docs/configuration.md` — builtin mode でも `github_refresh_enabled` の設定に関わらず GitHub アクセストークンが常に永続化される旨を追記
- CHANGELOG.md / CHANGELOG.ja.md 更新

## スコープ外（follow-up issue 起票済み）

rotation（GitHub Apps の "Expire user authorization tokens" 運用向け対応）は独立した enhancement のため、[#190](https://github.com/scottlz0310/mcp-gateway/issues/190) に切り出した。

- `builtinProvider.RefreshToken` は現状 `ErrRefreshNotSupported` を常に返すハードコード実装。rotation を機能させるには GitHub OAuth への委譲実装が別途必要
- builtin mode 専用の rotation ロジック（cache key = JWT を変えずに record 内の provider フィールドだけ更新する設計。既存の非builtin用 rotation とは非互換）
- `ProviderRefreshToken` / `ProviderAccessExpiry` の refresh_token grant 経由の引き継ぎ（rotation が無ければ意味を持たない）

## テスト

- ストレージ層: `tokenstore_test.go`（mem/file `TokenStore`・`RefreshTokenStore` 契約テストに `SaveProviderAccessToken`/`LookupProviderAccessToken` ケース追加、soft-revoked entry からの読み出しを含む）、`tokenstore_sqlite_test.go`（永続化ラウンドトリップ、既存 DB への冪等マイグレーション確認）
- delegated access: `delegated_access_test.go` に builtin mode 用テスト2件追加
  - `TestEnsureFreshAccessTokenForSubject_BuiltinReturnsProviderTokenNotJWT` — issue の直接回帰テスト
  - `TestEnsureFreshAccessTokenForSubject_BuiltinLegacyRecordWithoutProviderToken` — 移行期間中の安全側フォールバック確認
- handler 統合テスト: `handler_test.go` に5件追加
  - `TestBuiltinTokenAuthCodePersistsProviderAccessToken`
  - `TestBuiltinDeviceGrantPersistsProviderAccessToken`
  - `TestBuiltinTokenRefreshCarriesForwardProviderAccessToken`
  - `TestBuiltinTokenRefreshCarriesForwardAfterOldRecordSwept` — refresh token 猶予期間ギャップの回帰テスト
  - `TestValidateToken_BuiltinModeDoesNotRotateOnCacheHit` — セキュリティガードの回帰テスト

`go build ./...` / `go vet ./...` / `go test ./...` 全て pass。lefthook の pre-commit（vet）・pre-push（test/build/lint）も通過。

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)