### PR TITLE
feat(auth): RFC 7009 トークン失効エンドポイント (/revoke) を実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- RFC 7009 OAuth 2.0 Token Revocation (`POST /revoke`) を実装 ([#192](https://github.com/scottlz0310/mcp-gateway/issues/192))
+  - `token` + 任意 `token_type_hint`（`access_token`/`refresh_token`）を受け付け、hint に関わらず両方の失効経路を試行する。未知・期限切れ・二重失効のトークンでも常に `200 OK` を返す（RFC 7009 §2.2）
+  - refresh token の失効は既存の RFC 6819 family 失効（`RevokeFamily`）を再利用し、ファミリー全体を無効化する
+  - builtin mode（`OAUTH_PROVIDER=builtin`）の gateway JWT は、`jti` クレームによる失効 denylist を新設して即時失効に対応。JWT 検証はステートレスなため、TokenStore からのキャッシュ削除だけでは有効期限（デフォルト 90 日）まで生き続けてしまう問題を解消した。denylist は `RefreshTokenStore` の SQLite DB（`tokens.json.refresh.db`）に相乗りし、既存の Sweep サイクルで自然に失効エントリを掃除する
+  - refresh token の失効時は、紐づく現行アクセストークン（gateway JWT）の `jti` も即座に denylist へ登録し、将来のローテーションだけでなく既発行トークンも即時失効させる
+  - `.well-known/oauth-authorization-server` の discovery メタデータに `revocation_endpoint` を追加
+  - non-builtin mode（GitHub トークンを直接使用）ではゲートウェイ側のローカルキャッシュのみ失効させる。GitHub 側のトークン自体の失効 API 呼び出しはスコープ外（別 issue で検討）
 - `Mcp-Session-Id` 双方向透過の回帰テストと診断ログ・トラブルシュート手順を追加 ([#182](https://github.com/scottlz0310/mcp-gateway/issues/182))
   - `proxy request` / `proxy response` ログに `mcp_session_id_present` フィールドを追加（セッション ID の実値はログに出力しない）
   - `handler_test.go` に request・response 双方向透過の回帰テスト追加

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -280,6 +280,7 @@ func main() {
 	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
 	mux.HandleFunc("GET /callback", oauthHandler.Callback)
 	mux.HandleFunc("POST /token", oauthHandler.Token)
+	mux.HandleFunc("POST /revoke", oauthHandler.Revoke)
 	mux.HandleFunc("POST /register", oauthHandler.Register)
 	mux.HandleFunc("POST /device_authorization", oauthHandler.DeviceAuthorize)
 	mux.HandleFunc("GET /activate", oauthHandler.Activate)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -378,6 +378,7 @@ MCP_GATEWAY_TRUSTED_PROXIES=127.0.0.1/32,10.0.0.0/8
 | `/callback` | GET | GitHub OAuth コールバック。 |
 | `/device_authorization` | POST | Device Authorization Grant エンドポイント（RFC 8628）。 |
 | `/token` | POST | authorization code + PKCE・device code・refresh token grant 用トークンエンドポイント。 |
+| `/revoke` | POST | RFC 7009 トークン失効エンドポイント。`token` + 任意 `token_type_hint`（`access_token`/`refresh_token`）を受け付ける。refresh token の失効はファミリー全体（RFC 6819 reuse detection と同じ仕組み）と、builtin mode ではそのファミリーに紐づく現行アクセストークン（gateway JWT）の即時失効も行う。未知・期限切れ・二重失効のトークンでも常に 200 を返す（RFC 7009 §2.2）。 |
 | `/register` | POST | RFC 7591 形式の動的クライアント登録。 |
 | `/jwks` | GET | JSON Web Key Set（gateway が OIDC Provider として動作する場合）。 |
 | `/userinfo` | GET | OIDC UserInfo エンドポイント。 |

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -870,6 +870,17 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		// Propagate the same familyID so the token lineage remains traceable.
 		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
+			// newGatewayToken was already cached (with its provider access
+			// token, nonce, and jti, and indexed under sub) above, but the
+			// client is about to receive an error response and will never see
+			// it. Left as-is, the orphaned TokenRecord would remain reachable
+			// via EnsureFreshAccessTokenForSubject (Phase B delegated access),
+			// which resolves subjects via the subject index regardless of
+			// whether the token was ever handed to a client — silently
+			// keeping delegated access (including the live provider access
+			// token) alive after a concurrent /revoke. Invalidate it in both
+			// branches below so no unpublished record survives this failure.
+			h.store.InvalidateCachedToken(newGatewayToken)
 			if errors.Is(rtErr, ErrRefreshTokenFamilyRevoked) {
 				// The family was revoked (POST /revoke) concurrently with this
 				// rotation. RestoreRefreshToken below is a no-op for the same
@@ -1899,17 +1910,21 @@ func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
 		if err := h.store.RevokeSingleRefreshToken(token); err != nil {
 			storeErr = errors.Join(storeErr, fmt.Errorf("revoking refresh token: %w", err))
 		}
-		// Resolve the family's currently active access token BEFORE
-		// RevokeRefreshTokenFamily marks every row revoked: if the presented
-		// token is a stale, already-rotated predecessor, its own accessToken
-		// field points at an earlier JWT, not the one actually in use today.
+		// currentAccessToken falls back to the presented token's own row
+		// value, used only when familyID is empty (no family-level pointer
+		// to consult). When familyID is non-empty, RevokeRefreshTokenFamily's
+		// return value is the sole source of truth: it is read atomically
+		// with the tombstone write (see its doc comment), which a separate
+		// "look up the active row, then revoke the family" sequence cannot
+		// guarantee — a rotation's Save could otherwise commit a newer
+		// access token between those two steps and never get denylisted.
 		currentAccessToken := accessToken
 		if familyID != "" {
-			if active, ok := h.store.LookupActiveRefreshTokenAccessToken(familyID); ok {
-				currentAccessToken = active
-			}
-			if err := h.store.RevokeRefreshTokenFamily(familyID); err != nil {
+			active, err := h.store.RevokeRefreshTokenFamily(familyID)
+			if err != nil {
 				storeErr = errors.Join(storeErr, fmt.Errorf("revoking refresh token family: %w", err))
+			} else if active != "" {
+				currentAccessToken = active
 			}
 		}
 		// RevokeRefreshTokenFamily only blocks *future* rotations — the

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -330,6 +330,7 @@ func (h *Handler) Discovery(w http.ResponseWriter, r *http.Request) {
 		"token_endpoint":                   h.cfg.BaseURL + "/token",
 		"registration_endpoint":            h.cfg.BaseURL + "/register",
 		"device_authorization_endpoint":    h.cfg.BaseURL + "/device_authorization",
+		"revocation_endpoint":              h.cfg.BaseURL + "/revoke",
 		"response_types_supported":         []string{"code"},
 		"grant_types_supported":            []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
 		"code_challenge_methods_supported": []string{"S256"},
@@ -595,7 +596,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		// server-side, indexed under the JWT, so that EnsureFreshAccessTokenForSubject
 		// (Phase B delegated access) can still hand it to authorized background
 		// workers. See scottlz0310/mcp-gateway#188.
-		gatewayToken, genErr := h.generateGatewayAccessToken(result.Subject, result.Audience)
+		gatewayToken, jti, genErr := h.generateGatewayAccessToken(result.Subject, result.Audience)
 		if genErr != nil {
 			h.auditFailure("token_exchange", "server_error", "gateway access token generation failed", genErr, http.StatusInternalServerError, "")
 			slog.Error("gateway access token generation failed", "err", genErr)
@@ -605,6 +606,7 @@ func (h *Handler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		h.store.CacheToken(gatewayToken, result.Subject, result.Audience)
 		h.store.RecordProviderAccessToken(gatewayToken, result.AccessToken)
 		h.store.SaveTokenNonce(gatewayToken, result.Nonce)
+		h.store.SaveTokenJti(gatewayToken, jti)
 		familyID, fidErr := generateCode()
 		if fidErr != nil {
 			slog.Warn("failed to generate refresh token family ID", "err", fidErr)
@@ -685,9 +687,10 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		token := completed.AccessToken
+		var jti string
 		if h.isBuiltinMode() {
 			var genErr error
-			token, genErr = h.generateGatewayAccessToken(completed.Subject, completed.Audience)
+			token, jti, genErr = h.generateGatewayAccessToken(completed.Subject, completed.Audience)
 			if genErr != nil {
 				h.auditFailure("token_exchange", "server_error", "device grant token generation failed", genErr, http.StatusInternalServerError, "")
 				slog.Error("device grant token generation failed", "err", genErr)
@@ -702,6 +705,7 @@ func (h *Handler) tokenDeviceGrant(w http.ResponseWriter, r *http.Request) {
 			// EnsureFreshAccessTokenForSubject can still hand it to
 			// authorized background workers.
 			h.store.RecordProviderAccessToken(token, completed.AccessToken)
+			h.store.SaveTokenJti(token, jti)
 		}
 		h.persistProviderRefresh(completed.AccessToken, completed.ProviderRefreshToken, completed.ProviderAccessExpiry)
 		familyID, fidErr := generateCode()
@@ -838,15 +842,18 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 
 	if h.isBuiltinMode() {
 		// builtin mode: verify the existing gateway JWT locally to extract subject,
-		// then issue a new gateway JWT. GitHub API is not consulted.
-		sub, _, jwtErr := h.verifyGatewayJWT(accessToken)
+		// then issue a new gateway JWT. GitHub API is not consulted. Revocation
+		// of the old access token's jti (POST /revoke, token_type_hint=access_token)
+		// is intentionally not checked here: per RFC 7009, revoking an access
+		// token does not invalidate its refresh token grant.
+		sub, _, _, jwtErr := h.verifyGatewayJWT(accessToken)
 		if jwtErr != nil {
 			h.auditFailure("refresh", "invalid_grant", "refresh token gateway JWT invalid", jwtErr, http.StatusBadRequest, tokenFingerprint(accessToken))
 			slog.Warn("refresh rejected: gateway JWT invalid", "err", jwtErr)
 			oauthError(w, "invalid_grant", "underlying token no longer valid", http.StatusBadRequest)
 			return
 		}
-		newGatewayToken, genErr := h.generateGatewayAccessToken(sub, audience)
+		newGatewayToken, newJti, genErr := h.generateGatewayAccessToken(sub, audience)
 		if genErr != nil {
 			h.auditFailure("refresh", "server_error", "gateway token generation failed during refresh", genErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
 			slog.Error("gateway access token generation failed during refresh", "err", genErr)
@@ -859,6 +866,7 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 			h.store.RecordProviderAccessToken(newGatewayToken, providerAccessToken)
 		}
 		h.store.SaveTokenNonce(newGatewayToken, nonce)
+		h.store.SaveTokenJti(newGatewayToken, newJti)
 		// Propagate the same familyID so the token lineage remains traceable.
 		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
@@ -1127,6 +1135,16 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 	audience = normalizeAudience(audience)
 	record, cached := h.store.LookupToken(token)
 	if cached {
+		// builtin mode: a cache hit must still be rejected if the JWT's jti was
+		// added to the revocation denylist after it was cached (POST /revoke).
+		// Without this check, a revoked JWT would keep validating until the
+		// cache TTL expires (up to ExpiresIn, default 90 days).
+		if h.isBuiltinMode() && record.Jti != "" && h.store.IsJTIRevoked(record.Jti) {
+			h.store.InvalidateCachedToken(token)
+			revokedErr := fmt.Errorf("gateway JWT has been revoked")
+			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT revoked", revokedErr, http.StatusUnauthorized, tokenFingerprint(token))
+			return "", "", revokedErr
+		}
 		if err := h.validateAudience(token, record, audience); err != nil {
 			return "", "", err
 		}
@@ -1166,10 +1184,15 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 	// record on cache miss; validateAudience(token, TokenRecord{}, audience) would
 	// erroneously reject valid tokens when TokenAudienceStrict is enabled.
 	if h.isBuiltinMode() {
-		sub, tokenAud, jwtErr := h.verifyGatewayJWT(token)
+		sub, tokenAud, jti, jwtErr := h.verifyGatewayJWT(token)
 		if jwtErr != nil {
 			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT verification failed", jwtErr, http.StatusUnauthorized, tokenFingerprint(token))
 			return "", "", jwtErr
+		}
+		if jti != "" && h.store.IsJTIRevoked(jti) {
+			revokedErr := fmt.Errorf("gateway JWT has been revoked")
+			h.auditFailure("identity_resolution", "invalid_token", "gateway JWT revoked", revokedErr, http.StatusUnauthorized, tokenFingerprint(token))
+			return "", "", revokedErr
 		}
 		// Validate that the JWT audience matches the requested resource.
 		// normalizeAudience("") returns "" which means any audience is accepted.
@@ -1184,6 +1207,7 @@ func (h *Handler) ValidateToken(ctx context.Context, token, audience string) (su
 			cacheAudience = audience
 		}
 		h.store.CacheToken(token, sub, cacheAudience)
+		h.store.SaveTokenJti(token, jti)
 		h.auditSuccess("identity_resolution", "gateway JWT verified", http.StatusOK)
 		return sub, "", nil
 	}
@@ -1815,6 +1839,86 @@ func (h *Handler) UserInfo(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(doc)
 }
 
+// Revoke implements RFC 7009 OAuth 2.0 Token Revocation for POST /revoke.
+//
+// token_type_hint is accepted but not load-bearing: per RFC 7009 §2.1, a hint
+// that does not match the token's actual type must not cause the server to
+// skip the correct revocation path, so both the refresh-token and
+// access-token paths are always attempted regardless of the hint. Presenting
+// an unknown, already-expired, or already-revoked token is not an error (RFC
+// 7009 §2.2) — the endpoint always responds 200 with an empty body, so a
+// caller cannot use it to probe whether a token is currently valid.
+func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	if err := r.ParseForm(); err != nil {
+		h.auditFailure("revoke", "invalid_request", "revoke request body rejected", err, http.StatusBadRequest, "")
+		oauthError(w, "invalid_request", "malformed request body", http.StatusBadRequest)
+		return
+	}
+	token := r.FormValue("token")
+	if token == "" {
+		h.auditFailure("revoke", "invalid_request", "revoke request missing token", nil, http.StatusBadRequest, "")
+		oauthError(w, "invalid_request", "missing token", http.StatusBadRequest)
+		return
+	}
+
+	revokedSomething := false
+
+	// Refresh-token path. LookupAnyRefreshToken finds both active and
+	// soft-revoked (already-rotated) entries so a client presenting a token
+	// it no longer holds the "current" copy of still reaches its familyID.
+	if accessToken, _, familyID, _, _, ok := h.store.LookupAnyRefreshToken(token); ok {
+		revokedSomething = true
+		if familyID != "" {
+			if err := h.store.RevokeRefreshTokenFamily(familyID); err != nil {
+				slog.Warn("revoke: refresh token family revocation failed", "err", err)
+			}
+		}
+		// RevokeRefreshTokenFamily only blocks *future* rotations — the
+		// gateway JWT already issued for this family remains valid
+		// (stateless) until its own exp unless separately denylisted here.
+		if h.isBuiltinMode() && accessToken != "" {
+			h.revokeGatewayJWTIfValid(accessToken)
+		}
+	}
+
+	// Access-token path.
+	if h.isBuiltinMode() {
+		if h.revokeGatewayJWTIfValid(token) {
+			revokedSomething = true
+		}
+	} else if _, ok := h.store.LookupToken(token); ok {
+		h.store.InvalidateCachedToken(token)
+		revokedSomething = true
+	}
+
+	if revokedSomething {
+		h.auditSuccess("revoke", "token revoked", http.StatusOK)
+	} else {
+		h.auditSuccess("revoke", "revoke request for unknown or already-invalid token", http.StatusOK)
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+}
+
+// revokeGatewayJWTIfValid adds token's jti to the revocation denylist and
+// invalidates its cache entry, but only if token is a well-formed,
+// signature-valid, not-yet-expired gateway JWT. Returns false (no-op) for a
+// malformed or already-expired token: an expired token needs no denylist
+// entry since verifyGatewayJWT's own exp check already rejects it, and this
+// keeps the denylist bounded to tokens that would otherwise still validate.
+func (h *Handler) revokeGatewayJWTIfValid(token string) bool {
+	claims, err := h.parseGatewayJWTClaims(token)
+	if err != nil || claims.Jti == "" || claims.Exp <= 0 || time.Now().Unix() > claims.Exp {
+		return false
+	}
+	if err := h.store.RevokeJTI(claims.Jti, time.Unix(claims.Exp, 0)); err != nil {
+		slog.Warn("revoke: jti denylist write failed", "err", err)
+	}
+	h.store.InvalidateCachedToken(token)
+	return true
+}
+
 // isBuiltinMode reports whether the handler operates in builtin mode, where
 // the gateway issues its own RS256 JWTs instead of forwarding provider tokens.
 func (h *Handler) isBuiltinMode() bool {
@@ -1824,9 +1928,11 @@ func (h *Handler) isBuiltinMode() bool {
 // generateGatewayAccessToken creates a signed RS256 JWT suitable for use as
 // the client-facing access_token in builtin mode. Unlike generateIDToken it
 // uses h.cfg.ExpiresIn for the expiry so the lifetime matches the token store TTL.
-func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, error) {
+// It also returns the jti claim so the caller can persist it (TokenRecord.Jti)
+// for cache-hit revocation checks (see Store.SaveTokenJti).
+func (h *Handler) generateGatewayAccessToken(subject, audience string) (token, jti string, err error) {
 	if h.privateKey == nil {
-		return "", fmt.Errorf("private key is nil")
+		return "", "", fmt.Errorf("private key is nil")
 	}
 	header := map[string]string{
 		"alg": "RS256",
@@ -1835,7 +1941,7 @@ func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, 
 	}
 	headerBytes, err := json.Marshal(header)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	headerB64 := base64.RawURLEncoding.EncodeToString(headerBytes)
 
@@ -1846,19 +1952,20 @@ func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, 
 	}
 	jtiBytes := make([]byte, 16)
 	if _, err := rand.Read(jtiBytes); err != nil {
-		return "", fmt.Errorf("generating JWT ID: %w", err)
+		return "", "", fmt.Errorf("generating JWT ID: %w", err)
 	}
+	jti = base64.RawURLEncoding.EncodeToString(jtiBytes)
 	payload := map[string]any{
 		"iss": h.cfg.BaseURL,
 		"sub": subject,
 		"aud": audience,
 		"iat": now.Unix(),
 		"exp": now.Add(expiresIn).Unix(),
-		"jti": base64.RawURLEncoding.EncodeToString(jtiBytes),
+		"jti": jti,
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
 
@@ -1869,67 +1976,93 @@ func (h *Handler) generateGatewayAccessToken(subject, audience string) (string, 
 
 	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, h.privateKey, crypto.SHA256, hashed)
 	if err != nil {
-		return "", fmt.Errorf("signing gateway access token: %w", err)
+		return "", "", fmt.Errorf("signing gateway access token: %w", err)
 	}
-	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), nil
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sigBytes), jti, nil
 }
 
-// verifyGatewayJWT verifies a gateway-issued RS256 JWT and returns the subject
-// and audience claims. It validates alg, signature, exp (required), and sub.
-// Audience matching against the request resource is the caller's responsibility.
-func (h *Handler) verifyGatewayJWT(token string) (subject, audience string, err error) {
+// gatewayJWTClaims holds the claims of a gateway-issued RS256 JWT after
+// signature verification.
+type gatewayJWTClaims struct {
+	Sub string
+	Aud string
+	Jti string
+	Exp int64
+}
+
+// parseGatewayJWTClaims verifies the signature and alg of a gateway-issued
+// RS256 JWT and returns its claims, WITHOUT enforcing exp. Used by both
+// verifyGatewayJWT (which adds the exp check) and the /revoke handler, which
+// must accept an already-expired token as a no-op rather than an error (RFC
+// 7009 §2.2) — enforcing exp here would make that distinction impossible.
+func (h *Handler) parseGatewayJWTClaims(token string) (gatewayJWTClaims, error) {
 	parts := strings.SplitN(token, ".", 3)
 	if len(parts) != 3 {
-		return "", "", fmt.Errorf("malformed JWT: expected 3 parts")
+		return gatewayJWTClaims{}, fmt.Errorf("malformed JWT: expected 3 parts")
 	}
 
 	// Validate header: alg must be RS256.
 	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {
-		return "", "", fmt.Errorf("JWT header decode: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT header decode: %w", err)
 	}
 	var header struct {
 		Alg string `json:"alg"`
 	}
 	if err := json.Unmarshal(headerBytes, &header); err != nil {
-		return "", "", fmt.Errorf("JWT header parse: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT header parse: %w", err)
 	}
 	if header.Alg != "RS256" {
-		return "", "", fmt.Errorf("JWT alg must be RS256, got %q", header.Alg)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT alg must be RS256, got %q", header.Alg)
 	}
 
 	signingInput := parts[0] + "." + parts[1]
 	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
 	if err != nil {
-		return "", "", fmt.Errorf("JWT signature decode: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT signature decode: %w", err)
 	}
 	hasher := sha256.New()
 	hasher.Write([]byte(signingInput))
 	hashed := hasher.Sum(nil)
 	if err := rsa.VerifyPKCS1v15(&h.privateKey.PublicKey, crypto.SHA256, hashed, sigBytes); err != nil {
-		return "", "", fmt.Errorf("JWT signature invalid: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT signature invalid: %w", err)
 	}
 
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return "", "", fmt.Errorf("JWT payload decode: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT payload decode: %w", err)
 	}
 	var claims struct {
 		Sub string `json:"sub"`
 		Aud string `json:"aud"`
+		Jti string `json:"jti"`
 		Exp int64  `json:"exp"`
 	}
 	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
-		return "", "", fmt.Errorf("JWT payload parse: %w", err)
+		return gatewayJWTClaims{}, fmt.Errorf("JWT payload parse: %w", err)
 	}
 	if claims.Sub == "" {
-		return "", "", fmt.Errorf("JWT missing sub claim")
+		return gatewayJWTClaims{}, fmt.Errorf("JWT missing sub claim")
+	}
+	return gatewayJWTClaims{Sub: claims.Sub, Aud: claims.Aud, Jti: claims.Jti, Exp: claims.Exp}, nil
+}
+
+// verifyGatewayJWT verifies a gateway-issued RS256 JWT and returns the
+// subject, audience, and jti claims. It validates alg, signature, exp
+// (required), and sub. Audience matching against the request resource is the
+// caller's responsibility. Revocation (jti denylist) is checked by the caller
+// (ValidateToken), not here, since this function has no access to the
+// revocation store.
+func (h *Handler) verifyGatewayJWT(token string) (subject, audience, jti string, err error) {
+	claims, err := h.parseGatewayJWTClaims(token)
+	if err != nil {
+		return "", "", "", err
 	}
 	// exp is required in gateway-issued JWTs; absence or zero is rejected.
 	if claims.Exp <= 0 || time.Now().Unix() > claims.Exp {
-		return "", "", fmt.Errorf("JWT expired or missing exp claim")
+		return "", "", "", fmt.Errorf("JWT expired or missing exp claim")
 	}
-	return claims.Sub, claims.Aud, nil
+	return claims.Sub, claims.Aud, claims.Jti, nil
 }
 
 // generateIDToken creates a signed RS256 JWT for the given subject.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -870,6 +870,18 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 		// Propagate the same familyID so the token lineage remains traceable.
 		newRT, rtErr := h.store.CreateRefreshToken(newGatewayToken, audience, familyID, h.refreshTokenTTL())
 		if rtErr != nil {
+			if errors.Is(rtErr, ErrRefreshTokenFamilyRevoked) {
+				// The family was revoked (POST /revoke) concurrently with this
+				// rotation. RestoreRefreshToken below is a no-op for the same
+				// reason (Save also rejects the tombstoned family), so the
+				// reserved token stays gone — report the permanent, intentional
+				// nature of this outcome rather than a transient 500 that might
+				// invite a retry loop.
+				h.auditFailure("refresh", "invalid_grant", "refresh token family revoked concurrently with rotation", rtErr, http.StatusBadRequest, tokenFingerprint(newGatewayToken))
+				h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
+				oauthError(w, "invalid_grant", "refresh token has been revoked", http.StatusBadRequest)
+				return
+			}
 			h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(newGatewayToken))
 			slog.Error("failed to rotate refresh token (builtin)", "err", rtErr)
 			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
@@ -912,6 +924,12 @@ func (h *Handler) tokenRefresh(w http.ResponseWriter, r *http.Request) {
 	// Issue the rotated refresh token propagating familyID for reuse tracking.
 	newRT, rtErr := h.store.CreateRefreshToken(accessToken, audience, familyID, h.refreshTokenTTL())
 	if rtErr != nil {
+		if errors.Is(rtErr, ErrRefreshTokenFamilyRevoked) {
+			h.auditFailure("refresh", "invalid_grant", "refresh token family revoked concurrently with rotation", rtErr, http.StatusBadRequest, tokenFingerprint(accessToken))
+			h.store.RestoreRefreshToken(rt, accessToken, originalAudience, familyID, rtExpiresAt)
+			oauthError(w, "invalid_grant", "refresh token has been revoked", http.StatusBadRequest)
+			return
+		}
 		h.auditFailure("refresh", "store_error", "refresh token rotation failed", rtErr, http.StatusInternalServerError, tokenFingerprint(accessToken))
 		slog.Error("failed to rotate refresh token", "err", rtErr)
 		// Restore the original token (with its original audience) so the client can retry.
@@ -1846,8 +1864,11 @@ func (h *Handler) UserInfo(w http.ResponseWriter, r *http.Request) {
 // skip the correct revocation path, so both the refresh-token and
 // access-token paths are always attempted regardless of the hint. Presenting
 // an unknown, already-expired, or already-revoked token is not an error (RFC
-// 7009 §2.2) — the endpoint always responds 200 with an empty body, so a
-// caller cannot use it to probe whether a token is currently valid.
+// 7009 §2.2) — the endpoint responds 200 with an empty body for those cases,
+// so a caller cannot use it to probe whether a token is currently valid. A
+// genuine store write failure is different: it means revocation could not be
+// guaranteed, so it is surfaced as 500 rather than reported as success (see
+// revokeGatewayJWTIfValid).
 func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 	if err := r.ParseForm(); err != nil {
@@ -1863,33 +1884,63 @@ func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	revokedSomething := false
+	var storeErr error
 
 	// Refresh-token path. LookupAnyRefreshToken finds both active and
 	// soft-revoked (already-rotated) entries so a client presenting a token
 	// it no longer holds the "current" copy of still reaches its familyID.
 	if accessToken, _, familyID, _, _, ok := h.store.LookupAnyRefreshToken(token); ok {
 		revokedSomething = true
+		// Always revoke the presented token itself, independent of familyID:
+		// familyID can be empty when family-ID generation failed at issuance
+		// time (rare best-effort fallback in tokenAuthCode/tokenDeviceGrant),
+		// in which case RevokeRefreshTokenFamily below is a no-op and this
+		// call is the only thing that actually invalidates the presented token.
+		if err := h.store.RevokeSingleRefreshToken(token); err != nil {
+			storeErr = errors.Join(storeErr, fmt.Errorf("revoking refresh token: %w", err))
+		}
+		// Resolve the family's currently active access token BEFORE
+		// RevokeRefreshTokenFamily marks every row revoked: if the presented
+		// token is a stale, already-rotated predecessor, its own accessToken
+		// field points at an earlier JWT, not the one actually in use today.
+		currentAccessToken := accessToken
 		if familyID != "" {
+			if active, ok := h.store.LookupActiveRefreshTokenAccessToken(familyID); ok {
+				currentAccessToken = active
+			}
 			if err := h.store.RevokeRefreshTokenFamily(familyID); err != nil {
-				slog.Warn("revoke: refresh token family revocation failed", "err", err)
+				storeErr = errors.Join(storeErr, fmt.Errorf("revoking refresh token family: %w", err))
 			}
 		}
 		// RevokeRefreshTokenFamily only blocks *future* rotations — the
 		// gateway JWT already issued for this family remains valid
 		// (stateless) until its own exp unless separately denylisted here.
-		if h.isBuiltinMode() && accessToken != "" {
-			h.revokeGatewayJWTIfValid(accessToken)
+		if h.isBuiltinMode() && currentAccessToken != "" {
+			if _, err := h.revokeGatewayJWTIfValid(currentAccessToken); err != nil {
+				storeErr = errors.Join(storeErr, fmt.Errorf("revoking cascaded access token: %w", err))
+			}
 		}
 	}
 
 	// Access-token path.
 	if h.isBuiltinMode() {
-		if h.revokeGatewayJWTIfValid(token) {
+		revoked, err := h.revokeGatewayJWTIfValid(token)
+		if err != nil {
+			storeErr = errors.Join(storeErr, fmt.Errorf("revoking access token: %w", err))
+		}
+		if revoked {
 			revokedSomething = true
 		}
 	} else if _, ok := h.store.LookupToken(token); ok {
 		h.store.InvalidateCachedToken(token)
 		revokedSomething = true
+	}
+
+	if storeErr != nil {
+		h.auditFailure("revoke", "server_error", "token revocation could not be persisted", storeErr, http.StatusInternalServerError, tokenFingerprint(token))
+		slog.Error("revoke: store write failed", "err", storeErr)
+		oauthError(w, "server_error", "token revocation could not be persisted", http.StatusInternalServerError)
+		return
 	}
 
 	if revokedSomething {
@@ -1903,20 +1954,28 @@ func (h *Handler) Revoke(w http.ResponseWriter, r *http.Request) {
 
 // revokeGatewayJWTIfValid adds token's jti to the revocation denylist and
 // invalidates its cache entry, but only if token is a well-formed,
-// signature-valid, not-yet-expired gateway JWT. Returns false (no-op) for a
-// malformed or already-expired token: an expired token needs no denylist
-// entry since verifyGatewayJWT's own exp check already rejects it, and this
-// keeps the denylist bounded to tokens that would otherwise still validate.
-func (h *Handler) revokeGatewayJWTIfValid(token string) bool {
-	claims, err := h.parseGatewayJWTClaims(token)
-	if err != nil || claims.Jti == "" || claims.Exp <= 0 || time.Now().Unix() > claims.Exp {
-		return false
+// signature-valid, not-yet-expired gateway JWT.
+//
+// revoked=false, err=nil for a malformed or already-expired token: an
+// expired token needs no denylist entry since verifyGatewayJWT's own exp
+// check already rejects it, and this keeps the denylist bounded to tokens
+// that would otherwise still validate — this is the RFC 7009 §2.2 no-op
+// case, not an error.
+//
+// err != nil means token WAS a valid, currently-live JWT but the denylist
+// write failed. The caller must not report success in this case: a token
+// whose cache entry is deleted but whose jti was never durably denylisted
+// would simply re-validate (and re-cache) on the next request.
+func (h *Handler) revokeGatewayJWTIfValid(token string) (revoked bool, err error) {
+	claims, parseErr := h.parseGatewayJWTClaims(token)
+	if parseErr != nil || claims.Jti == "" || claims.Exp <= 0 || time.Now().Unix() > claims.Exp {
+		return false, nil
 	}
 	if err := h.store.RevokeJTI(claims.Jti, time.Unix(claims.Exp, 0)); err != nil {
-		slog.Warn("revoke: jti denylist write failed", "err", err)
+		return false, fmt.Errorf("jti denylist write failed: %w", err)
 	}
 	h.store.InvalidateCachedToken(token)
-	return true
+	return true, nil
 }
 
 // isBuiltinMode reports whether the handler operates in builtin mode, where

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1498,8 +1498,12 @@ func (d *deleteFailRefreshStore) SaveProviderAccessToken(rt, pat string) error {
 func (d *deleteFailRefreshStore) LookupProviderAccessToken(rt string) string {
 	return d.inner.LookupProviderAccessToken(rt)
 }
-func (d *deleteFailRefreshStore) Delete(_ string) error { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) Sweep() error          { return d.inner.Sweep() }
+func (d *deleteFailRefreshStore) RevokeJTI(jti string, exp time.Time) error {
+	return d.inner.RevokeJTI(jti, exp)
+}
+func (d *deleteFailRefreshStore) IsJTIRevoked(jti string) bool { return d.inner.IsJTIRevoked(jti) }
+func (d *deleteFailRefreshStore) Delete(_ string) error        { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) Sweep() error                 { return d.inner.Sweep() }
 
 // TestTokenRefreshDeleteFailed503 verifies that when the refresh token store
 // fails to delete the token during rotation (ErrRefreshTokenDeleteFailed),
@@ -1512,7 +1516,7 @@ func TestTokenRefreshDeleteFailed503(t *testing.T) {
 		Scopes:       "repo,user",
 	})
 
-	inner := &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
+	inner := &memRefreshTokenStore{entries: make(map[string]memRTEntry), revokedJTI: make(map[string]time.Time)}
 	failStore := &deleteFailRefreshStore{inner: inner}
 	_ = inner.Save("test-rt", "test-at", "http://localhost:8080/mcp", "fid-test", time.Now().Add(time.Hour))
 
@@ -3195,6 +3199,247 @@ func TestBuiltinTokenFlowIssuesGatewayJWT(t *testing.T) {
 	}
 }
 
+// issueBuiltinTokens drives the full authorize -> callback -> token exchange
+// flow in builtin mode and returns the issued gateway JWT (access_token) and
+// opaque refresh_token. subject is the identity the mock GitHub provider
+// resolves the flow to.
+func issueBuiltinTokens(t *testing.T, h *Handler, subject string) (accessToken, refreshToken string) {
+	t.Helper()
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := pkceChallenge(verifier)
+	state := "state-" + subject
+	const redirectURI = "http://localhost/cb"
+
+	authReq := httptest.NewRequest(http.MethodGet,
+		"/authorize?response_type=code&state="+state+"&redirect_uri="+url.QueryEscape(redirectURI)+
+			"&code_challenge="+challenge+"&code_challenge_method=S256", nil)
+	h.Authorize(httptest.NewRecorder(), authReq)
+
+	cbReq := httptest.NewRequest(http.MethodGet, "/callback?code=gh-code&state="+state, nil)
+	cbRec := httptest.NewRecorder()
+	h.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback: got %d; body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	redirectURL, err := url.Parse(cbRec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	internalCode := redirectURL.Query().Get("code")
+
+	tokenBody := "grant_type=authorization_code" +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&code=" + url.QueryEscape(internalCode) +
+		"&code_verifier=" + url.QueryEscape(verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(tokenBody))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	h.Token(tokenRec, tokenReq)
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token: got %d; body=%s", tokenRec.Code, tokenRec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(tokenRec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	accessToken, _ = resp["access_token"].(string)
+	refreshToken, _ = resp["refresh_token"].(string)
+	if accessToken == "" || refreshToken == "" {
+		t.Fatalf("token response missing access_token/refresh_token: %#v", resp)
+	}
+	return accessToken, refreshToken
+}
+
+// revokeRequest issues a POST /revoke with the given token and optional hint
+// and returns the recorder for assertions.
+func revokeRequest(h *Handler, token, hint string) *httptest.ResponseRecorder {
+	body := "token=" + url.QueryEscape(token)
+	if hint != "" {
+		body += "&token_type_hint=" + url.QueryEscape(hint)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.Revoke(rec, req)
+	return rec
+}
+
+func TestRevokeMissingTokenReturns400(t *testing.T) {
+	h := newTestHandler(t)
+	rec := revokeRequest(h, "", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// TestRevokeBuiltinAccessTokenRejectsCacheMiss verifies that revoking a
+// gateway JWT (builtin mode) via token_type_hint=access_token causes a
+// subsequent ValidateToken cache-miss verification to fail, even though the
+// JWT's own exp claim has not yet passed.
+func TestRevokeBuiltinAccessTokenRejectsCacheMiss(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, _ := issueBuiltinTokens(t, h, "alice")
+
+	rec := revokeRequest(h, accessToken, "access_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Force a cache miss: strip the cache entry the token exchange created,
+	// simulating a request that arrives after the in-memory cache entry has
+	// been evicted (e.g. a different process, or after eviction) — the jti
+	// denylist, not the cache, is what must reject it.
+	h.store.InvalidateCachedToken(accessToken)
+
+	if _, _, err := h.ValidateToken(context.Background(), accessToken, ""); err == nil {
+		t.Error("ValidateToken: expected error for revoked JWT on cache-miss path, got nil")
+	}
+}
+
+// TestRevokeBuiltinAccessTokenRejectsCacheHit verifies the cache-hit path
+// also honours the denylist: a token that was cached (e.g. by a prior
+// request) before being revoked must not keep validating for the remainder
+// of its cache TTL.
+func TestRevokeBuiltinAccessTokenRejectsCacheHit(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, _ := issueBuiltinTokens(t, h, "alice")
+
+	// Prime the cache (cache-hit path) before revoking.
+	if _, _, err := h.ValidateToken(context.Background(), accessToken, ""); err != nil {
+		t.Fatalf("priming ValidateToken: %v", err)
+	}
+
+	rec := revokeRequest(h, accessToken, "access_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	if _, _, err := h.ValidateToken(context.Background(), accessToken, ""); err == nil {
+		t.Error("ValidateToken: expected error for revoked JWT on cache-hit path, got nil")
+	}
+}
+
+// TestRevokeRefreshTokenCascadesFamilyAndCurrentAccessToken verifies that
+// revoking a refresh token (a) blocks future rotation of its family and (b)
+// immediately denylists the jti of the access token currently associated
+// with that family, rather than leaving it valid until its own exp.
+func TestRevokeRefreshTokenCascadesFamilyAndCurrentAccessToken(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, refreshToken := issueBuiltinTokens(t, h, "alice")
+
+	rec := revokeRequest(h, refreshToken, "refresh_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// (a) the refresh token itself can no longer be used for rotation.
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code == http.StatusOK {
+		t.Errorf("refresh grant with revoked refresh_token unexpectedly succeeded: %s", refreshRec.Body.String())
+	}
+
+	// (b) the access token issued alongside it is also immediately rejected,
+	// not just when it would eventually be rotated.
+	h.store.InvalidateCachedToken(accessToken)
+	if _, _, err := h.ValidateToken(context.Background(), accessToken, ""); err == nil {
+		t.Error("ValidateToken: expected error for access token cascaded from refresh token revocation")
+	}
+}
+
+// TestRevokeIdempotentAndUnknownTokens verifies RFC 7009 §2.2: revoking an
+// unknown, already-expired, or already-revoked token is not an error — the
+// endpoint always responds 200 so a caller cannot use it to probe validity.
+func TestRevokeIdempotentAndUnknownTokens(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, _ := issueBuiltinTokens(t, h, "alice")
+
+	if rec := revokeRequest(h, "totally-unknown-opaque-token", ""); rec.Code != http.StatusOK {
+		t.Errorf("revoke unknown token: got %d, want 200", rec.Code)
+	}
+	if rec := revokeRequest(h, "not.a.jwt", ""); rec.Code != http.StatusOK {
+		t.Errorf("revoke malformed token: got %d, want 200", rec.Code)
+	}
+	// Double revoke of the same valid token must also succeed both times.
+	if rec := revokeRequest(h, accessToken, "access_token"); rec.Code != http.StatusOK {
+		t.Errorf("first revoke: got %d, want 200", rec.Code)
+	}
+	if rec := revokeRequest(h, accessToken, "access_token"); rec.Code != http.StatusOK {
+		t.Errorf("second (duplicate) revoke: got %d, want 200", rec.Code)
+	}
+}
+
+// TestRevokeNonBuiltinModeInvalidatesCache verifies that in non-builtin mode
+// (cache key = provider access token), /revoke removes the cached entry so a
+// subsequent request re-validates against the upstream provider rather than
+// trusting a stale cache hit.
+func TestRevokeNonBuiltinModeInvalidatesCache(t *testing.T) {
+	h := newTestHandler(t)
+	h.store.CacheToken("gh-access-token", "carol", "http://localhost:8080/mcp")
+	if _, ok := h.store.LookupToken("gh-access-token"); !ok {
+		t.Fatal("setup: expected cache hit before revoke")
+	}
+
+	rec := revokeRequest(h, "gh-access-token", "access_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	if _, ok := h.store.LookupToken("gh-access-token"); ok {
+		t.Error("expected cache entry to be removed after /revoke")
+	}
+}
+
+// TestDiscoveryIncludesRevocationEndpoint verifies RFC 8414 discovery
+// advertises the revocation_endpoint so clients can find it.
+func TestDiscoveryIncludesRevocationEndpoint(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	rec := httptest.NewRecorder()
+	h.Discovery(rec, req)
+
+	var doc map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode discovery doc: %v", err)
+	}
+	want := h.cfg.BaseURL + "/revoke"
+	if got, _ := doc["revocation_endpoint"].(string); got != want {
+		t.Errorf("revocation_endpoint: got %q, want %q", got, want)
+	}
+}
+
 func TestBuiltinGitHubAccessTokenNotLeaked(t *testing.T) {
 	const ghAccessToken = "SUPER_SECRET_GITHUB_TOKEN"
 	h := newBuiltinTestHandler(t,
@@ -4327,7 +4572,7 @@ func TestValidateToken_BuiltinModeDoesNotRotateOnCacheHit(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	jwt, err := h.generateGatewayAccessToken("kevin", "http://localhost:8080")
+	jwt, _, err := h.generateGatewayAccessToken("kevin", "http://localhost:8080")
 	if err != nil {
 		t.Fatalf("generateGatewayAccessToken: %v", err)
 	}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1488,6 +1488,9 @@ func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, string, time
 func (d *deleteFailRefreshStore) LookupAny(rt string) (string, string, string, time.Time, bool, bool) {
 	return d.inner.LookupAny(rt)
 }
+func (d *deleteFailRefreshStore) LookupActiveByFamily(fid string) (string, bool) {
+	return d.inner.LookupActiveByFamily(fid)
+}
 func (d *deleteFailRefreshStore) Revoke(_ string) error         { return fmt.Errorf("disk I/O error") }
 func (d *deleteFailRefreshStore) RevokeFamily(fid string) error { return d.inner.RevokeFamily(fid) }
 func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error  { return d.inner.SaveNonce(rt, n) }
@@ -3398,6 +3401,136 @@ func TestRevokeIdempotentAndUnknownTokens(t *testing.T) {
 	}
 	if rec := revokeRequest(h, accessToken, "access_token"); rec.Code != http.StatusOK {
 		t.Errorf("second (duplicate) revoke: got %d, want 200", rec.Code)
+	}
+}
+
+// TestRevokeRefreshTokenWithEmptyFamilyIDStillRevokesToken verifies that a
+// refresh token issued with familyID == "" (the best-effort fallback in
+// tokenAuthCode/tokenDeviceGrant when family-ID generation fails) is still
+// individually invalidated by /revoke. Before this fix, /revoke only called
+// RevokeRefreshTokenFamily, which is a no-op for an empty familyID, leaving
+// the presented token itself usable after a 200 response (thread-owl review,
+// PR #195).
+func TestRevokeRefreshTokenWithEmptyFamilyIDStillRevokesToken(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, _ := issueBuiltinTokens(t, h, "alice")
+	// Simulate the familyID-generation-failure fallback directly: create a
+	// second refresh token for the same access token with familyID = "".
+	rt, err := h.store.CreateRefreshToken(accessToken, "", "", h.refreshTokenTTL())
+	if err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+
+	rec := revokeRequest(h, rt, "refresh_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(rt)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code == http.StatusOK {
+		t.Errorf("refresh grant with revoked (empty-familyID) refresh_token unexpectedly succeeded: %s", refreshRec.Body.String())
+	}
+}
+
+// TestRevokeStaleRefreshTokenCascadesToCurrentAccessToken verifies that
+// revoking an already-rotated (stale) refresh token still finds and denylists
+// the CURRENT access token for that family, not just the older JWT recorded
+// on the stale token's own row. Before this fix, LookupAnyRefreshToken's
+// accessToken field pointed at the predecessor JWT minted before rotation,
+// so the live JWT actually in use remained valid (thread-owl review, PR #195).
+func TestRevokeStaleRefreshTokenCascadesToCurrentAccessToken(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	_, refreshToken1 := issueBuiltinTokens(t, h, "alice")
+
+	// Rotate once: refreshToken1 becomes stale, and a new access/refresh
+	// token pair is issued in the same family.
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken1)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("rotation: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+	var refreshResp map[string]any
+	if err := json.NewDecoder(refreshRec.Body).Decode(&refreshResp); err != nil {
+		t.Fatalf("decode rotation response: %v", err)
+	}
+	accessToken2, _ := refreshResp["access_token"].(string)
+	if accessToken2 == "" {
+		t.Fatal("rotation response missing access_token")
+	}
+
+	// Revoke the STALE (pre-rotation) refresh token.
+	rec := revokeRequest(h, refreshToken1, "refresh_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The CURRENT access token (accessToken2), not just the original one,
+	// must now be rejected.
+	h.store.InvalidateCachedToken(accessToken2)
+	if _, _, err := h.ValidateToken(context.Background(), accessToken2, ""); err == nil {
+		t.Error("ValidateToken: expected error for current access token cascaded from a stale refresh token revocation")
+	}
+}
+
+// revokeJTIFailStore wraps a RefreshTokenStore, delegating everything except
+// RevokeJTI, which always fails — simulating a denylist write failure (e.g.
+// SQLite read-only/locked/corrupt) to verify /revoke does not report success
+// when the security property it promises could not actually be persisted.
+type revokeJTIFailStore struct {
+	RefreshTokenStore
+}
+
+func (r *revokeJTIFailStore) RevokeJTI(_ string, _ time.Time) error {
+	return fmt.Errorf("simulated jti denylist write failure")
+}
+
+// TestRevokeStoreWriteFailurePropagatesAsServerError verifies that a failed
+// RevokeJTI write is surfaced as 500 server_error rather than 200 — silently
+// reporting success would leave the JWT re-validating after the next cache
+// eviction (thread-owl review, PR #195).
+func TestRevokeStoreWriteFailurePropagatesAsServerError(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	accessToken, _ := issueBuiltinTokens(t, h, "alice")
+
+	// Swap in a RefreshTokenStore whose RevokeJTI always fails, simulating a
+	// denylist write failure discovered only once /revoke is called. The
+	// OAuth session/PKCE bookkeeping used only during Authorize->Callback->
+	// Token is no longer needed at this point, so replacing the whole store
+	// (rather than mutating it in place, which Store does not expose) is safe.
+	h.store = NewStore(10*time.Minute, 90*24*time.Hour, NewMemTokenStore(),
+		WithRefreshTokenStore(&revokeJTIFailStore{RefreshTokenStore: NewMemRefreshTokenStore()}))
+
+	rec := revokeRequest(h, accessToken, "access_token")
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("revoke with failing denylist write: got %d, want 500; body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1488,13 +1488,12 @@ func (d *deleteFailRefreshStore) Lookup(rt string) (string, string, string, time
 func (d *deleteFailRefreshStore) LookupAny(rt string) (string, string, string, time.Time, bool, bool) {
 	return d.inner.LookupAny(rt)
 }
-func (d *deleteFailRefreshStore) LookupActiveByFamily(fid string) (string, bool) {
-	return d.inner.LookupActiveByFamily(fid)
+func (d *deleteFailRefreshStore) Revoke(_ string) error { return fmt.Errorf("disk I/O error") }
+func (d *deleteFailRefreshStore) RevokeFamily(fid string) (string, error) {
+	return d.inner.RevokeFamily(fid)
 }
-func (d *deleteFailRefreshStore) Revoke(_ string) error         { return fmt.Errorf("disk I/O error") }
-func (d *deleteFailRefreshStore) RevokeFamily(fid string) error { return d.inner.RevokeFamily(fid) }
-func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error  { return d.inner.SaveNonce(rt, n) }
-func (d *deleteFailRefreshStore) LookupNonce(rt string) string  { return d.inner.LookupNonce(rt) }
+func (d *deleteFailRefreshStore) SaveNonce(rt, n string) error { return d.inner.SaveNonce(rt, n) }
+func (d *deleteFailRefreshStore) LookupNonce(rt string) string { return d.inner.LookupNonce(rt) }
 func (d *deleteFailRefreshStore) SaveProviderAccessToken(rt, pat string) error {
 	return d.inner.SaveProviderAccessToken(rt, pat)
 }
@@ -1519,7 +1518,12 @@ func TestTokenRefreshDeleteFailed503(t *testing.T) {
 		Scopes:       "repo,user",
 	})
 
-	inner := &memRefreshTokenStore{entries: make(map[string]memRTEntry), revokedJTI: make(map[string]time.Time)}
+	inner := &memRefreshTokenStore{
+		entries:                  make(map[string]memRTEntry),
+		revokedJTI:               make(map[string]time.Time),
+		revokedFamilies:          make(map[string]struct{}),
+		familyCurrentAccessToken: make(map[string]memFamilyPointer),
+	}
 	failStore := &deleteFailRefreshStore{inner: inner}
 	_ = inner.Save("test-rt", "test-at", "http://localhost:8080/mcp", "fid-test", time.Now().Add(time.Hour))
 
@@ -3490,6 +3494,170 @@ func TestRevokeStaleRefreshTokenCascadesToCurrentAccessToken(t *testing.T) {
 	h.store.InvalidateCachedToken(accessToken2)
 	if _, _, err := h.ValidateToken(context.Background(), accessToken2, ""); err == nil {
 		t.Error("ValidateToken: expected error for current access token cascaded from a stale refresh token revocation")
+	}
+}
+
+// TestRevokeStaleRefreshTokenFindsCurrentAccessTokenDuringConcurrentReservation
+// pins the exact race thread-owl flagged in the second review round: a row
+// scan for "the non-revoked row in this family" finds nothing during the
+// narrow window where a concurrent rotation has reserved (soft-revoked) the
+// current refresh token but has not yet committed its replacement row. The
+// family_current_access_token pointer must still resolve to the access token
+// actually in the client's hands (accessToken2), not the stale
+// predecessor (accessToken1) and not "" (thread-owl review, PR #195).
+func TestRevokeStaleRefreshTokenFindsCurrentAccessTokenDuringConcurrentReservation(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	_, refreshToken1 := issueBuiltinTokens(t, h, "alice")
+
+	// Rotation 1, via the normal HTTP path: refreshToken1 -> accessToken2/refreshToken2.
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken1)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("rotation 1: got %d; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+	var resp1 map[string]any
+	if err := json.NewDecoder(refreshRec.Body).Decode(&resp1); err != nil {
+		t.Fatalf("decode rotation 1 response: %v", err)
+	}
+	accessToken2, _ := resp1["access_token"].(string)
+	refreshToken2, _ := resp1["refresh_token"].(string)
+	if accessToken2 == "" || refreshToken2 == "" {
+		t.Fatalf("rotation 1 response missing tokens: %#v", resp1)
+	}
+
+	// Simulate rotation 2 currently in flight: refreshToken2 has been
+	// reserved (soft-revoked) but its replacement row has not been created
+	// yet. ReserveRefreshToken is exactly what tokenRefresh calls internally
+	// before minting the next access/refresh token pair.
+	if _, _, _, _, err := h.store.ReserveRefreshToken(refreshToken2); err != nil {
+		t.Fatalf("ReserveRefreshToken: %v", err)
+	}
+
+	// Revoke the now-stale refreshToken1 while rotation 2 is mid-flight.
+	rec := revokeRequest(h, refreshToken1, "refresh_token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// accessToken2 — the token actually held by the client at this point —
+	// must be rejected, even though no non-revoked refresh_tokens row
+	// exists for the family right now.
+	h.store.InvalidateCachedToken(accessToken2)
+	if _, _, err := h.ValidateToken(context.Background(), accessToken2, ""); err == nil {
+		t.Error("ValidateToken: expected error for accessToken2 despite the concurrent reservation window")
+	}
+}
+
+// recordingTokenStore wraps a TokenStore, recording every token passed to
+// Save so a test can capture a provisional token minted mid-request without
+// the handler ever returning it.
+type recordingTokenStore struct {
+	TokenStore
+	mu    sync.Mutex
+	saved []string
+}
+
+func (r *recordingTokenStore) Save(token, subject string, audiences []string, expiresAt time.Time) error {
+	r.mu.Lock()
+	r.saved = append(r.saved, token)
+	r.mu.Unlock()
+	return r.TokenStore.Save(token, subject, audiences, expiresAt)
+}
+
+func (r *recordingTokenStore) lastSaved() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.saved) == 0 {
+		return ""
+	}
+	return r.saved[len(r.saved)-1]
+}
+
+// revokeFamilyOnFirstSave wraps a RefreshTokenStore and, on the first Save
+// call carrying a non-empty familyID, first revokes that family on the
+// underlying store before delegating — deterministically simulating a
+// concurrent POST /revoke whose RevokeFamily transaction commits at the
+// exact instant a rotation's own Save (guarded against the same tombstone)
+// is about to run. This reproduces the race window from a single goroutine,
+// without depending on real scheduling.
+type revokeFamilyOnFirstSave struct {
+	RefreshTokenStore
+	fired bool
+}
+
+func (r *revokeFamilyOnFirstSave) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
+	if !r.fired && familyID != "" {
+		r.fired = true
+		if _, err := r.RevokeFamily(familyID); err != nil {
+			panic(fmt.Sprintf("test setup: RevokeFamily: %v", err))
+		}
+	}
+	return r.RefreshTokenStore.Save(refreshToken, accessToken, audience, familyID, expiresAt)
+}
+
+// TestRevokeConcurrentRotationDoesNotLeakProvisionalToken pins the second
+// finding from thread-owl's review: when a rotation's CreateRefreshToken
+// fails because its family was concurrently revoked, the gateway JWT already
+// cached (with its provider access token and subject-index entry) before
+// that failure must not survive — otherwise it remains reachable via
+// EnsureFreshAccessTokenForSubject (Phase B delegated access) even though
+// the client never received it and /revoke was supposed to cut off access
+// (thread-owl review, PR #195).
+func TestRevokeConcurrentRotationDoesNotLeakProvisionalToken(t *testing.T) {
+	h := newBuiltinTestHandler(t,
+		func(_ context.Context, _ string) (provider.TokenResponse, error) {
+			return provider.TokenResponse{AccessToken: "gh-tok"}, nil
+		},
+		func(_ context.Context, _ string) (provider.Identity, error) {
+			return provider.Identity{Subject: "alice"}, nil
+		},
+	)
+	_, refreshToken1 := issueBuiltinTokens(t, h, "alice")
+
+	// Swap in a recording TokenStore (to capture the provisional token) and
+	// a RefreshTokenStore that revokes refreshToken1's family the instant
+	// the rotation below tries to Save its replacement row — simulating a
+	// concurrent /revoke landing in the middle of this rotation. The
+	// underlying refresh-token store is preserved as-is (it already holds
+	// refreshToken1). The OAuth session/PKCE bookkeeping used only during
+	// Authorize->Callback->Token is no longer needed at this point.
+	rec := &recordingTokenStore{TokenStore: NewMemTokenStore()}
+	wrappedRefresh := &revokeFamilyOnFirstSave{RefreshTokenStore: h.store.refreshStore}
+	h.store = NewStore(10*time.Minute, 90*24*time.Hour, rec, WithRefreshTokenStore(wrappedRefresh))
+
+	// Attempt rotation via refreshToken1. ReserveRefreshToken succeeds
+	// normally (the family is not yet tombstoned), but by the time
+	// CreateRefreshToken tries to Save the new row, revokeFamilyOnFirstSave
+	// has already tombstoned the family — exactly the outcome a real
+	// concurrent /revoke call racing this rotation would produce.
+	refreshBody := "grant_type=refresh_token&refresh_token=" + url.QueryEscape(refreshToken1)
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(refreshBody))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	h.Token(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusBadRequest {
+		t.Fatalf("rotation racing a concurrent revoke: got %d, want 400; body=%s", refreshRec.Code, refreshRec.Body.String())
+	}
+	if !wrappedRefresh.fired {
+		t.Fatal("setup: expected the concurrent-revoke hook to have fired")
+	}
+
+	provisional := rec.lastSaved()
+	if provisional == "" {
+		t.Fatal("setup: expected a provisional token to have been generated and Saved")
+	}
+	if _, ok := h.store.LookupToken(provisional); ok {
+		t.Error("provisional gateway JWT must be invalidated after CreateRefreshToken fails due to a concurrently revoked family")
 	}
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -744,6 +744,15 @@ func (s *Store) SaveTokenNonce(token, nonce string) {
 	}
 }
 
+// SaveTokenJti attaches the JWT ID claim (builtin mode) to an existing token
+// entry so a subsequent cache-hit ValidateToken call can check it against the
+// revocation denylist without re-parsing the raw token.
+func (s *Store) SaveTokenJti(token, jti string) {
+	if err := s.tokens.SaveJti(token, jti); err != nil {
+		slog.Warn("token store jti save failed", "err", err)
+	}
+}
+
 // SaveRefreshTokenNonce attaches the OIDC nonce to a refresh-token entry so
 // the nonce survives past the access-token TTL and can be retrieved during
 // token refresh (OIDC Core §12.2). No-op when entry is absent or expired.
@@ -779,6 +788,34 @@ func (s *Store) SaveRefreshTokenProviderAccessToken(refreshToken, providerAccess
 // value remains readable during the rotation, mirroring LookupRefreshTokenNonce.
 func (s *Store) LookupRefreshTokenProviderAccessToken(refreshToken string) string {
 	return s.refreshStore.LookupProviderAccessToken(refreshToken)
+}
+
+// LookupAnyRefreshToken looks up refreshToken including soft-revoked
+// (already-rotated) entries that have not yet expired. Used by POST /revoke
+// (RFC 7009) to resolve token_type_hint=refresh_token: an already-rotated
+// token must still resolve its familyID so the whole lineage can be revoked.
+func (s *Store) LookupAnyRefreshToken(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, revoked, ok bool) {
+	return s.refreshStore.LookupAny(refreshToken)
+}
+
+// RevokeRefreshTokenFamily marks every non-revoked refresh token belonging to
+// familyID as revoked, invalidating the entire token lineage. Used by both
+// reuse detection (ReserveRefreshToken) and POST /revoke.
+func (s *Store) RevokeRefreshTokenFamily(familyID string) error {
+	return s.refreshStore.RevokeFamily(familyID)
+}
+
+// RevokeJTI adds jti to the revocation denylist until expiresAt (the JWT's
+// own exp claim). Used by POST /revoke so a gateway-issued access token
+// (builtin mode) is rejected even though JWT verification is otherwise
+// stateless.
+func (s *Store) RevokeJTI(jti string, expiresAt time.Time) error {
+	return s.refreshStore.RevokeJTI(jti, expiresAt)
+}
+
+// IsJTIRevoked reports whether jti is present in the revocation denylist.
+func (s *Store) IsJTIRevoked(jti string) bool {
+	return s.refreshStore.IsJTIRevoked(jti)
 }
 
 // ClearProviderRefresh drops the provider refresh metadata for token (sets

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -465,7 +465,7 @@ func (s *Store) ReserveRefreshToken(refreshToken string) (accessToken, audience,
 			slog.Warn("refresh token reuse detected — revoking token family",
 				"family_id", revokedFID,
 			)
-			_ = s.refreshStore.RevokeFamily(revokedFID)
+			_, _ = s.refreshStore.RevokeFamily(revokedFID)
 		}
 		return "", "", "", time.Time{}, fmt.Errorf("refresh token not found or expired")
 	}
@@ -798,15 +798,6 @@ func (s *Store) LookupAnyRefreshToken(refreshToken string) (accessToken, audienc
 	return s.refreshStore.LookupAny(refreshToken)
 }
 
-// LookupActiveRefreshTokenAccessToken returns the access token of the
-// current (non-revoked, non-expired) refresh-token row for familyID, or
-// ("", false) when none exists. Used by POST /revoke to find the access
-// token actually in use today even when the presented refresh token is a
-// stale, already-rotated predecessor.
-func (s *Store) LookupActiveRefreshTokenAccessToken(familyID string) (accessToken string, ok bool) {
-	return s.refreshStore.LookupActiveByFamily(familyID)
-}
-
 // RevokeSingleRefreshToken marks refreshToken itself as revoked, independent
 // of familyID. Used by POST /revoke so the presented token is always
 // individually invalidated even in the rare case familyID is empty (family-ID
@@ -818,9 +809,13 @@ func (s *Store) RevokeSingleRefreshToken(refreshToken string) error {
 }
 
 // RevokeRefreshTokenFamily marks every non-revoked refresh token belonging to
-// familyID as revoked, invalidating the entire token lineage. Used by both
-// reuse detection (ReserveRefreshToken) and POST /revoke.
-func (s *Store) RevokeRefreshTokenFamily(familyID string) error {
+// familyID as revoked, and returns the family's current access token as
+// observed atomically within the same operation (see
+// RefreshTokenStore.RevokeFamily's doc comment for why a separate
+// lookup-then-revoke sequence would have its own race window). Used by both
+// reuse detection (ReserveRefreshToken, return value discarded) and POST
+// /revoke, which denylists the returned access token.
+func (s *Store) RevokeRefreshTokenFamily(familyID string) (currentAccessToken string, err error) {
 	return s.refreshStore.RevokeFamily(familyID)
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -798,6 +798,25 @@ func (s *Store) LookupAnyRefreshToken(refreshToken string) (accessToken, audienc
 	return s.refreshStore.LookupAny(refreshToken)
 }
 
+// LookupActiveRefreshTokenAccessToken returns the access token of the
+// current (non-revoked, non-expired) refresh-token row for familyID, or
+// ("", false) when none exists. Used by POST /revoke to find the access
+// token actually in use today even when the presented refresh token is a
+// stale, already-rotated predecessor.
+func (s *Store) LookupActiveRefreshTokenAccessToken(familyID string) (accessToken string, ok bool) {
+	return s.refreshStore.LookupActiveByFamily(familyID)
+}
+
+// RevokeSingleRefreshToken marks refreshToken itself as revoked, independent
+// of familyID. Used by POST /revoke so the presented token is always
+// individually invalidated even in the rare case familyID is empty (family-ID
+// generation failed at issuance time, so RevokeRefreshTokenFamily would
+// otherwise be the only revocation attempted and — being a no-op for an
+// empty familyID — would leave the token usable).
+func (s *Store) RevokeSingleRefreshToken(refreshToken string) error {
+	return s.refreshStore.Revoke(refreshToken)
+}
+
 // RevokeRefreshTokenFamily marks every non-revoked refresh token belonging to
 // familyID as revoked, invalidating the entire token lineage. Used by both
 // reuse detection (ReserveRefreshToken) and POST /revoke.

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -239,6 +239,7 @@ func (e *errTokenStore) SaveProviderAccessToken(token, providerAccessToken strin
 }
 func (e *errTokenStore) Lookup(token string) (TokenRecord, bool) { return e.mem.Lookup(token) }
 func (e *errTokenStore) SaveNonce(token, nonce string) error     { return e.mem.SaveNonce(token, nonce) }
+func (e *errTokenStore) SaveJti(token, jti string) error         { return e.mem.SaveJti(token, jti) }
 func (e *errTokenStore) MarkRotationFailed(_ string) error       { return nil }
 func (e *errTokenStore) Delete(_ string) error                   { return fmt.Errorf("injected delete error") }
 func (e *errTokenStore) Sweep() error                            { return e.mem.Sweep() }

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -583,6 +584,16 @@ func (f *fileTokenStore) flush() error {
 
 // ── RefreshTokenStore ────────────────────────────────────────────────────────
 
+// ErrRefreshTokenFamilyRevoked is returned by Save when familyID has been
+// tombstoned by a prior RevokeFamily call. This closes a TOCTOU race between
+// POST /revoke (which revokes a family) and a concurrently in-flight
+// tokenRefresh rotation for the same family: without the tombstone, a
+// rotation that reads its old row before RevokeFamily's UPDATE but writes
+// its new row after would create a fresh, non-revoked entry that survives
+// the revocation. familyID == "" is never tombstoned (Save always succeeds
+// for it), matching RevokeFamily's existing no-op for an empty familyID.
+var ErrRefreshTokenFamilyRevoked = errors.New("refresh token family has been revoked")
+
 // RefreshTokenStore persists gateway-issued refresh token → access token mappings.
 // Two implementations: memRefreshTokenStore (default) and fileRefreshTokenStore (JSON file).
 //
@@ -591,7 +602,10 @@ func (f *fileTokenStore) flush() error {
 // inherited across rotations. When a revoked token is presented again (reuse
 // attack), RevokeFamily invalidates the entire lineage.
 type RefreshTokenStore interface {
-	// Save records that refreshToken maps to accessToken/audience/familyID and is valid until expiresAt.
+	// Save records that refreshToken maps to accessToken/audience/familyID and
+	// is valid until expiresAt. Returns ErrRefreshTokenFamilyRevoked (without
+	// writing) when familyID is non-empty and has been tombstoned by a prior
+	// RevokeFamily call — see ErrRefreshTokenFamilyRevoked.
 	Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error
 	// Lookup returns the access token, audience, familyID, and expiry for an active (non-revoked,
 	// non-expired) refresh token. Returns false when the token is unknown, expired, or revoked.
@@ -600,12 +614,21 @@ type RefreshTokenStore interface {
 	// LookupAny is like Lookup but also returns revoked entries that have not yet expired.
 	// Used for reuse detection: a revoked-but-present entry indicates a replay attack.
 	LookupAny(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, revoked, ok bool)
+	// LookupActiveByFamily returns the access token of the current (non-revoked,
+	// non-expired) refresh-token row for familyID, or ("", false) when none
+	// exists. Used by POST /revoke to find the access token actually in use
+	// today even when the presented refresh token is a stale, already-rotated
+	// predecessor whose own accessToken field points at an earlier JWT.
+	LookupActiveByFamily(familyID string) (accessToken string, ok bool)
 	// Revoke marks a single refresh token as revoked without deleting it.
 	// The revoked entry is retained until it expires so that reuse detection
 	// (via LookupAny) can identify replay attacks within the expiry window.
 	Revoke(refreshToken string) error
-	// RevokeFamily marks all non-revoked tokens belonging to familyID as revoked.
-	// Used on reuse detection to invalidate the entire token lineage.
+	// RevokeFamily marks all non-revoked tokens belonging to familyID as
+	// revoked AND tombstones familyID (permanently; see
+	// ErrRefreshTokenFamilyRevoked) so a concurrently in-flight Save for the
+	// same familyID is rejected rather than resurrecting the family. Used on
+	// reuse detection to invalidate the entire token lineage.
 	RevokeFamily(familyID string) error
 	// Delete removes a single refresh token entry immediately.
 	Delete(refreshToken string) error
@@ -658,23 +681,30 @@ type memRTEntry struct {
 }
 
 type memRefreshTokenStore struct {
-	mu         sync.RWMutex
-	entries    map[string]memRTEntry // key: tokenKey(rawRefreshToken)
-	revokedJTI map[string]time.Time  // key: jti, value: expiresAt
+	mu              sync.RWMutex
+	entries         map[string]memRTEntry // key: tokenKey(rawRefreshToken)
+	revokedJTI      map[string]time.Time  // key: jti, value: expiresAt
+	revokedFamilies map[string]struct{}   // key: familyID, tombstoned by RevokeFamily
 }
 
 // NewMemRefreshTokenStore returns an in-memory RefreshTokenStore.
 // All data is lost when the process exits.
 func NewMemRefreshTokenStore() RefreshTokenStore {
 	return &memRefreshTokenStore{
-		entries:    make(map[string]memRTEntry),
-		revokedJTI: make(map[string]time.Time),
+		entries:         make(map[string]memRTEntry),
+		revokedJTI:      make(map[string]time.Time),
+		revokedFamilies: make(map[string]struct{}),
 	}
 }
 
 func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if familyID != "" {
+		if _, revoked := m.revokedFamilies[familyID]; revoked {
+			return ErrRefreshTokenFamilyRevoked
+		}
+	}
 	m.entries[tokenKey(refreshToken)] = memRTEntry{
 		accessToken: accessToken,
 		audience:    audience,
@@ -704,6 +734,21 @@ func (m *memRefreshTokenStore) LookupAny(refreshToken string) (string, string, s
 	return e.accessToken, e.audience, e.familyID, e.expiresAt, e.revoked, true
 }
 
+func (m *memRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if familyID == "" {
+		return "", false
+	}
+	now := time.Now()
+	for _, e := range m.entries {
+		if e.familyID == familyID && !e.revoked && now.Before(e.expiresAt) {
+			return e.accessToken, true
+		}
+	}
+	return "", false
+}
+
 func (m *memRefreshTokenStore) Revoke(refreshToken string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -720,12 +765,21 @@ func (m *memRefreshTokenStore) Revoke(refreshToken string) error {
 func (m *memRefreshTokenStore) RevokeFamily(familyID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if familyID == "" {
+		return nil
+	}
 	for k, e := range m.entries {
 		if e.familyID == familyID && !e.revoked {
 			e.revoked = true
 			m.entries[k] = e
 		}
 	}
+	// Tombstone permanently: a concurrent Save for this familyID (e.g. a
+	// rotation racing this call) must be rejected rather than resurrecting
+	// the family after this call returns. Never swept — mirrors the
+	// rotationFailed map precedent (session.go): expected to stay small
+	// since it only grows with explicit revocations.
+	m.revokedFamilies[familyID] = struct{}{}
 	return nil
 }
 
@@ -836,13 +890,14 @@ type fileRefreshTokenStore struct {
 	mu      sync.RWMutex
 	path    string
 	entries map[string]fileRTEntry // key: tokenKey(rawRefreshToken)
-	// revokedJTI is intentionally in-memory only (not persisted to path).
-	// This legacy file-backed implementation is only exercised directly by
-	// its own contract tests; the live NewHandler path migrates it to
-	// sqliteRefreshTokenStore at startup (see tokenstore_sqlite_migrate.go)
-	// before any /revoke traffic can occur, so a durable denylist here is
-	// unreachable in production.
-	revokedJTI map[string]time.Time
+	// revokedJTI and revokedFamilies are intentionally in-memory only (not
+	// persisted to path). This legacy file-backed implementation is only
+	// exercised directly by its own contract tests; the live NewHandler path
+	// migrates it to sqliteRefreshTokenStore at startup (see
+	// tokenstore_sqlite_migrate.go) before any /revoke traffic can occur, so
+	// a durable denylist/tombstone here is unreachable in production.
+	revokedJTI      map[string]time.Time
+	revokedFamilies map[string]struct{}
 }
 
 // NewFileRefreshTokenStore returns a file-backed RefreshTokenStore that loads
@@ -851,9 +906,10 @@ type fileRefreshTokenStore struct {
 // If the file does not yet exist, an empty store is returned without error.
 func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	s := &fileRefreshTokenStore{
-		path:       path,
-		entries:    make(map[string]fileRTEntry),
-		revokedJTI: make(map[string]time.Time),
+		path:            path,
+		entries:         make(map[string]fileRTEntry),
+		revokedJTI:      make(map[string]time.Time),
+		revokedFamilies: make(map[string]struct{}),
 	}
 	if err := s.load(); err != nil {
 		if !os.IsNotExist(err) {
@@ -902,6 +958,11 @@ func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if familyID != "" {
+		if _, revoked := f.revokedFamilies[familyID]; revoked {
+			return ErrRefreshTokenFamilyRevoked
+		}
+	}
 	key := tokenKey(refreshToken)
 	prev, hasPrev := f.entries[key]
 	f.entries[key] = fileRTEntry{AccessToken: accessToken, Audience: audience, FamilyID: familyID, ExpiresAt: expiresAt}
@@ -936,6 +997,21 @@ func (f *fileRefreshTokenStore) LookupAny(refreshToken string) (string, string, 
 	return e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt, e.Revoked, true
 }
 
+func (f *fileRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if familyID == "" {
+		return "", false
+	}
+	now := time.Now()
+	for _, e := range f.entries {
+		if e.FamilyID == familyID && !e.Revoked && now.Before(e.ExpiresAt) {
+			return e.AccessToken, true
+		}
+	}
+	return "", false
+}
+
 func (f *fileRefreshTokenStore) Revoke(refreshToken string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -957,6 +1033,9 @@ func (f *fileRefreshTokenStore) Revoke(refreshToken string) error {
 func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if familyID == "" {
+		return nil
+	}
 	changed := false
 	for k, e := range f.entries {
 		if e.FamilyID == familyID && !e.Revoked {
@@ -965,6 +1044,10 @@ func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
 			changed = true
 		}
 	}
+	// Tombstone permanently (in-memory only — see the revokedFamilies field
+	// comment) regardless of whether any row existed to revoke, so a
+	// concurrent Save for this familyID is rejected either way.
+	f.revokedFamilies[familyID] = struct{}{}
 	if !changed {
 		return nil
 	}

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -605,7 +605,11 @@ type RefreshTokenStore interface {
 	// Save records that refreshToken maps to accessToken/audience/familyID and
 	// is valid until expiresAt. Returns ErrRefreshTokenFamilyRevoked (without
 	// writing) when familyID is non-empty and has been tombstoned by a prior
-	// RevokeFamily call — see ErrRefreshTokenFamilyRevoked.
+	// RevokeFamily call — see ErrRefreshTokenFamilyRevoked. When familyID is
+	// non-empty, Save also atomically updates the family's "current access
+	// token" pointer (read back by RevokeFamily) to accessToken — see
+	// RevokeFamily's doc comment for why this must happen in the same
+	// operation as the row write rather than as a separate step.
 	Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error
 	// Lookup returns the access token, audience, familyID, and expiry for an active (non-revoked,
 	// non-expired) refresh token. Returns false when the token is unknown, expired, or revoked.
@@ -614,22 +618,34 @@ type RefreshTokenStore interface {
 	// LookupAny is like Lookup but also returns revoked entries that have not yet expired.
 	// Used for reuse detection: a revoked-but-present entry indicates a replay attack.
 	LookupAny(refreshToken string) (accessToken, audience, familyID string, expiresAt time.Time, revoked, ok bool)
-	// LookupActiveByFamily returns the access token of the current (non-revoked,
-	// non-expired) refresh-token row for familyID, or ("", false) when none
-	// exists. Used by POST /revoke to find the access token actually in use
-	// today even when the presented refresh token is a stale, already-rotated
-	// predecessor whose own accessToken field points at an earlier JWT.
-	LookupActiveByFamily(familyID string) (accessToken string, ok bool)
 	// Revoke marks a single refresh token as revoked without deleting it.
 	// The revoked entry is retained until it expires so that reuse detection
 	// (via LookupAny) can identify replay attacks within the expiry window.
 	Revoke(refreshToken string) error
 	// RevokeFamily marks all non-revoked tokens belonging to familyID as
-	// revoked AND tombstones familyID (permanently; see
-	// ErrRefreshTokenFamilyRevoked) so a concurrently in-flight Save for the
-	// same familyID is rejected rather than resurrecting the family. Used on
-	// reuse detection to invalidate the entire token lineage.
-	RevokeFamily(familyID string) error
+	// revoked, tombstones familyID (permanently; see
+	// ErrRefreshTokenFamilyRevoked), and returns the family's current access
+	// token (the value most recently written by Save for this familyID) as
+	// observed atomically within the same operation as the tombstone write.
+	//
+	// The atomicity matters: a naive "read the current access token, then
+	// call RevokeFamily" sequence has its own TOCTOU window, because a
+	// concurrently in-flight rotation's Save can commit its new access token
+	// between the read and the revoke — the reader would then denylist a
+	// stale access token while the client walks away with a fresh,
+	// never-denylisted one. Returning the pointer value from inside
+	// RevokeFamily's own transaction closes that window: any Save racing
+	// this call either fully commits before RevokeFamily starts (so this
+	// read sees it) or is rejected by the tombstone this call just wrote (so
+	// it never produces an access token this call could have missed).
+	// familyID == "" returns ("", nil) without tombstoning anything, matching
+	// Save's existing no-op contract for an empty familyID.
+	//
+	// Used on reuse detection (return value discarded) to invalidate the
+	// entire token lineage, and by POST /revoke to find and denylist the
+	// live access token even when the presented refresh token is a stale,
+	// already-rotated predecessor.
+	RevokeFamily(familyID string) (currentAccessToken string, err error)
 	// Delete removes a single refresh token entry immediately.
 	Delete(refreshToken string) error
 	// SaveNonce attaches the OIDC nonce to an existing refresh-token entry so it
@@ -680,20 +696,32 @@ type memRTEntry struct {
 	providerAccessToken string
 }
 
+// memFamilyPointer records the "current access token" for a family: the
+// access token most recently written by a successful Save for that
+// familyID, independent of whether the underlying refresh-token row has
+// since been soft-revoked (e.g. mid-rotation, after ReserveRefreshToken but
+// before the new row's Save). See RevokeFamily's doc comment.
+type memFamilyPointer struct {
+	accessToken string
+	expiresAt   time.Time
+}
+
 type memRefreshTokenStore struct {
-	mu              sync.RWMutex
-	entries         map[string]memRTEntry // key: tokenKey(rawRefreshToken)
-	revokedJTI      map[string]time.Time  // key: jti, value: expiresAt
-	revokedFamilies map[string]struct{}   // key: familyID, tombstoned by RevokeFamily
+	mu                       sync.RWMutex
+	entries                  map[string]memRTEntry       // key: tokenKey(rawRefreshToken)
+	revokedJTI               map[string]time.Time        // key: jti, value: expiresAt
+	revokedFamilies          map[string]struct{}         // key: familyID, tombstoned by RevokeFamily
+	familyCurrentAccessToken map[string]memFamilyPointer // key: familyID
 }
 
 // NewMemRefreshTokenStore returns an in-memory RefreshTokenStore.
 // All data is lost when the process exits.
 func NewMemRefreshTokenStore() RefreshTokenStore {
 	return &memRefreshTokenStore{
-		entries:         make(map[string]memRTEntry),
-		revokedJTI:      make(map[string]time.Time),
-		revokedFamilies: make(map[string]struct{}),
+		entries:                  make(map[string]memRTEntry),
+		revokedJTI:               make(map[string]time.Time),
+		revokedFamilies:          make(map[string]struct{}),
+		familyCurrentAccessToken: make(map[string]memFamilyPointer),
 	}
 }
 
@@ -710,6 +738,9 @@ func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience, familyI
 		audience:    audience,
 		familyID:    familyID,
 		expiresAt:   expiresAt,
+	}
+	if familyID != "" {
+		m.familyCurrentAccessToken[familyID] = memFamilyPointer{accessToken: accessToken, expiresAt: expiresAt}
 	}
 	return nil
 }
@@ -734,21 +765,6 @@ func (m *memRefreshTokenStore) LookupAny(refreshToken string) (string, string, s
 	return e.accessToken, e.audience, e.familyID, e.expiresAt, e.revoked, true
 }
 
-func (m *memRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if familyID == "" {
-		return "", false
-	}
-	now := time.Now()
-	for _, e := range m.entries {
-		if e.familyID == familyID && !e.revoked && now.Before(e.expiresAt) {
-			return e.accessToken, true
-		}
-	}
-	return "", false
-}
-
 func (m *memRefreshTokenStore) Revoke(refreshToken string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -762,11 +778,11 @@ func (m *memRefreshTokenStore) Revoke(refreshToken string) error {
 	return nil
 }
 
-func (m *memRefreshTokenStore) RevokeFamily(familyID string) error {
+func (m *memRefreshTokenStore) RevokeFamily(familyID string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if familyID == "" {
-		return nil
+		return "", nil
 	}
 	for k, e := range m.entries {
 		if e.familyID == familyID && !e.revoked {
@@ -780,7 +796,16 @@ func (m *memRefreshTokenStore) RevokeFamily(familyID string) error {
 	// rotationFailed map precedent (session.go): expected to stay small
 	// since it only grows with explicit revocations.
 	m.revokedFamilies[familyID] = struct{}{}
-	return nil
+	// Read the pointer under the same lock held for the tombstone write
+	// above: no Save for this familyID can observe a state between "not yet
+	// tombstoned" and "tombstoned" from this goroutine's perspective, so
+	// this is the family's authoritative current access token as of the
+	// moment revocation takes effect.
+	p, ok := m.familyCurrentAccessToken[familyID]
+	if !ok || time.Now().After(p.expiresAt) {
+		return "", nil
+	}
+	return p.accessToken, nil
 }
 
 func (m *memRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
@@ -867,6 +892,11 @@ func (m *memRefreshTokenStore) Sweep() error {
 			delete(m.revokedJTI, jti)
 		}
 	}
+	for familyID, p := range m.familyCurrentAccessToken {
+		if now.After(p.expiresAt) {
+			delete(m.familyCurrentAccessToken, familyID)
+		}
+	}
 	return nil
 }
 
@@ -890,14 +920,16 @@ type fileRefreshTokenStore struct {
 	mu      sync.RWMutex
 	path    string
 	entries map[string]fileRTEntry // key: tokenKey(rawRefreshToken)
-	// revokedJTI and revokedFamilies are intentionally in-memory only (not
-	// persisted to path). This legacy file-backed implementation is only
-	// exercised directly by its own contract tests; the live NewHandler path
-	// migrates it to sqliteRefreshTokenStore at startup (see
-	// tokenstore_sqlite_migrate.go) before any /revoke traffic can occur, so
-	// a durable denylist/tombstone here is unreachable in production.
-	revokedJTI      map[string]time.Time
-	revokedFamilies map[string]struct{}
+	// revokedJTI, revokedFamilies, and familyCurrentAccessToken are
+	// intentionally in-memory only (not persisted to path). This legacy
+	// file-backed implementation is only exercised directly by its own
+	// contract tests; the live NewHandler path migrates it to
+	// sqliteRefreshTokenStore at startup (see tokenstore_sqlite_migrate.go)
+	// before any /revoke traffic can occur, so durable denylist/tombstone/
+	// pointer state here is unreachable in production.
+	revokedJTI               map[string]time.Time
+	revokedFamilies          map[string]struct{}
+	familyCurrentAccessToken map[string]memFamilyPointer
 }
 
 // NewFileRefreshTokenStore returns a file-backed RefreshTokenStore that loads
@@ -906,10 +938,11 @@ type fileRefreshTokenStore struct {
 // If the file does not yet exist, an empty store is returned without error.
 func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	s := &fileRefreshTokenStore{
-		path:            path,
-		entries:         make(map[string]fileRTEntry),
-		revokedJTI:      make(map[string]time.Time),
-		revokedFamilies: make(map[string]struct{}),
+		path:                     path,
+		entries:                  make(map[string]fileRTEntry),
+		revokedJTI:               make(map[string]time.Time),
+		revokedFamilies:          make(map[string]struct{}),
+		familyCurrentAccessToken: make(map[string]memFamilyPointer),
 	}
 	if err := s.load(); err != nil {
 		if !os.IsNotExist(err) {
@@ -974,6 +1007,9 @@ func (f *fileRefreshTokenStore) Save(refreshToken, accessToken, audience, family
 		}
 		return err
 	}
+	if familyID != "" {
+		f.familyCurrentAccessToken[familyID] = memFamilyPointer{accessToken: accessToken, expiresAt: expiresAt}
+	}
 	return nil
 }
 
@@ -997,21 +1033,6 @@ func (f *fileRefreshTokenStore) LookupAny(refreshToken string) (string, string, 
 	return e.AccessToken, e.Audience, e.FamilyID, e.ExpiresAt, e.Revoked, true
 }
 
-func (f *fileRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	if familyID == "" {
-		return "", false
-	}
-	now := time.Now()
-	for _, e := range f.entries {
-		if e.FamilyID == familyID && !e.Revoked && now.Before(e.ExpiresAt) {
-			return e.AccessToken, true
-		}
-	}
-	return "", false
-}
-
 func (f *fileRefreshTokenStore) Revoke(refreshToken string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1030,11 +1051,11 @@ func (f *fileRefreshTokenStore) Revoke(refreshToken string) error {
 	return nil
 }
 
-func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
+func (f *fileRefreshTokenStore) RevokeFamily(familyID string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if familyID == "" {
-		return nil
+		return "", nil
 	}
 	changed := false
 	for k, e := range f.entries {
@@ -1048,10 +1069,18 @@ func (f *fileRefreshTokenStore) RevokeFamily(familyID string) error {
 	// comment) regardless of whether any row existed to revoke, so a
 	// concurrent Save for this familyID is rejected either way.
 	f.revokedFamilies[familyID] = struct{}{}
-	if !changed {
-		return nil
+	var flushErr error
+	if changed {
+		flushErr = f.flush()
 	}
-	return f.flush()
+	// Read the pointer under the same lock as the tombstone write above —
+	// see RevokeFamily's interface doc comment for why this must be atomic
+	// with the tombstone rather than a separate call.
+	p, ok := f.familyCurrentAccessToken[familyID]
+	if !ok || time.Now().After(p.expiresAt) {
+		return "", flushErr
+	}
+	return p.accessToken, flushErr
 }
 
 func (f *fileRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
@@ -1150,6 +1179,11 @@ func (f *fileRefreshTokenStore) Sweep() error {
 	for jti, expiresAt := range f.revokedJTI {
 		if now.After(expiresAt) {
 			delete(f.revokedJTI, jti)
+		}
+	}
+	for familyID, p := range f.familyCurrentAccessToken {
+		if now.After(p.expiresAt) {
+			delete(f.familyCurrentAccessToken, familyID)
 		}
 	}
 	if changed := f.sweepLocked(); !changed {

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -37,6 +37,12 @@ import (
 // §3.1.3.7). It is propagated to id_token on refresh (OIDC Core §12.2) so
 // that the nonce binding survives token rotation. Empty when no nonce was
 // requested.
+//
+// Jti is the JWT ID claim of the gateway-issued access token (builtin mode
+// only). It is cached alongside the token record so that a cache-hit
+// ValidateToken call can check the entry against the revocation denylist
+// (RevokeJTI/IsJTIRevoked) without re-parsing the raw token. Empty for
+// non-builtin mode and for JWTs issued before this field existed.
 type TokenRecord struct {
 	Subject                   string
 	Audiences                 []string
@@ -46,6 +52,7 @@ type TokenRecord struct {
 	ProviderAccessExpiry      time.Time
 	RotationPermanentlyFailed bool
 	Nonce                     string
+	Jti                       string
 }
 
 // HasAudience reports whether the token record is scoped to audience.
@@ -84,6 +91,11 @@ type TokenStore interface {
 	// already exist; if absent or expired the call is a no-op. An empty
 	// nonce clears any previously stored value.
 	SaveNonce(token, nonce string) error
+	// SaveJti attaches the JWT ID claim (builtin mode) to an existing entry so
+	// cache-hit ValidateToken calls can check it against the revocation
+	// denylist. The entry must already exist; if absent or expired the call
+	// is a no-op.
+	SaveJti(token, jti string) error
 	// MarkRotationFailed marks token as having a permanent rotation failure.
 	// The entry must already exist; if it is absent or expired the call is a
 	// no-op. For file-backed stores the flag is flushed to disk immediately so
@@ -112,6 +124,7 @@ type memEntry struct {
 	providerAccessExpiry      time.Time
 	rotationPermanentlyFailed bool
 	nonce                     string
+	jti                       string
 }
 
 type memTokenStore struct {
@@ -191,6 +204,7 @@ func (m *memTokenStore) Lookup(token string) (TokenRecord, bool) {
 		ProviderAccessExpiry:      e.providerAccessExpiry,
 		RotationPermanentlyFailed: e.rotationPermanentlyFailed,
 		Nonce:                     e.nonce,
+		Jti:                       e.jti,
 	}, true
 }
 
@@ -203,6 +217,19 @@ func (m *memTokenStore) SaveNonce(token, nonce string) error {
 		return nil
 	}
 	entry.nonce = nonce
+	m.entries[key] = entry
+	return nil
+}
+
+func (m *memTokenStore) SaveJti(token, jti string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := m.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+	entry.jti = jti
 	m.entries[key] = entry
 	return nil
 }
@@ -260,6 +287,7 @@ type fileEntry struct {
 	ProviderAccessExpiry time.Time `json:"pae,omitempty"`
 	RotationFailed       bool      `json:"rf,omitempty"`
 	Nonce                string    `json:"n,omitempty"`
+	Jti                  string    `json:"jti,omitempty"`
 }
 
 type fileTokenStore struct {
@@ -409,6 +437,7 @@ func (f *fileTokenStore) Lookup(token string) (TokenRecord, bool) {
 		ProviderAccessExpiry:      e.ProviderAccessExpiry,
 		RotationPermanentlyFailed: e.RotationFailed,
 		Nonce:                     e.Nonce,
+		Jti:                       e.Jti,
 	}, true
 }
 
@@ -422,6 +451,24 @@ func (f *fileTokenStore) SaveNonce(token, nonce string) error {
 	}
 	previous := entry
 	entry.Nonce = nonce
+	f.entries[key] = entry
+	if err := f.flush(); err != nil {
+		f.entries[key] = previous
+		return err
+	}
+	return nil
+}
+
+func (f *fileTokenStore) SaveJti(token, jti string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := tokenKey(token)
+	entry, ok := f.entries[key]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return nil
+	}
+	previous := entry
+	entry.Jti = jti
 	f.entries[key] = entry
 	if err := f.flush(); err != nil {
 		f.entries[key] = previous
@@ -584,6 +631,16 @@ type RefreshTokenStore interface {
 	// value even for soft-revoked (already-rotated) entries so it can be read
 	// after ReserveRefreshToken, mirroring LookupNonce.
 	LookupProviderAccessToken(refreshToken string) string
+	// RevokeJTI adds the JWT ID (jti claim) of a gateway-issued access token
+	// (builtin mode) to the revocation denylist until expiresAt, which should
+	// be the token's own exp claim so the entry is naturally swept once the
+	// JWT would have expired anyway. Used by POST /revoke (RFC 7009) so that a
+	// revoked JWT is rejected even though JWT verification is otherwise
+	// stateless.
+	RevokeJTI(jti string, expiresAt time.Time) error
+	// IsJTIRevoked reports whether jti is present in the (non-expired)
+	// revocation denylist.
+	IsJTIRevoked(jti string) bool
 	// Sweep removes all expired entries. Called periodically by the Store janitor.
 	Sweep() error
 }
@@ -601,14 +658,18 @@ type memRTEntry struct {
 }
 
 type memRefreshTokenStore struct {
-	mu      sync.RWMutex
-	entries map[string]memRTEntry // key: tokenKey(rawRefreshToken)
+	mu         sync.RWMutex
+	entries    map[string]memRTEntry // key: tokenKey(rawRefreshToken)
+	revokedJTI map[string]time.Time  // key: jti, value: expiresAt
 }
 
 // NewMemRefreshTokenStore returns an in-memory RefreshTokenStore.
 // All data is lost when the process exits.
 func NewMemRefreshTokenStore() RefreshTokenStore {
-	return &memRefreshTokenStore{entries: make(map[string]memRTEntry)}
+	return &memRefreshTokenStore{
+		entries:    make(map[string]memRTEntry),
+		revokedJTI: make(map[string]time.Time),
+	}
 }
 
 func (m *memRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
@@ -721,6 +782,23 @@ func (m *memRefreshTokenStore) Delete(refreshToken string) error {
 	return nil
 }
 
+func (m *memRefreshTokenStore) RevokeJTI(jti string, expiresAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revokedJTI[jti] = expiresAt
+	return nil
+}
+
+func (m *memRefreshTokenStore) IsJTIRevoked(jti string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	expiresAt, ok := m.revokedJTI[jti]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(expiresAt)
+}
+
 func (m *memRefreshTokenStore) Sweep() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -728,6 +806,11 @@ func (m *memRefreshTokenStore) Sweep() error {
 	for k, v := range m.entries {
 		if now.After(v.expiresAt) {
 			delete(m.entries, k)
+		}
+	}
+	for jti, expiresAt := range m.revokedJTI {
+		if now.After(expiresAt) {
+			delete(m.revokedJTI, jti)
 		}
 	}
 	return nil
@@ -753,6 +836,13 @@ type fileRefreshTokenStore struct {
 	mu      sync.RWMutex
 	path    string
 	entries map[string]fileRTEntry // key: tokenKey(rawRefreshToken)
+	// revokedJTI is intentionally in-memory only (not persisted to path).
+	// This legacy file-backed implementation is only exercised directly by
+	// its own contract tests; the live NewHandler path migrates it to
+	// sqliteRefreshTokenStore at startup (see tokenstore_sqlite_migrate.go)
+	// before any /revoke traffic can occur, so a durable denylist here is
+	// unreachable in production.
+	revokedJTI map[string]time.Time
 }
 
 // NewFileRefreshTokenStore returns a file-backed RefreshTokenStore that loads
@@ -761,8 +851,9 @@ type fileRefreshTokenStore struct {
 // If the file does not yet exist, an empty store is returned without error.
 func NewFileRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	s := &fileRefreshTokenStore{
-		path:    path,
-		entries: make(map[string]fileRTEntry),
+		path:       path,
+		entries:    make(map[string]fileRTEntry),
+		revokedJTI: make(map[string]time.Time),
 	}
 	if err := s.load(); err != nil {
 		if !os.IsNotExist(err) {
@@ -952,9 +1043,32 @@ func (f *fileRefreshTokenStore) Delete(refreshToken string) error {
 	return nil
 }
 
+func (f *fileRefreshTokenStore) RevokeJTI(jti string, expiresAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revokedJTI[jti] = expiresAt
+	return nil
+}
+
+func (f *fileRefreshTokenStore) IsJTIRevoked(jti string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	expiresAt, ok := f.revokedJTI[jti]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(expiresAt)
+}
+
 func (f *fileRefreshTokenStore) Sweep() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	now := time.Now()
+	for jti, expiresAt := range f.revokedJTI {
+		if now.After(expiresAt) {
+			delete(f.revokedJTI, jti)
+		}
+	}
 	if changed := f.sweepLocked(); !changed {
 		return nil
 	}

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -67,6 +67,49 @@ type sqliteRefreshTokenStore struct {
 	db *sql.DB
 }
 
+// sqlExecer is satisfied by both *sql.DB and *sql.Tx, letting
+// backfillFamilyCurrentAccessToken run either as a standalone statement
+// (startup) or inside an existing transaction (legacy file migration).
+type sqlExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// backfillFamilyCurrentAccessTokenSQL populates family_current_access_token
+// for any family that has non-revoked, non-expired refresh_tokens rows but
+// no pointer entry yet — i.e. rows that predate this feature (an existing
+// database reopened after upgrade) or that were just written directly by
+// migrateFileRefreshTokenStore (which inserts into refresh_tokens without
+// going through Save, so it never populates the pointer table on its own).
+// INSERT OR IGNORE is a no-op for a family that already has a pointer, so
+// this never clobbers state Save has correctly been maintaining.
+//
+// Per family, the backfilled row is the non-revoked one with the latest
+// expires_at. Under correct operation at most one non-revoked row exists per
+// family at a time (rotation soft-revokes the predecessor before creating
+// the successor), so this is unambiguous; the MAX(expires_at) tie-break only
+// matters for anomalous pre-existing data, where it is a reasonable
+// heuristic (each rotation extends expires_at to a fresh TTL, so the
+// non-revoked row with the furthest-out expiry is the most recently rotated
+// one).
+const backfillFamilyCurrentAccessTokenSQL = `
+INSERT OR IGNORE INTO family_current_access_token (family_id, access_token, expires_at)
+SELECT r.family_id, r.access_token, r.expires_at
+FROM refresh_tokens r
+WHERE r.revoked = 0 AND r.family_id != '' AND r.expires_at > ?
+  AND r.expires_at = (
+    SELECT MAX(r2.expires_at) FROM refresh_tokens r2
+    WHERE r2.family_id = r.family_id AND r2.revoked = 0
+  )
+`
+
+func backfillFamilyCurrentAccessToken(ex sqlExecer) error {
+	_, err := ex.Exec(backfillFamilyCurrentAccessTokenSQL, time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("backfilling family_current_access_token: %w", err)
+	}
+	return nil
+}
+
 // NewSQLiteRefreshTokenStore returns a SQLite-backed RefreshTokenStore.
 // path may be ":memory:" for in-process testing.
 func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
@@ -87,6 +130,14 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	// intentionally ignore).
 	_, _ = db.Exec(`ALTER TABLE refresh_tokens ADD COLUMN nonce TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE refresh_tokens ADD COLUMN provider_access_token TEXT NOT NULL DEFAULT ''`)
+	// Backfill family_current_access_token for a database that predates this
+	// feature — otherwise a family whose only pointer-eligible row exists
+	// from before the upgrade would resolve to no current access token on
+	// the first POST /revoke after upgrading (see backfillFamilyCurrentAccessTokenSQL).
+	if err := backfillFamilyCurrentAccessToken(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("initialising SQLite refresh token store: %w", err)
+	}
 	if path != ":memory:" {
 		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
 			slog.Warn("SQLite refresh token store chmod failed", "path", path, "err", err)

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -46,6 +46,21 @@ CREATE TABLE IF NOT EXISTS revoked_families (
 	family_id  TEXT PRIMARY KEY,
 	revoked_at INTEGER NOT NULL
 );
+
+-- family_current_access_token tracks, per family, the access token most
+-- recently written by a successful Save — independent of whether the
+-- refresh_tokens row backing it has since been soft-revoked (e.g.
+-- mid-rotation, after the old row is reserved but before the new row's Save
+-- runs). RevokeFamily reads this atomically alongside its own tombstone
+-- write so POST /revoke can denylist the access token actually in use at
+-- the moment of revocation, not a stale predecessor. Swept on the same
+-- expires_at basis as refresh_tokens.
+CREATE TABLE IF NOT EXISTS family_current_access_token (
+	family_id    TEXT PRIMARY KEY,
+	access_token TEXT NOT NULL,
+	expires_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_family_cat_expires ON family_current_access_token (expires_at);
 `
 
 type sqliteRefreshTokenStore struct {
@@ -89,26 +104,47 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 }
 
 // Save writes refreshToken's row guarded by a NOT EXISTS check against
-// revoked_families: the write and the tombstone check happen inside a single
-// statement, so this is atomic with RevokeFamily's own write with respect to
-// concurrent callers (the store's single DB connection — see
+// revoked_families, and — inside the same transaction — updates the
+// family's family_current_access_token pointer. Wrapping both in one
+// transaction means this is atomic with RevokeFamily's own transaction with
+// respect to concurrent callers (the store's single DB connection — see
 // NewSQLiteRefreshTokenStore's SetMaxOpenConns(1) — fully serialises every
-// Exec against this database, so whichever of Save/RevokeFamily's writes
-// commits first is authoritative for the other). If familyID is tombstoned,
-// RowsAffected is 0 and ErrRefreshTokenFamilyRevoked is returned without
-// writing a row.
+// transaction against this database, so whichever of Save/RevokeFamily
+// commits first is authoritative for the other: a Save that commits first
+// is guaranteed to be observed by a subsequent RevokeFamily's pointer read,
+// and a Save that runs after RevokeFamily's tombstone commits is guaranteed
+// to be rejected). If familyID is tombstoned, RowsAffected is 0 and
+// ErrRefreshTokenFamilyRevoked is returned without writing anything.
 func (s *sqliteRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
-	res, err := s.db.Exec(
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("saving refresh token: %w", err)
+	}
+	res, err := tx.Exec(
 		`INSERT OR REPLACE INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked)
 		 SELECT ?, ?, ?, ?, ?, 0
 		 WHERE ? = '' OR NOT EXISTS (SELECT 1 FROM revoked_families WHERE family_id = ?)`,
 		tokenKey(refreshToken), accessToken, audience, familyID, expiresAt.Unix(), familyID, familyID,
 	)
 	if err != nil {
+		_ = tx.Rollback()
 		return fmt.Errorf("saving refresh token: %w", err)
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
+		_ = tx.Rollback()
 		return ErrRefreshTokenFamilyRevoked
+	}
+	if familyID != "" {
+		if _, err := tx.Exec(
+			`INSERT OR REPLACE INTO family_current_access_token (family_id, access_token, expires_at) VALUES (?, ?, ?)`,
+			familyID, accessToken, expiresAt.Unix(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("saving refresh token: updating family pointer: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("saving refresh token: %w", err)
 	}
 	return nil
 }
@@ -142,23 +178,6 @@ func (s *sqliteRefreshTokenStore) LookupAny(refreshToken string) (string, string
 	return at, aud, fid, time.Unix(expiresUnix, 0), revokedInt != 0, true
 }
 
-func (s *sqliteRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
-	if familyID == "" {
-		return "", false
-	}
-	var at string
-	err := s.db.QueryRow(
-		`SELECT access_token FROM refresh_tokens
-		 WHERE family_id = ? AND expires_at > ? AND revoked = 0
-		 LIMIT 1`,
-		familyID, time.Now().Unix(),
-	).Scan(&at)
-	if err != nil {
-		return "", false
-	}
-	return at, true
-}
-
 func (s *sqliteRefreshTokenStore) Revoke(refreshToken string) error {
 	_, err := s.db.Exec(
 		`UPDATE refresh_tokens SET revoked = 1 WHERE token_hash = ? AND expires_at > ? AND revoked = 0`,
@@ -170,39 +189,50 @@ func (s *sqliteRefreshTokenStore) Revoke(refreshToken string) error {
 	return nil
 }
 
-// RevokeFamily marks every non-revoked row for familyID as revoked and
-// tombstones familyID in revoked_families, all inside one transaction so a
-// concurrent Save for the same familyID (see Save's doc comment) either
-// commits entirely before this transaction starts (and is caught by the
-// UPDATE below) or is blocked by the tombstone once this transaction
-// commits — the single DB connection means there is no interleaving window
-// between the two.
-func (s *sqliteRefreshTokenStore) RevokeFamily(familyID string) error {
+// RevokeFamily marks every non-revoked row for familyID as revoked,
+// tombstones familyID in revoked_families, and reads back the family's
+// current access token pointer — all inside one transaction, so a concurrent
+// Save for the same familyID (see Save's doc comment) either commits
+// entirely before this transaction starts (in which case both the UPDATE
+// below and the pointer read see it) or is blocked by the tombstone once
+// this transaction commits (in which case it can never produce a pointer
+// value this call could have missed). The single DB connection means there
+// is no interleaving window between the two.
+func (s *sqliteRefreshTokenStore) RevokeFamily(familyID string) (string, error) {
 	if familyID == "" {
-		return nil
+		return "", nil
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
-		return fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
+		return "", fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
 	}
 	if _, err := tx.Exec(
 		`UPDATE refresh_tokens SET revoked = 1 WHERE family_id = ? AND revoked = 0`,
 		familyID,
 	); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
+		return "", fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
 	}
 	if _, err := tx.Exec(
 		`INSERT OR IGNORE INTO revoked_families (family_id, revoked_at) VALUES (?, ?)`,
 		familyID, time.Now().Unix(),
 	); err != nil {
 		_ = tx.Rollback()
-		return fmt.Errorf("tombstoning refresh token family %q: %w", familyID, err)
+		return "", fmt.Errorf("tombstoning refresh token family %q: %w", familyID, err)
+	}
+	var currentAccessToken string
+	err = tx.QueryRow(
+		`SELECT access_token FROM family_current_access_token WHERE family_id = ? AND expires_at > ?`,
+		familyID, time.Now().Unix(),
+	).Scan(&currentAccessToken)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		_ = tx.Rollback()
+		return "", fmt.Errorf("reading current access token for family %q: %w", familyID, err)
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("committing refresh token family revocation %q: %w", familyID, err)
+		return "", fmt.Errorf("committing refresh token family revocation %q: %w", familyID, err)
 	}
-	return nil
+	return currentAccessToken, nil
 }
 
 func (s *sqliteRefreshTokenStore) SaveNonce(refreshToken, nonce string) error {
@@ -296,6 +326,10 @@ func (s *sqliteRefreshTokenStore) Sweep() error {
 	_, err = s.db.Exec(`DELETE FROM revoked_jti WHERE expires_at <= ?`, time.Now().Unix())
 	if err != nil {
 		return fmt.Errorf("sweeping expired revoked jti entries: %w", err)
+	}
+	_, err = s.db.Exec(`DELETE FROM family_current_access_token WHERE expires_at <= ?`, time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("sweeping expired family access token pointers: %w", err)
 	}
 	return nil
 }

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -23,6 +23,16 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 );
 CREATE INDEX IF NOT EXISTS idx_rt_family  ON refresh_tokens (family_id) WHERE revoked = 0;
 CREATE INDEX IF NOT EXISTS idx_rt_expires ON refresh_tokens (expires_at);
+
+-- revoked_jti is the denylist for gateway-issued access tokens (builtin
+-- mode). expires_at mirrors the token's own exp claim so entries are
+-- naturally swept once the JWT would have expired anyway, bounding the
+-- table to the set of revoked-but-not-yet-expired tokens.
+CREATE TABLE IF NOT EXISTS revoked_jti (
+	jti        TEXT    PRIMARY KEY,
+	expires_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_revoked_jti_expires ON revoked_jti (expires_at);
 `
 
 type sqliteRefreshTokenStore struct {
@@ -182,9 +192,36 @@ func (s *sqliteRefreshTokenStore) Delete(refreshToken string) error {
 	return nil
 }
 
+func (s *sqliteRefreshTokenStore) RevokeJTI(jti string, expiresAt time.Time) error {
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO revoked_jti (jti, expires_at) VALUES (?, ?)`,
+		jti, expiresAt.Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("revoking jti: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteRefreshTokenStore) IsJTIRevoked(jti string) bool {
+	var expiresAt int64
+	err := s.db.QueryRow(
+		`SELECT expires_at FROM revoked_jti WHERE jti = ? AND expires_at > ?`,
+		jti, time.Now().Unix(),
+	).Scan(&expiresAt)
+	return err == nil
+}
+
 func (s *sqliteRefreshTokenStore) Sweep() error {
 	_, err := s.sweepNow()
-	return err
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`DELETE FROM revoked_jti WHERE expires_at <= ?`, time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("sweeping expired revoked jti entries: %w", err)
+	}
+	return nil
 }
 
 func (s *sqliteRefreshTokenStore) sweepNow() (int64, error) {

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -33,6 +34,18 @@ CREATE TABLE IF NOT EXISTS revoked_jti (
 	expires_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_revoked_jti_expires ON revoked_jti (expires_at);
+
+-- revoked_families tombstones a refresh-token family (RFC 6819 §5.2.2.3)
+-- permanently, independent of the mutable revoked flag on individual
+-- refresh_tokens rows. Save() checks this table so a rotation racing a
+-- concurrent RevokeFamily cannot resurrect the family with a fresh,
+-- non-revoked row after the revocation appears to have completed. Never
+-- swept: family IDs are single-use random strings, so this table only grows
+-- with explicit revocations (expected to stay small).
+CREATE TABLE IF NOT EXISTS revoked_families (
+	family_id  TEXT PRIMARY KEY,
+	revoked_at INTEGER NOT NULL
+);
 `
 
 type sqliteRefreshTokenStore struct {
@@ -75,14 +88,27 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	return s, nil
 }
 
+// Save writes refreshToken's row guarded by a NOT EXISTS check against
+// revoked_families: the write and the tombstone check happen inside a single
+// statement, so this is atomic with RevokeFamily's own write with respect to
+// concurrent callers (the store's single DB connection — see
+// NewSQLiteRefreshTokenStore's SetMaxOpenConns(1) — fully serialises every
+// Exec against this database, so whichever of Save/RevokeFamily's writes
+// commits first is authoritative for the other). If familyID is tombstoned,
+// RowsAffected is 0 and ErrRefreshTokenFamilyRevoked is returned without
+// writing a row.
 func (s *sqliteRefreshTokenStore) Save(refreshToken, accessToken, audience, familyID string, expiresAt time.Time) error {
-	_, err := s.db.Exec(
+	res, err := s.db.Exec(
 		`INSERT OR REPLACE INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked)
-		 VALUES (?, ?, ?, ?, ?, 0)`,
-		tokenKey(refreshToken), accessToken, audience, familyID, expiresAt.Unix(),
+		 SELECT ?, ?, ?, ?, ?, 0
+		 WHERE ? = '' OR NOT EXISTS (SELECT 1 FROM revoked_families WHERE family_id = ?)`,
+		tokenKey(refreshToken), accessToken, audience, familyID, expiresAt.Unix(), familyID, familyID,
 	)
 	if err != nil {
 		return fmt.Errorf("saving refresh token: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrRefreshTokenFamilyRevoked
 	}
 	return nil
 }
@@ -116,6 +142,23 @@ func (s *sqliteRefreshTokenStore) LookupAny(refreshToken string) (string, string
 	return at, aud, fid, time.Unix(expiresUnix, 0), revokedInt != 0, true
 }
 
+func (s *sqliteRefreshTokenStore) LookupActiveByFamily(familyID string) (string, bool) {
+	if familyID == "" {
+		return "", false
+	}
+	var at string
+	err := s.db.QueryRow(
+		`SELECT access_token FROM refresh_tokens
+		 WHERE family_id = ? AND expires_at > ? AND revoked = 0
+		 LIMIT 1`,
+		familyID, time.Now().Unix(),
+	).Scan(&at)
+	if err != nil {
+		return "", false
+	}
+	return at, true
+}
+
 func (s *sqliteRefreshTokenStore) Revoke(refreshToken string) error {
 	_, err := s.db.Exec(
 		`UPDATE refresh_tokens SET revoked = 1 WHERE token_hash = ? AND expires_at > ? AND revoked = 0`,
@@ -127,16 +170,37 @@ func (s *sqliteRefreshTokenStore) Revoke(refreshToken string) error {
 	return nil
 }
 
+// RevokeFamily marks every non-revoked row for familyID as revoked and
+// tombstones familyID in revoked_families, all inside one transaction so a
+// concurrent Save for the same familyID (see Save's doc comment) either
+// commits entirely before this transaction starts (and is caught by the
+// UPDATE below) or is blocked by the tombstone once this transaction
+// commits — the single DB connection means there is no interleaving window
+// between the two.
 func (s *sqliteRefreshTokenStore) RevokeFamily(familyID string) error {
 	if familyID == "" {
 		return nil
 	}
-	_, err := s.db.Exec(
-		`UPDATE refresh_tokens SET revoked = 1 WHERE family_id = ? AND revoked = 0`,
-		familyID,
-	)
+	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE refresh_tokens SET revoked = 1 WHERE family_id = ? AND revoked = 0`,
+		familyID,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("revoking refresh token family %q: %w", familyID, err)
+	}
+	if _, err := tx.Exec(
+		`INSERT OR IGNORE INTO revoked_families (family_id, revoked_at) VALUES (?, ?)`,
+		familyID, time.Now().Unix(),
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("tombstoning refresh token family %q: %w", familyID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing refresh token family revocation %q: %w", familyID, err)
 	}
 	return nil
 }
@@ -203,13 +267,25 @@ func (s *sqliteRefreshTokenStore) RevokeJTI(jti string, expiresAt time.Time) err
 	return nil
 }
 
+// IsJTIRevoked fails closed: sql.ErrNoRows (the jti is genuinely absent) is
+// the only error treated as "not revoked". Any other error — a locked,
+// unreadable, or corrupt database — is treated as revoked, because the
+// alternative (failing open) would let an actually-revoked gateway JWT keep
+// validating whenever the denylist happens to be unreadable.
 func (s *sqliteRefreshTokenStore) IsJTIRevoked(jti string) bool {
 	var expiresAt int64
 	err := s.db.QueryRow(
 		`SELECT expires_at FROM revoked_jti WHERE jti = ? AND expires_at > ?`,
 		jti, time.Now().Unix(),
 	).Scan(&expiresAt)
-	return err == nil
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false
+	}
+	slog.Warn("jti denylist query failed; failing closed (treating token as revoked)", "err", err)
+	return true
 }
 
 func (s *sqliteRefreshTokenStore) Sweep() error {

--- a/internal/auth/tokenstore_sqlite_migrate.go
+++ b/internal/auth/tokenstore_sqlite_migrate.go
@@ -70,6 +70,15 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 		}
 		imported++
 	}
+	// migrated rows are inserted directly into refresh_tokens, bypassing
+	// Save, so family_current_access_token is never populated for them on
+	// its own — backfill within the same transaction so a family that had
+	// already rotated in the legacy store resolves to its current access
+	// token on the very first POST /revoke after migration.
+	if err := backfillFamilyCurrentAccessToken(tx); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("backfilling migrated family pointers: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing migration transaction: %w", err)
 	}

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -312,5 +314,89 @@ func TestSQLiteRefreshTokenStoreRevoke(t *testing.T) {
 	// Sibling token in the same family must be unaffected.
 	if _, _, _, _, ok := rts.Lookup("rt-b"); !ok {
 		t.Error("Lookup rt-b: sibling must remain accessible after Revoke(rt-a)")
+	}
+}
+
+// TestSQLiteRefreshTokenStoreIsJTIRevokedFailsClosedOnDBError verifies that
+// IsJTIRevoked treats a database error (as opposed to a legitimate "not
+// found") as revoked, per the Copilot review finding on PR #195: failing
+// open here would let a JWT that really was denylisted keep validating
+// whenever the store happens to be unreadable (locked, corrupt, read-only).
+func TestSQLiteRefreshTokenStoreIsJTIRevokedFailsClosedOnDBError(t *testing.T) {
+	rts, err := NewSQLiteRefreshTokenStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteRefreshTokenStore: %v", err)
+	}
+	sq := rts.(*sqliteRefreshTokenStore)
+
+	// Baseline: an absent jti (sql.ErrNoRows path) is correctly "not revoked".
+	if sq.IsJTIRevoked("never-revoked") {
+		t.Fatal("IsJTIRevoked: expected false for an absent jti before simulating a DB error")
+	}
+
+	// Force every subsequent query to fail with something other than
+	// ErrNoRows by closing the underlying connection.
+	if err := sq.db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	if !sq.IsJTIRevoked("any-jti") {
+		t.Error("IsJTIRevoked: expected true (fail closed) when the database is unreadable")
+	}
+}
+
+// TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke stress-tests the
+// atomicity between Save (rotation) and RevokeFamily (POST /revoke) for the
+// same family, racing many goroutines against a single family to catch any
+// interleaving that would let a rotation slip a fresh, non-revoked row past
+// a concurrent revocation (thread-owl review, PR #195).
+func TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke(t *testing.T) {
+	rts, err := NewSQLiteRefreshTokenStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteRefreshTokenStore: %v", err)
+	}
+	sq := rts.(*sqliteRefreshTokenStore)
+	t.Cleanup(func() { _ = sq.Close() })
+
+	const familyID = "fid-race"
+	exp := time.Now().Add(time.Hour)
+	if err := rts.Save("rt-race-0", "at-race-0", "aud", familyID, exp); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	const attempts = 200
+	revokeStart := make(chan struct{})
+	saveResults := make([]error, attempts)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-revokeStart
+		for i := range attempts {
+			rt := fmt.Sprintf("rt-race-%d", i+1)
+			saveResults[i] = rts.Save(rt, "at-race-n", "aud", familyID, exp)
+		}
+	}()
+
+	close(revokeStart)
+	if err := rts.RevokeFamily(familyID); err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+	<-done
+
+	// Every successful Save must have produced a row that RevokeFamily's own
+	// UPDATE would have caught (i.e. it is now revoked) — the invariant this
+	// test protects is "no active, non-revoked row survives a completed
+	// RevokeFamily call for its family", not any particular split between
+	// successful and rejected Saves (that split is a legitimate race outcome
+	// depending on scheduling).
+	active, ok := rts.LookupActiveByFamily(familyID)
+	if ok {
+		t.Errorf("LookupActiveByFamily after RevokeFamily: got active row %q, want none", active)
+	}
+	for i, err := range saveResults {
+		if err != nil && !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
+			t.Errorf("Save[%d]: unexpected error %v", i, err)
+		}
 	}
 }

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -246,6 +246,44 @@ func TestMigrateFileRefreshTokenStore(t *testing.T) {
 	}
 }
 
+// TestMigrateFileRefreshTokenStoreBackfillsFamilyPointer verifies that a
+// legacy family which had already rotated once (an old revoked row plus a
+// current non-revoked row for the same family_id) resolves to its current
+// access token via RevokeFamily immediately after migration — legacy rows
+// are inserted directly into refresh_tokens, bypassing Save, so
+// family_current_access_token would otherwise stay empty for them
+// (thread-owl review round 3, PR #195).
+func TestMigrateFileRefreshTokenStoreBackfillsFamilyPointer(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json.refresh")
+
+	exp := time.Now().Add(time.Hour)
+	entries := map[string]fileRTEntry{
+		tokenKey("rt-legacy-old"):     {AccessToken: "at-legacy-old", Audience: "aud", FamilyID: "fid-legacy", ExpiresAt: exp, Revoked: true},
+		tokenKey("rt-legacy-current"): {AccessToken: "at-legacy-current", Audience: "aud", FamilyID: "fid-legacy", ExpiresAt: exp},
+	}
+	data, _ := json.Marshal(entries)
+	if err := os.WriteFile(legacyPath, data, 0o600); err != nil {
+		t.Fatalf("writing legacy file: %v", err)
+	}
+
+	dst, err := NewSQLiteRefreshTokenStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteRefreshTokenStore: %v", err)
+	}
+	if err := migrateFileRefreshTokenStore(legacyPath, dst); err != nil {
+		t.Fatalf("migrateFileRefreshTokenStore: %v", err)
+	}
+
+	current, err := dst.RevokeFamily("fid-legacy")
+	if err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+	if current != "at-legacy-current" {
+		t.Errorf("RevokeFamily after migration: got %q, want %q (the non-revoked legacy row, not the stale one)", current, "at-legacy-current")
+	}
+}
+
 // TestMigrateFileRefreshTokenStoreNoFile verifies that migration is a no-op
 // when the legacy file does not exist.
 func TestMigrateFileRefreshTokenStoreNoFile(t *testing.T) {
@@ -423,5 +461,67 @@ func TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke(t *testing.T) {
 	}
 	if pointerAfter != currentAccessToken {
 		t.Errorf("family_current_access_token after RevokeFamily: got %q, want unchanged %q", pointerAfter, currentAccessToken)
+	}
+}
+
+// TestSQLiteRefreshTokenStoreBackfillsFamilyPointerOnReopen verifies that
+// reopening a database whose refresh_tokens rows predate the
+// family_current_access_token feature (inserted directly, bypassing Save)
+// backfills the pointer from the existing non-revoked row — otherwise a
+// family that had already rotated before an upgrade would resolve to no
+// current access token (or handler.go's stale fallback) on the first POST
+// /revoke after upgrading (thread-owl review round 3, PR #195).
+func TestSQLiteRefreshTokenStoreBackfillsFamilyPointerOnReopen(t *testing.T) {
+	path := tempSQLitePath(t)
+
+	rts1, err := NewSQLiteRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	sq1 := rts1.(*sqliteRefreshTokenStore)
+
+	// Simulate rows that predate the pointer feature: insert directly into
+	// refresh_tokens, bypassing Save (which would have populated
+	// family_current_access_token on its own).
+	exp := time.Now().Add(time.Hour).Unix()
+	if _, err := sq1.db.Exec(
+		`INSERT INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked) VALUES (?, ?, ?, ?, ?, 1)`,
+		tokenKey("rt-legacy-old"), "at-legacy-old", "aud", "fid-legacy", exp,
+	); err != nil {
+		t.Fatalf("seed old row: %v", err)
+	}
+	if _, err := sq1.db.Exec(
+		`INSERT INTO refresh_tokens (token_hash, access_token, audience, family_id, expires_at, revoked) VALUES (?, ?, ?, ?, ?, 0)`,
+		tokenKey("rt-legacy-current"), "at-legacy-current", "aud", "fid-legacy", exp,
+	); err != nil {
+		t.Fatalf("seed current row: %v", err)
+	}
+	var count int
+	if err := sq1.db.QueryRow(
+		`SELECT COUNT(*) FROM family_current_access_token WHERE family_id = ?`, "fid-legacy",
+	).Scan(&count); err != nil {
+		t.Fatalf("querying pointer count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("setup: expected no pointer before reopen, got %d", count)
+	}
+	if err := sq1.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen: NewSQLiteRefreshTokenStore must backfill the pointer from the
+	// pre-existing non-revoked row.
+	rts2, err := NewSQLiteRefreshTokenStore(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	closeSQLiteStore(t, rts2)
+
+	current, err := rts2.RevokeFamily("fid-legacy")
+	if err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+	if current != "at-legacy-current" {
+		t.Errorf("RevokeFamily after backfill-on-reopen: got %q, want %q", current, "at-legacy-current")
 	}
 }

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -169,7 +169,7 @@ func TestSQLiteRefreshTokenStoreRevokedPersists(t *testing.T) {
 	if err := rts1.Save("rt-rv", "at-rv", "aud", "fid-rv", exp); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := rts1.RevokeFamily("fid-rv"); err != nil {
+	if _, err := rts1.RevokeFamily("fid-rv"); err != nil {
 		t.Fatalf("RevokeFamily: %v", err)
 	}
 	rts1.(*sqliteRefreshTokenStore).Close() //nolint — close before reopening
@@ -348,8 +348,9 @@ func TestSQLiteRefreshTokenStoreIsJTIRevokedFailsClosedOnDBError(t *testing.T) {
 // TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke stress-tests the
 // atomicity between Save (rotation) and RevokeFamily (POST /revoke) for the
 // same family, racing many goroutines against a single family to catch any
-// interleaving that would let a rotation slip a fresh, non-revoked row past
-// a concurrent revocation (thread-owl review, PR #195).
+// interleaving that would let a rotation slip a fresh, non-revoked row (or
+// an unaccounted-for family_current_access_token pointer value) past a
+// concurrent revocation (thread-owl review, PR #195).
 func TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke(t *testing.T) {
 	rts, err := NewSQLiteRefreshTokenStore(":memory:")
 	if err != nil {
@@ -359,14 +360,22 @@ func TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke(t *testing.T) {
 	t.Cleanup(func() { _ = sq.Close() })
 
 	const familyID = "fid-race"
+	const seedAccessToken = "at-race-0"
 	exp := time.Now().Add(time.Hour)
-	if err := rts.Save("rt-race-0", "at-race-0", "aud", familyID, exp); err != nil {
+	if err := rts.Save("rt-race-0", seedAccessToken, "aud", familyID, exp); err != nil {
 		t.Fatalf("seed Save: %v", err)
 	}
 
 	const attempts = 200
 	revokeStart := make(chan struct{})
 	saveResults := make([]error, attempts)
+	// Each attempt writes a distinct access token so a successful Save can be
+	// unambiguously identified by value alone (rather than by index, which a
+	// racing goroutine cannot correlate to RevokeFamily's returned pointer).
+	accessTokens := make([]string, attempts)
+	for i := range attempts {
+		accessTokens[i] = fmt.Sprintf("at-race-%d", i+1)
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -374,29 +383,45 @@ func TestSQLiteRefreshTokenStoreConcurrentRotationVsRevoke(t *testing.T) {
 		<-revokeStart
 		for i := range attempts {
 			rt := fmt.Sprintf("rt-race-%d", i+1)
-			saveResults[i] = rts.Save(rt, "at-race-n", "aud", familyID, exp)
+			saveResults[i] = rts.Save(rt, accessTokens[i], "aud", familyID, exp)
 		}
 	}()
 
 	close(revokeStart)
-	if err := rts.RevokeFamily(familyID); err != nil {
+	currentAccessToken, err := rts.RevokeFamily(familyID)
+	if err != nil {
 		t.Fatalf("RevokeFamily: %v", err)
 	}
 	<-done
 
-	// Every successful Save must have produced a row that RevokeFamily's own
-	// UPDATE would have caught (i.e. it is now revoked) — the invariant this
-	// test protects is "no active, non-revoked row survives a completed
-	// RevokeFamily call for its family", not any particular split between
-	// successful and rejected Saves (that split is a legitimate race outcome
-	// depending on scheduling).
-	active, ok := rts.LookupActiveByFamily(familyID)
-	if ok {
-		t.Errorf("LookupActiveByFamily after RevokeFamily: got active row %q, want none", active)
-	}
+	// RevokeFamily's returned pointer must correspond to a write that
+	// actually happened — either the seed or one of the Saves that reported
+	// success — never an unknown or torn value.
+	validValues := map[string]bool{seedAccessToken: true}
 	for i, err := range saveResults {
-		if err != nil && !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
+		if err == nil {
+			validValues[accessTokens[i]] = true
+		} else if !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
 			t.Errorf("Save[%d]: unexpected error %v", i, err)
 		}
+	}
+	if currentAccessToken == "" || !validValues[currentAccessToken] {
+		t.Errorf("RevokeFamily: returned currentAccessToken %q, want one of the seed or successfully-saved values", currentAccessToken)
+	}
+
+	// Once RevokeFamily has returned, the tombstone must stick: no further
+	// Save for this family can succeed, so the pointer can never advance
+	// past whatever RevokeFamily observed.
+	if err := rts.Save("rt-race-post", "at-race-post", "aud", familyID, exp); !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
+		t.Errorf("Save after RevokeFamily returned: got err=%v, want ErrRefreshTokenFamilyRevoked", err)
+	}
+	var pointerAfter string
+	if err := sq.db.QueryRow(
+		`SELECT access_token FROM family_current_access_token WHERE family_id = ?`, familyID,
+	).Scan(&pointerAfter); err != nil {
+		t.Fatalf("querying family_current_access_token: %v", err)
+	}
+	if pointerAfter != currentAccessToken {
+		t.Errorf("family_current_access_token after RevokeFamily: got %q, want unchanged %q", pointerAfter, currentAccessToken)
 	}
 }

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -125,6 +125,37 @@ func testTokenStoreContract(t *testing.T, ts TokenStore) {
 	if _, ok := ts.Lookup("no-such-token"); ok {
 		t.Error("SaveProviderAccessToken must not create an entry for an unknown token")
 	}
+
+	// SaveJti attaches the JWT ID to an existing entry; Lookup returns it.
+	if err := ts.Save("tok-jti", "grace", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save tok-jti: %v", err)
+	}
+	if err := ts.SaveJti("tok-jti", "jti-abc123"); err != nil {
+		t.Fatalf("SaveJti: %v", err)
+	}
+	recJti, okJti := ts.Lookup("tok-jti")
+	if !okJti {
+		t.Fatal("Lookup tok-jti: expected hit after SaveJti")
+	}
+	if recJti.Jti != "jti-abc123" {
+		t.Errorf("SaveJti: Jti got %q, want %q", recJti.Jti, "jti-abc123")
+	}
+
+	// SaveJti on absent token is a no-op (no error, no entry created).
+	if err := ts.SaveJti("no-such-token", "jti-ghost"); err != nil {
+		t.Fatalf("SaveJti on absent token returned error: %v", err)
+	}
+	if _, ok := ts.Lookup("no-such-token"); ok {
+		t.Error("SaveJti must not create an entry for an unknown token")
+	}
+
+	// SaveJti on expired token is a no-op (no error).
+	if err := ts.Save("tok-expired-jti", "heidi", nil, time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("Save expired jti token: %v", err)
+	}
+	if err := ts.SaveJti("tok-expired-jti", "jti-xyz"); err != nil {
+		t.Fatalf("SaveJti on expired token returned error: %v", err)
+	}
 }
 
 // ── memTokenStore ─────────────────────────────────────────────────────────────
@@ -657,6 +688,34 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if got := rts.LookupProviderAccessToken("rt-pat-revoked"); got != "gho_rev1" {
 		t.Errorf("LookupProviderAccessToken after Revoke: got %q, want %q (soft-revoked entries must remain readable)", got, "gho_rev1")
 	}
+
+	// IsJTIRevoked is false before RevokeJTI.
+	if rts.IsJTIRevoked("jti-1") {
+		t.Error("IsJTIRevoked: expected false before RevokeJTI")
+	}
+	// RevokeJTI adds an entry that IsJTIRevoked then reports as revoked.
+	if err := rts.RevokeJTI("jti-1", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("RevokeJTI: %v", err)
+	}
+	if !rts.IsJTIRevoked("jti-1") {
+		t.Error("IsJTIRevoked: expected true after RevokeJTI")
+	}
+	// A jti revoked with an already-past expiresAt is not reported as revoked
+	// (mirrors natural expiry — the entry is inert even before Sweep runs).
+	if err := rts.RevokeJTI("jti-expired", time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("RevokeJTI (expired): %v", err)
+	}
+	if rts.IsJTIRevoked("jti-expired") {
+		t.Error("IsJTIRevoked: expected false for a jti revoked with a past expiresAt")
+	}
+	// Sweep must not error with revoked jti entries present (some already expired).
+	if err := rts.Sweep(); err != nil {
+		t.Fatalf("Sweep with revoked jti entries: %v", err)
+	}
+	// The still-valid jti survives Sweep.
+	if !rts.IsJTIRevoked("jti-1") {
+		t.Error("IsJTIRevoked: jti-1 should survive Sweep (not yet expired)")
+	}
 }
 
 // ── memRefreshTokenStore ──────────────────────────────────────────────────────
@@ -874,6 +933,8 @@ func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error               { re
 func (f *alwaysFailRefreshStore) LookupNonce(_ string) string               { return "" }
 func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error { return nil }
 func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string { return "" }
+func (f *alwaysFailRefreshStore) RevokeJTI(_ string, _ time.Time) error     { return nil }
+func (f *alwaysFailRefreshStore) IsJTIRevoked(_ string) bool                { return false }
 func (f *alwaysFailRefreshStore) Delete(_ string) error                     { return errInjectedStoreFailure }
 func (f *alwaysFailRefreshStore) Sweep() error                              { return nil }
 

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -716,6 +716,65 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if !rts.IsJTIRevoked("jti-1") {
 		t.Error("IsJTIRevoked: jti-1 should survive Sweep (not yet expired)")
 	}
+
+	// LookupActiveByFamily returns the access token of the current
+	// (non-revoked) row for a family, ignoring an older revoked sibling.
+	if err := rts.Save("rt-fam-old", "at-fam-old", "aud", "fid-fam", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-fam-old: %v", err)
+	}
+	if err := rts.Revoke("rt-fam-old"); err != nil {
+		t.Fatalf("Revoke rt-fam-old: %v", err)
+	}
+	if err := rts.Save("rt-fam-new", "at-fam-new", "aud", "fid-fam", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-fam-new: %v", err)
+	}
+	if got, ok := rts.LookupActiveByFamily("fid-fam"); !ok || got != "at-fam-new" {
+		t.Errorf("LookupActiveByFamily: got (%q, %v), want (%q, true)", got, ok, "at-fam-new")
+	}
+	// No active row -> (\"\", false).
+	if got, ok := rts.LookupActiveByFamily("fid-no-such-family"); ok || got != "" {
+		t.Errorf("LookupActiveByFamily on unknown family: got (%q, %v), want (\"\", false)", got, ok)
+	}
+	// Empty familyID never matches (Save never associates a row with "").
+	if got, ok := rts.LookupActiveByFamily(""); ok || got != "" {
+		t.Errorf("LookupActiveByFamily(\"\"): got (%q, %v), want (\"\", false)", got, ok)
+	}
+
+	// RevokeFamily tombstones familyID: a subsequent Save for a *different*
+	// refresh token in the same family must be rejected with
+	// ErrRefreshTokenFamilyRevoked, closing the race where a rotation
+	// in-flight when /revoke runs would otherwise resurrect the family with
+	// a fresh, non-revoked row (thread-owl review, PR #195).
+	if err := rts.Save("rt-tomb-1", "at-tomb-1", "aud", "fid-tomb", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save rt-tomb-1: %v", err)
+	}
+	if err := rts.RevokeFamily("fid-tomb"); err != nil {
+		t.Fatalf("RevokeFamily: %v", err)
+	}
+	if err := rts.Save("rt-tomb-2", "at-tomb-2", "aud", "fid-tomb", time.Now().Add(time.Hour)); !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
+		t.Errorf("Save into revoked family: got err=%v, want ErrRefreshTokenFamilyRevoked", err)
+	}
+	// The blocked Save must not have written a row.
+	if _, _, _, _, ok := rts.Lookup("rt-tomb-2"); ok {
+		t.Error("Save into revoked family must not create a row despite returning an error")
+	}
+	// RevokeFamily on a familyID with no existing rows still tombstones it
+	// (a rotation could otherwise race the very first Save for a brand-new
+	// family and slip in before any row exists to revoke).
+	if err := rts.RevokeFamily("fid-tomb-empty"); err != nil {
+		t.Fatalf("RevokeFamily (no rows): %v", err)
+	}
+	if err := rts.Save("rt-tomb-empty", "at", "aud", "fid-tomb-empty", time.Now().Add(time.Hour)); !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
+		t.Errorf("Save into family revoked before any row existed: got err=%v, want ErrRefreshTokenFamilyRevoked", err)
+	}
+	// familyID == "" is never tombstoned; RevokeFamily(\"\") remains a no-op
+	// (mirrors the pre-existing contract) and Save with familyID="" always succeeds.
+	if err := rts.RevokeFamily(""); err != nil {
+		t.Fatalf("RevokeFamily(\"\"): %v", err)
+	}
+	if err := rts.Save("rt-no-family", "at", "aud", "", time.Now().Add(time.Hour)); err != nil {
+		t.Errorf("Save with empty familyID: got err=%v, want nil", err)
+	}
 }
 
 // ── memRefreshTokenStore ──────────────────────────────────────────────────────
@@ -927,16 +986,17 @@ func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, string, time.
 func (f *alwaysFailRefreshStore) LookupAny(_ string) (string, string, string, time.Time, bool, bool) {
 	return "", "", "", time.Time{}, false, false
 }
-func (f *alwaysFailRefreshStore) Revoke(_ string) error                     { return nil }
-func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error               { return nil }
-func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error               { return nil }
-func (f *alwaysFailRefreshStore) LookupNonce(_ string) string               { return "" }
-func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error { return nil }
-func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string { return "" }
-func (f *alwaysFailRefreshStore) RevokeJTI(_ string, _ time.Time) error     { return nil }
-func (f *alwaysFailRefreshStore) IsJTIRevoked(_ string) bool                { return false }
-func (f *alwaysFailRefreshStore) Delete(_ string) error                     { return errInjectedStoreFailure }
-func (f *alwaysFailRefreshStore) Sweep() error                              { return nil }
+func (f *alwaysFailRefreshStore) LookupActiveByFamily(_ string) (string, bool) { return "", false }
+func (f *alwaysFailRefreshStore) Revoke(_ string) error                        { return nil }
+func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error                  { return nil }
+func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error                  { return nil }
+func (f *alwaysFailRefreshStore) LookupNonce(_ string) string                  { return "" }
+func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error    { return nil }
+func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string    { return "" }
+func (f *alwaysFailRefreshStore) RevokeJTI(_ string, _ time.Time) error        { return nil }
+func (f *alwaysFailRefreshStore) IsJTIRevoked(_ string) bool                   { return false }
+func (f *alwaysFailRefreshStore) Delete(_ string) error                        { return errInjectedStoreFailure }
+func (f *alwaysFailRefreshStore) Sweep() error                                 { return nil }
 
 // testRefreshTokenStoreReuseDetection exercises LookupAny and RevokeFamily on
 // the given RefreshTokenStore.  It is shared across in-memory and file-backed

--- a/internal/auth/tokenstore_test.go
+++ b/internal/auth/tokenstore_test.go
@@ -717,8 +717,11 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 		t.Error("IsJTIRevoked: jti-1 should survive Sweep (not yet expired)")
 	}
 
-	// LookupActiveByFamily returns the access token of the current
-	// (non-revoked) row for a family, ignoring an older revoked sibling.
+	// RevokeFamily returns the family's current access token pointer — the
+	// value most recently written by Save for that family — even though the
+	// row backing it was never itself revoked before this call. Unlike a
+	// row-scan for "non-revoked", the pointer is unaffected by an older
+	// sibling's revoked flag: it always reflects the latest Save.
 	if err := rts.Save("rt-fam-old", "at-fam-old", "aud", "fid-fam", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save rt-fam-old: %v", err)
 	}
@@ -728,16 +731,20 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if err := rts.Save("rt-fam-new", "at-fam-new", "aud", "fid-fam", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save rt-fam-new: %v", err)
 	}
-	if got, ok := rts.LookupActiveByFamily("fid-fam"); !ok || got != "at-fam-new" {
-		t.Errorf("LookupActiveByFamily: got (%q, %v), want (%q, true)", got, ok, "at-fam-new")
+	if got, err := rts.RevokeFamily("fid-fam"); err != nil || got != "at-fam-new" {
+		t.Errorf("RevokeFamily: got (%q, %v), want (%q, nil)", got, err, "at-fam-new")
 	}
-	// No active row -> (\"\", false).
-	if got, ok := rts.LookupActiveByFamily("fid-no-such-family"); ok || got != "" {
-		t.Errorf("LookupActiveByFamily on unknown family: got (%q, %v), want (\"\", false)", got, ok)
+	// No pointer for a family that was never Saved -> ("", nil).
+	if got, err := rts.RevokeFamily("fid-no-such-family"); err != nil || got != "" {
+		t.Errorf("RevokeFamily on unknown family: got (%q, %v), want (\"\", nil)", got, err)
 	}
-	// Empty familyID never matches (Save never associates a row with "").
-	if got, ok := rts.LookupActiveByFamily(""); ok || got != "" {
-		t.Errorf("LookupActiveByFamily(\"\"): got (%q, %v), want (\"\", false)", got, ok)
+	// Empty familyID is a permanent no-op: never tombstoned, never has a
+	// pointer (Save never associates a row with "").
+	if got, err := rts.RevokeFamily(""); err != nil || got != "" {
+		t.Errorf("RevokeFamily(\"\"): got (%q, %v), want (\"\", nil)", got, err)
+	}
+	if err := rts.Save("rt-no-family", "at", "aud", "", time.Now().Add(time.Hour)); err != nil {
+		t.Errorf("Save with empty familyID: got err=%v, want nil", err)
 	}
 
 	// RevokeFamily tombstones familyID: a subsequent Save for a *different*
@@ -748,7 +755,7 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	if err := rts.Save("rt-tomb-1", "at-tomb-1", "aud", "fid-tomb", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("Save rt-tomb-1: %v", err)
 	}
-	if err := rts.RevokeFamily("fid-tomb"); err != nil {
+	if _, err := rts.RevokeFamily("fid-tomb"); err != nil {
 		t.Fatalf("RevokeFamily: %v", err)
 	}
 	if err := rts.Save("rt-tomb-2", "at-tomb-2", "aud", "fid-tomb", time.Now().Add(time.Hour)); !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
@@ -761,19 +768,11 @@ func testRefreshTokenStoreContract(t *testing.T, rts RefreshTokenStore) {
 	// RevokeFamily on a familyID with no existing rows still tombstones it
 	// (a rotation could otherwise race the very first Save for a brand-new
 	// family and slip in before any row exists to revoke).
-	if err := rts.RevokeFamily("fid-tomb-empty"); err != nil {
+	if _, err := rts.RevokeFamily("fid-tomb-empty"); err != nil {
 		t.Fatalf("RevokeFamily (no rows): %v", err)
 	}
 	if err := rts.Save("rt-tomb-empty", "at", "aud", "fid-tomb-empty", time.Now().Add(time.Hour)); !errors.Is(err, ErrRefreshTokenFamilyRevoked) {
 		t.Errorf("Save into family revoked before any row existed: got err=%v, want ErrRefreshTokenFamilyRevoked", err)
-	}
-	// familyID == "" is never tombstoned; RevokeFamily(\"\") remains a no-op
-	// (mirrors the pre-existing contract) and Save with familyID="" always succeeds.
-	if err := rts.RevokeFamily(""); err != nil {
-		t.Fatalf("RevokeFamily(\"\"): %v", err)
-	}
-	if err := rts.Save("rt-no-family", "at", "aud", "", time.Now().Add(time.Hour)); err != nil {
-		t.Errorf("Save with empty familyID: got err=%v, want nil", err)
 	}
 }
 
@@ -986,17 +985,18 @@ func (f *alwaysFailRefreshStore) Lookup(_ string) (string, string, string, time.
 func (f *alwaysFailRefreshStore) LookupAny(_ string) (string, string, string, time.Time, bool, bool) {
 	return "", "", "", time.Time{}, false, false
 }
-func (f *alwaysFailRefreshStore) LookupActiveByFamily(_ string) (string, bool) { return "", false }
-func (f *alwaysFailRefreshStore) Revoke(_ string) error                        { return nil }
-func (f *alwaysFailRefreshStore) RevokeFamily(_ string) error                  { return nil }
-func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error                  { return nil }
-func (f *alwaysFailRefreshStore) LookupNonce(_ string) string                  { return "" }
-func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error    { return nil }
-func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string    { return "" }
-func (f *alwaysFailRefreshStore) RevokeJTI(_ string, _ time.Time) error        { return nil }
-func (f *alwaysFailRefreshStore) IsJTIRevoked(_ string) bool                   { return false }
-func (f *alwaysFailRefreshStore) Delete(_ string) error                        { return errInjectedStoreFailure }
-func (f *alwaysFailRefreshStore) Sweep() error                                 { return nil }
+func (f *alwaysFailRefreshStore) Revoke(_ string) error { return nil }
+func (f *alwaysFailRefreshStore) RevokeFamily(_ string) (string, error) {
+	return "", nil
+}
+func (f *alwaysFailRefreshStore) SaveNonce(_, _ string) error               { return nil }
+func (f *alwaysFailRefreshStore) LookupNonce(_ string) string               { return "" }
+func (f *alwaysFailRefreshStore) SaveProviderAccessToken(_, _ string) error { return nil }
+func (f *alwaysFailRefreshStore) LookupProviderAccessToken(_ string) string { return "" }
+func (f *alwaysFailRefreshStore) RevokeJTI(_ string, _ time.Time) error     { return nil }
+func (f *alwaysFailRefreshStore) IsJTIRevoked(_ string) bool                { return false }
+func (f *alwaysFailRefreshStore) Delete(_ string) error                     { return errInjectedStoreFailure }
+func (f *alwaysFailRefreshStore) Sweep() error                              { return nil }
 
 // testRefreshTokenStoreReuseDetection exercises LookupAny and RevokeFamily on
 // the given RefreshTokenStore.  It is shared across in-memory and file-backed
@@ -1029,7 +1029,7 @@ func testRefreshTokenStoreReuseDetection(t *testing.T, rts RefreshTokenStore) {
 	}
 
 	// Save a token then revoke the family — rt-b must become inaccessible via Lookup.
-	if err := rts.RevokeFamily("fid-one"); err != nil {
+	if _, err := rts.RevokeFamily("fid-one"); err != nil {
 		t.Fatalf("RevokeFamily: %v", err)
 	}
 	if _, _, _, _, ok := rts.Lookup("rt-b"); ok {
@@ -1072,7 +1072,7 @@ func TestFileRefreshTokenStoreRevokedPersists(t *testing.T) {
 	if err := rts1.Save("rt-rv", "at-rv", "aud", "fid-rv", exp); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := rts1.RevokeFamily("fid-rv"); err != nil {
+	if _, err := rts1.RevokeFamily("fid-rv"); err != nil {
 		t.Fatalf("RevokeFamily: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- `POST /revoke`（RFC 7009 OAuth 2.0 Token Revocation）を実装。`token` + 任意 `token_type_hint`（`access_token`/`refresh_token`）を受け付け、hint に関わらず refresh token / access token 両方の失効経路を試行する
- builtin mode（`OAUTH_PROVIDER=builtin`）の gateway JWT はステートレス検証のため、TokenStore からのキャッシュ削除だけでは失効が有効期限（デフォルト90日）まで反映されない。`jti` denylist を既存 `RefreshTokenStore` の SQLite DB（`tokens.json.refresh.db`）に追加し、`ValidateToken` の cache-hit/cache-miss 両経路でチェックするようにした
- refresh token の失効は既存の RFC 6819 family 失効（`RevokeFamily`、reuse detection と同じ仕組み）を再利用。加えて、そのファミリーに紐づく現行アクセストークンの `jti` も即時 denylist へ登録し、将来のローテーションだけでなく既発行トークンも即座に失効させる
- 未知・期限切れ・二重失効のトークンでも常に `200 OK`（RFC 7009 §2.2、probing 防止）
- `.well-known/oauth-authorization-server` に `revocation_endpoint` を追加

## スコープ外（設計方針として合意済み）

- `/logout`: MCP クライアント向け gateway にブラウザセッション概念がないため対象外
- GitHub 側トークン失効 API（`DELETE /applications/{client_id}/token`）呼び出し: 別 issue へ切り出し予定

設計方針の詳細は [#192 のコメント](https://github.com/scottlz0310/mcp-gateway/issues/192#issuecomment-4872892964) を参照。

Closes #192

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`（0 issues）
- [x] `go test ./...`（全パッケージ pass）
- [x] 新規回帰テスト（`internal/auth/handler_test.go`）
  - builtin mode: revoke 後の cache-miss 経路での拒否
  - builtin mode: revoke 後の cache-hit 経路での拒否
  - refresh token revoke による family + 現行 access token への cascade
  - 二重 revoke・未知トークン・不正トークンの冪等性（常に 200）
  - non-builtin mode でのキャッシュ即時削除
  - discovery メタデータへの `revocation_endpoint` 反映
- [x] 新規契約テスト（`internal/auth/tokenstore_test.go`）: `TokenStore.SaveJti` / `RefreshTokenStore.RevokeJTI`・`IsJTIRevoked` を mem/file/SQLite 全実装で検証
- [x] `docs/configuration.md` / `CHANGELOG.md` 更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)