### PR TITLE
feat(auth): プライマリ TokenStore を SQLite に移行 (#191)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -22,6 +22,15 @@
   - `ValidateToken` は builtin mode ではキャッシュヒット時に非 builtin 用の GitHub rotation 経路を呼ばなくなった。将来 builtin mode の rotation 対応が入った際に顕在化しうるトークン漏洩リスクを事前に塞ぐもの（rotation 自体は follow-up として未実装 — `builtinProvider.RefreshToken` は引き続き `ErrRefreshNotSupported` を返す）。
   - `docs/configuration.md` — builtin mode では `github_refresh_enabled` の設定に関わらず、GitHub アクセストークンが常に `tokens.json` / refresh token ストアに永続化される旨を追記。また builtin mode の delegated access には永続トークンストアが実質必須である旨を制限事項に追記（in-memory ストア構成では JWT に紐付けた GitHub アクセストークンがトークンキャッシュ TTL 経過または再起動で失われ、JWT が有効なまま delegated access だけが再認証を要求し続けるため）。
 
+### 変更
+
+- プライマリトークンストア（TokenStore）を平文 JSON ファイル（`tokens.json`）から SQLite へ移行し、#135 でリフレッシュトークンストアに対して始まったストレージ統合を完了（[#191](https://github.com/scottlz0310/mcp-gateway/issues/191)）
+  - アクセストークンとリフレッシュトークンが単一の SQLite データベース（`<token-store-path>.refresh.db`）を共有するようになった: 単一ファイル・単一 writer ロック・単一トランザクション境界でゲートウェイの論理トークン状態全体を管理する。ファイル名は歴史的経緯の `.refresh.db` を維持し、アップグレード時に既存データベースを再利用でき、旧バージョンへのロールバック時にも denylist・リフレッシュ状態が期待されるパスから参照できるようにした
+  - フィールド更新（`SaveProviderRefresh` / `SaveProviderAccessToken` / `SaveNonce` / `SaveJti` / `MarkRotationFailed`）は有効期限ガード付きの単一 `UPDATE` 文になり、file ストアのファイル全体 rewrite + 手動インメモリロールバックのパターンを置き換えた。期限切れエントリの掃除も全走査 + rewrite からインデックス付き `DELETE` になった
+  - 自動ワンタイムマイグレーション: 既存の `tokens.json` は初回起動時に単一トランザクションでインポートされ、`tokens.json.migrated` にリネームされる（#135 のパターン踏襲）。マイグレーション失敗時は元ファイルを残したまま起動を中止する
+  - TokenStore 契約テストを SQLite 実装にも適用。file-backed 実装はマイグレーション元フォーマットとしてレガシー扱いで残置
+  - `docs/configuration.md` の「トークン永続化」を実装に合わせて全面改訂: `MCP_GATEWAY_TOKEN_STORE_PATH` のベースパスとしての意味、共有データベース構成、マイグレーション挙動、バックアップ除外対象（`tokens.json.refresh.db` + `-wal`/`-shm` + `*.migrated`）。PR #189 がプライマリストアの SQLite バックエンドに言及済みだったドキュメントと実装の乖離（#191 で指摘）もこれで解消
+
 ## [0.7.0] - 2026-06-21
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and versioning follows [Semantic Versioning](https://semver.org/).
   - `handler_test.go` に request・response 双方向透過の回帰テスト追加
   - `docs/operations.md` に正しい MCP 初期化シーケンス・切り分け手順・gateway/upstream エラー判別方法を追加
 
+### Changed
+
+- Primary token store (TokenStore) migrated from a plaintext JSON file (`tokens.json`) to SQLite, completing the storage unification started for the refresh-token store in #135 ([#191](https://github.com/scottlz0310/mcp-gateway/issues/191))
+  - Access tokens and refresh tokens now share one SQLite database (`<token-store-path>.refresh.db`): one file, one writer lock, one transaction boundary for the gateway's whole logical token state. The file keeps its historical `.refresh.db` name so upgrades reuse the existing database and a rollback to an older gateway still finds its denylist/refresh state at the expected path
+  - Field updates (`SaveProviderRefresh` / `SaveProviderAccessToken` / `SaveNonce` / `SaveJti` / `MarkRotationFailed`) are now single expiry-guarded `UPDATE` statements, replacing the file store's whole-file rewrite + manual in-memory rollback pattern; expired entries are removed by an indexed `DELETE` instead of a full-map sweep + rewrite
+  - Automatic one-time migration: an existing `tokens.json` is imported on first startup inside a single transaction and renamed to `tokens.json.migrated` (the #135 pattern); startup aborts with the source file intact if migration fails
+  - The TokenStore contract test now also runs against the SQLite implementation; the file-backed implementation remains as the legacy migration-source format
+  - `docs/configuration.md` "Token Persistence" rewritten to match: base-path semantics of `MCP_GATEWAY_TOKEN_STORE_PATH`, shared-database layout, migration behaviour, and backup-exclusion targets (`tokens.json.refresh.db` + `-wal`/`-shm` + `*.migrated`). This resolves the documentation/implementation gap noted in #191 where PR #189 already referenced a SQLite backend for the primary store
+
 ## [0.7.0] - 2026-06-21
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -229,7 +229,7 @@ environment:
 |---------|---------|-------|
 | `MCP_CONFIG_FILE` | `{state-dir}/config.yaml` | setup 結果と暗号化 secret。 |
 | `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity。安全にバックアップしてください。 |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | token 永続化 path。Docker 環境では環境変数で上書きすること。 |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | token 永続化のベース path。実データは `<path>.refresh.db`（SQLite）に保存。Docker 環境では環境変数で上書きすること。 |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS のユーザー state 領域。公式 image では `/data/mcp-gateway/logs/auth-audit.jsonl` | OAuth 監査 JSON Lines。相対 path と Git worktree 配下は拒否されます。 |
 | *(自動生成)* | `{state-dir}/upstream_clients.json` | upstream AS の Dynamic Client Registration 記録（mode 0600）。upstream OAuth ルートへの初回アクセス時に作成。 |
 | *(自動生成)* | `{state-dir}/upstream_tokens.json` | ユーザーごとの upstream OAuth access/refresh token（mode 0600）。初回 upstream OAuth 認可完了時に作成。 |

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Important paths:
 |---------|---------|-------|
 | `MCP_CONFIG_FILE` | `{state-dir}/config.yaml` | Persisted setup and encrypted secrets. |
 | `MCP_GATEWAY_KEY_PATH` | `{state-dir}/gateway.key` | age X25519 identity. Back it up securely. |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | Persistent token store. Docker deployments pin this via env var. |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | `{state-dir}/tokens.json` | Persistent token store base path; data lives in `<path>.refresh.db` (SQLite). Docker deployments pin this via env var. |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS user state directory; `/data/mcp-gateway/logs/auth-audit.jsonl` in the official image | Rotating OAuth audit JSON Lines file. Relative paths and Git worktree paths are rejected. |
 | *(auto)* | `{state-dir}/upstream_clients.json` | Upstream AS Dynamic Client Registration records (mode 0600). Created on first upstream OAuth route access. |
 | *(auto)* | `{state-dir}/upstream_tokens.json` | Per-user upstream OAuth access/refresh tokens (mode 0600). Created on first upstream OAuth authorization. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ OAuth クライアントシークレットは意図的に特別扱いです。`c
 | `MCP_GATEWAY_PORT` | `8080` | `public_url` と `bind_addr` のデフォルト導出に使用するポート。 |
 | `MCP_GATEWAY_BASE_URL` | なし | `MCP_GATEWAY_PUBLIC_URL` の非推奨エイリアス。設定されると起動時警告を出力。 |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | なし | `X-Forwarded-*` ヘッダーを信頼する直前のリバースプロキシの CIDR リスト（カンマ区切り）。 |
-| `MCP_GATEWAY_TOKEN_STORE_PATH` | OS state dir¹ `/tokens.json` | 永続トークンストアのパス。空値に設定すると永続化を無効化。Docker 環境は環境変数で上書き。 |
+| `MCP_GATEWAY_TOKEN_STORE_PATH` | OS state dir¹ `/tokens.json` | 永続トークンストアのベースパス。実データは `<パス>.refresh.db`（SQLite）に保存される（[トークン永続化](#トークン永続化)参照）。空値に設定すると永続化を無効化。Docker 環境は環境変数で上書き。 |
 | `MCP_GATEWAY_AUTH_AUDIT_LOG_PATH` | OS audit dir² | OAuth 監査 JSON Lines の絶対 path。相対 path と Git worktree 配下は起動時に拒否される。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_SIZE_MB` | `10` | 監査ログ 1 ファイルの最大サイズ（MiB）。 |
 | `MCP_GATEWAY_AUTH_AUDIT_MAX_BACKUPS` | `5` | 保持するローテーション済み監査ログの最大数。 |
@@ -313,11 +313,13 @@ routes:
 
 ## トークン永続化
 
-デフォルトでは、検証済みトークン状態は `{state-dir}/tokens.json` に保存されます（上記[環境変数](#環境変数)セクションの OS state directory テーブルを参照）。Docker 環境は `docker-compose.yml` の `MCP_GATEWAY_TOKEN_STORE_PATH` で上書きします。明示的なパスを指定する場合:
+デフォルトでは、検証済みトークン状態は `{state-dir}/tokens.json.refresh.db`（SQLite、WAL モード）に保存されます（`{state-dir}` は上記[環境変数](#環境変数)セクションの OS state directory テーブルを参照）。Docker 環境は `docker-compose.yml` の `MCP_GATEWAY_TOKEN_STORE_PATH` で上書きします。明示的なパスを指定する場合:
 
 ```bash
 MCP_GATEWAY_TOKEN_STORE_PATH=/var/lib/mcp-gateway/tokens.json
 ```
+
+`MCP_GATEWAY_TOKEN_STORE_PATH` はベースパスであり、実データは `<パス>.refresh.db` に保存されます。アクセストークンストアとリフレッシュトークンストアは同一 SQLite データベースを共有し、単一のファイル・単一のトランザクション境界で管理されます。ファイル名の `.refresh` はリフレッシュトークンストアだけが SQLite だった時期の歴史的経緯によるもので、現在は全トークン状態を保持します（旧バージョンへのロールバック時にも同じパスが参照できるよう維持されています）。
 
 永続化を無効にするには空値に設定します:
 
@@ -327,24 +329,25 @@ MCP_GATEWAY_TOKEN_STORE_PATH=
 
 プライマリトークンストアの動作:
 
-- 起動時にトークンと identity のマッピングをロード。
-- 認証成功後にマッピングを保存。
-- 毎分、期限切れエントリをスイープ。
+- 認証成功後にトークンと identity のマッピングを保存。フィールド更新は単一の `UPDATE` 文で原子的に行われる。
+- 毎分、期限切れエントリをスイープ（インデックス付き `DELETE`）。
 - サポートされる環境ではモード `0600` で書き込み。
-- SHA-256 でハッシュ化したトークンキーを保存（生トークン値は保存しない）。
+- SHA-256 でハッシュ化したトークンキーを保存(生トークン値は保存しない)。
 
-トークン永続化が有効な場合、リフレッシュトークンは `<path>.refresh` に保存されます。このファイルはハッシュ化されたリフレッシュトークンキーと、対応するアクセストークン値を平文で保存します（ゲートウェイがリフレッシュ時に GitHub へアクセストークンを再提示する必要があるため）。機密データとして扱ってください。
+旧バージョンからのマイグレーション: 旧 file-backed ストア（`tokens.json` および `tokens.json.refresh`）が存在する場合、初回起動時に内容を SQLite データベースへインポートし、元ファイルを `<元パス>.migrated` にリネームします。マイグレーションに失敗した場合は元ファイルを残したまま起動を中止します。
 
-`MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true`（または `gateway.github_refresh_enabled: true`）の場合、ゲートウェイは GitHub OAuth **リフレッシュトークン**を（`.refresh` サイドファイルではなく）プライマリストアの `tokens.json` にも保存します。再起動をまたいでローテーションを継続するためです。リフレッシュトークンは GitHub の `/login/oauth/access_token` エンドポイントへの再送が必要なため平文で書き込まれます。
+リフレッシュトークンストアは、ハッシュ化されたリフレッシュトークンキーと対応するアクセストークン値を平文で保存します（ゲートウェイがリフレッシュ時に GitHub へアクセストークンを再提示する必要があるため）。機密データとして扱ってください。
+
+`MCP_GATEWAY_GITHUB_REFRESH_ENABLED=true`（または `gateway.github_refresh_enabled: true`）の場合、ゲートウェイは GitHub OAuth **リフレッシュトークン**をプライマリトークンストアにも保存します。再起動をまたいでローテーションを継続するためです。リフレッシュトークンは GitHub の `/login/oauth/access_token` エンドポイントへの再送が必要なため平文で書き込まれます。
 
 リフレッシュトークン永続化の運用上の注意:
 
-- `tokens.json` の読者はリフレッシュトークンの有効期間中、ログイン済みユーザーの GitHub セッションを乗っ取れます。GitHub の expiring-user-token 設定では通常**6ヶ月**（ユーザーが認可を取り消すか GitHub App が再設定されるまで）。
-- `tokens.json` のバックアップも同じリスクを持ちます。バックアップボリュームを保存時暗号化するか、広いバックアップスコープから `tokens.json` と `tokens.json.refresh` を除外してください。
+- トークンデータベースの読者はリフレッシュトークンの有効期間中、ログイン済みユーザーの GitHub セッションを乗っ取れます。GitHub の expiring-user-token 設定では通常**6ヶ月**（ユーザーが認可を取り消すか GitHub App が再設定されるまで）。
+- バックアップも同じリスクを持ちます。バックアップボリュームを保存時暗号化するか、広いバックアップスコープから `tokens.json.refresh.db`（および SQLite の付随ファイル `-wal` / `-shm`、マイグレーション済みの `*.migrated`）を除外してください。
 - コンテナイメージやスナップショットにいずれのファイルも含めないこと。
 - 再起動をまたいだローテーションが不要な場合は `github_refresh_enabled` を無効にしてください。リフレッシュトークンはディスクに書き込まれません。
 
-**builtin mode（`OAUTH_PROVIDER=builtin`）の追加事項:** builtin mode ではクライアントに渡すアクセストークンはゲートウェイ署名の JWT であり、GitHub アクセストークン自体ではありません。ただし Phase B delegated access（`EnsureFreshAccessTokenForSubject`、`upstream_provider_token=true` ルートおよび `/internal/v1/whoami` が使用）が upstream サービスへ GitHub トークンを引き渡せるようにするため、GitHub アクセストークンは JWT に紐付けて `tokens.json`（および `github_refresh_enabled` 無効時でも常に）と、そのリフレッシュトークンストア（file-backed 構成では `tokens.json.refresh`、`MCP_GATEWAY_TOKEN_STORE_PATH` が SQLite バックエンドを指す場合は同 DB 内）の両方に**平文で常に**保存されます。`github_refresh_enabled` はリフレッシュトークン自体の保存有無のみを制御し、GitHub アクセストークンの保存有無は制御しません。したがって上記の「`tokens.json` の読者はログイン済みユーザーの GitHub セッションを乗っ取れる」というリスクは、`github_refresh_enabled` の設定に関わらず builtin mode にも同様に適用されます。
+**builtin mode（`OAUTH_PROVIDER=builtin`）の追加事項:** builtin mode ではクライアントに渡すアクセストークンはゲートウェイ署名の JWT であり、GitHub アクセストークン自体ではありません。ただし Phase B delegated access（`EnsureFreshAccessTokenForSubject`、`upstream_provider_token=true` ルートおよび `/internal/v1/whoami` が使用）が upstream サービスへ GitHub トークンを引き渡せるようにするため、GitHub アクセストークンは JWT に紐付けて、アクセストークンストアとリフレッシュトークンストアの両方（同一 SQLite データベース内）に**平文で常に**保存されます（`github_refresh_enabled` 無効時でも同様）。`github_refresh_enabled` はリフレッシュトークン自体の保存有無のみを制御し、GitHub アクセストークンの保存有無は制御しません。したがって上記の「トークンデータベースの読者はログイン済みユーザーの GitHub セッションを乗っ取れる」というリスクは、`github_refresh_enabled` の設定に関わらず builtin mode にも同様に適用されます。
 
 ## リバースプロキシヘッダー
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -170,10 +170,21 @@ func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handle
 		if err != nil {
 			return nil, fmt.Errorf("auth.NewHandler: token store: %w", err)
 		}
+		// Both stores share one *sql.DB (see NewSQLiteTokenStores), so closing
+		// either one releases the handle; sql.DB.Close is idempotent, so this is
+		// safe to call from either migration failure branch below without
+		// tracking which store owns "the" close.
+		closeSharedDB := func() {
+			if c, ok := sqliteTS.(io.Closer); ok {
+				_ = c.Close()
+			}
+		}
 		if err := migrateFileTokenStore(cfg.TokenStorePath, sqliteTS); err != nil {
+			closeSharedDB()
 			return nil, fmt.Errorf("auth.NewHandler: migrating legacy token store: %w", err)
 		}
 		if err := migrateFileRefreshTokenStore(cfg.TokenStorePath+".refresh", sqliteRTS); err != nil {
+			closeSharedDB()
 			return nil, fmt.Errorf("auth.NewHandler: migrating legacy refresh token store: %w", err)
 		}
 		ts = sqliteTS

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -57,10 +57,12 @@ type Config struct {
 	// GitHub classic OAuth tokens do not expire on GitHub's side; this only
 	// controls how long the MCP client trusts its cached copy. Defaults to 90 days.
 	ExpiresIn time.Duration
-	// TokenStorePath is the path to the JSON file used for persistent token storage.
-	// When empty, an in-memory store is used (default; data lost on restart).
-	// When set, validated tokens survive container restarts; the file is written
-	// with mode 0600 and only hashed token keys are stored.
+	// TokenStorePath enables persistent token storage. When empty, an in-memory
+	// store is used (default; data lost on restart). When set, validated tokens
+	// and refresh tokens survive container restarts, stored in a shared SQLite
+	// database at <TokenStorePath>.refresh.db (mode 0600, only hashed token
+	// keys). A legacy JSON file at TokenStorePath itself is imported on startup
+	// and renamed to <TokenStorePath>.migrated.
 	TokenStorePath string
 	// AllowedAudiences is the set of RFC 8707 resource indicator values accepted
 	// by this gateway. BaseURL is always allowed.
@@ -129,9 +131,10 @@ func WithAuditRecorder(recorder authaudit.Recorder) HandlerOption {
 // It returns an error if the provider is nil or if the persistent token store
 // cannot be initialized.
 //
-// When cfg.TokenStorePath is non-empty, validated tokens are stored durably in a
-// JSON file so that MCP clients do not need to re-authenticate after gateway
-// restarts. Tokens are stored with TTL equal to cfg.ExpiresIn (default 90 days).
+// When cfg.TokenStorePath is non-empty, validated tokens are stored durably in
+// a SQLite database (shared with the refresh-token store) so that MCP clients
+// do not need to re-authenticate after gateway restarts. Tokens are stored with
+// TTL equal to cfg.ExpiresIn (default 90 days).
 // When cfg.TokenStorePath is empty, an in-memory store is used (TTL = cfg.CacheTTL).
 func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handler, error) {
 	if p == nil {
@@ -158,20 +161,23 @@ func NewHandler(cfg Config, p provider.Provider, opts ...HandlerOption) (*Handle
 	var tokensTTL time.Duration
 	var storeOpts []StoreOption
 	if cfg.TokenStorePath != "" {
-		fileStore, err := NewFileTokenStore(cfg.TokenStorePath)
+		// Both stores share one SQLite database. The file keeps its historical
+		// ".refresh.db" name (from when only the RefreshTokenStore was
+		// SQLite-backed, #135) so that upgrades reuse the existing database
+		// and a rollback to an older gateway still finds its denylist and
+		// refresh-token state at the path it expects.
+		sqliteTS, sqliteRTS, err := NewSQLiteTokenStores(cfg.TokenStorePath + ".refresh.db")
 		if err != nil {
 			return nil, fmt.Errorf("auth.NewHandler: token store: %w", err)
 		}
-		ts = fileStore
-		tokensTTL = cfg.ExpiresIn
-
-		sqliteRTS, err := NewSQLiteRefreshTokenStore(cfg.TokenStorePath + ".refresh.db")
-		if err != nil {
-			return nil, fmt.Errorf("auth.NewHandler: refresh token store: %w", err)
+		if err := migrateFileTokenStore(cfg.TokenStorePath, sqliteTS); err != nil {
+			return nil, fmt.Errorf("auth.NewHandler: migrating legacy token store: %w", err)
 		}
 		if err := migrateFileRefreshTokenStore(cfg.TokenStorePath+".refresh", sqliteRTS); err != nil {
 			return nil, fmt.Errorf("auth.NewHandler: migrating legacy refresh token store: %w", err)
 		}
+		ts = sqliteTS
+		tokensTTL = cfg.ExpiresIn
 		storeOpts = append(storeOpts, WithRefreshTokenStore(sqliteRTS))
 	} else {
 		ts = NewMemTokenStore()

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1627,6 +1627,77 @@ func TestNewHandlerRefreshStoreInitError(t *testing.T) {
 	}
 }
 
+// TestNewHandlerClosesDBOnTokenMigrationFailure verifies that when
+// migrateFileTokenStore fails, NewHandler closes the shared SQLite handle
+// before returning rather than leaking it (thread-owl review, PR #196):
+// leaving the handle open would keep the underlying .refresh.db file locked,
+// which on Windows makes even removing the file fail with "the process
+// cannot access the file because it is being used by another process".
+func TestNewHandlerClosesDBOnTokenMigrationFailure(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "tokens.json")
+	if err := os.WriteFile(storePath, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("writing corrupt tokens.json: %v", err)
+	}
+
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+	})
+	_, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		TokenStorePath: storePath,
+	}, p)
+	if err == nil {
+		t.Fatal("expected error from corrupt legacy tokens.json, got nil")
+	}
+
+	refreshDBPath := storePath + ".refresh.db"
+	if _, statErr := os.Stat(refreshDBPath); statErr != nil {
+		t.Fatalf(".refresh.db should have been created before migration ran: %v", statErr)
+	}
+	if removeErr := os.Remove(refreshDBPath); removeErr != nil {
+		t.Errorf("removing .refresh.db after failed migration: %v (handle appears to be leaked)", removeErr)
+	}
+}
+
+// TestNewHandlerClosesDBOnRefreshMigrationFailure is the counterpart of
+// TestNewHandlerClosesDBOnTokenMigrationFailure for the second migration call
+// (migrateFileRefreshTokenStore) in the same NewHandler error path.
+func TestNewHandlerClosesDBOnRefreshMigrationFailure(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "tokens.json")
+	if err := os.WriteFile(storePath+".refresh", []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("writing corrupt tokens.json.refresh: %v", err)
+	}
+
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+	})
+	_, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		TokenStorePath: storePath,
+	}, p)
+	if err == nil {
+		t.Fatal("expected error from corrupt legacy tokens.json.refresh, got nil")
+	}
+
+	refreshDBPath := storePath + ".refresh.db"
+	if _, statErr := os.Stat(refreshDBPath); statErr != nil {
+		t.Fatalf(".refresh.db should have been created before migration ran: %v", statErr)
+	}
+	if removeErr := os.Remove(refreshDBPath); removeErr != nil {
+		t.Errorf("removing .refresh.db after failed migration: %v (handle appears to be leaked)", removeErr)
+	}
+}
+
 // newTestRefreshHandlerWithGitHub creates a Handler wired to a stub GitHub user API
 // and configured with a ResourceAudienceMap for refresh token audience tests.
 func newTestRefreshHandlerWithGitHub(t *testing.T, resourceMap map[string]string) (*Handler, *httptest.Server) {

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1470,6 +1470,55 @@ func TestHandlerRefreshTokenSurvivesRestart(t *testing.T) {
 	}
 }
 
+// TestNewHandlerMigratesLegacyTokenStore verifies that a legacy tokens.json
+// written by the file-backed TokenStore is imported into the SQLite store on
+// startup and renamed to .migrated, so tokens validated before the upgrade
+// keep working (#191).
+func TestNewHandlerMigratesLegacyTokenStore(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "tokens.json")
+
+	legacy, err := NewFileTokenStore(storePath)
+	if err != nil {
+		t.Fatalf("NewFileTokenStore: %v", err)
+	}
+	if err := legacy.Save("tok-legacy", "alice", []string{"http://localhost:8080/mcp"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("legacy Save: %v", err)
+	}
+
+	p := provider.NewGitHub(provider.GitHubConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURI:  "http://localhost:8080/callback",
+		Scopes:       "repo,user",
+	})
+	h, err := NewHandler(Config{
+		BaseURL:        "http://localhost:8080",
+		SessionTTL:     10 * time.Minute,
+		CacheTTL:       5 * time.Minute,
+		ExpiresIn:      90 * 24 * time.Hour,
+		TokenStorePath: storePath,
+	}, p)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+
+	rec, ok := h.store.tokens.Lookup("tok-legacy")
+	if !ok {
+		t.Fatal("legacy token not found in SQLite store after migration")
+	}
+	if rec.Subject != "alice" {
+		t.Errorf("Subject: got %q, want %q", rec.Subject, "alice")
+	}
+	if _, statErr := os.Stat(storePath); !os.IsNotExist(statErr) {
+		t.Error("legacy tokens.json should have been renamed after migration")
+	}
+	if _, statErr := os.Stat(storePath + ".migrated"); statErr != nil {
+		t.Errorf("tokens.json.migrated not found: %v", statErr)
+	}
+}
+
 // ── error-injection helpers ───────────────────────────────────────────────────
 
 // deleteFailRefreshStore wraps a real in-memory store for all operations

--- a/internal/auth/tokenstore.go
+++ b/internal/auth/tokenstore.go
@@ -291,6 +291,11 @@ type fileEntry struct {
 	Jti                  string    `json:"jti,omitempty"`
 }
 
+// fileTokenStore is the legacy file-backed implementation, only exercised
+// directly by its own contract tests; the live NewHandler path opens the
+// SQLite-backed store and migrates any existing tokens.json into it at
+// startup (see tokenstore_sqlite_migrate.go). fileEntry remains the on-disk
+// format that migration reads.
 type fileTokenStore struct {
 	mu      sync.RWMutex
 	path    string

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,7 +12,25 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const sqliteRTSchema = `
+const sqliteTokenDBSchema = `
+-- access_tokens is the primary token store (TokenStore): metadata for
+-- validated access tokens, keyed by tokenKey(rawToken) so raw token values
+-- never reach disk. audiences is a JSON-encoded string array ('' = none).
+-- provider_access_expiry is 0 when the provider gave no expiry hint.
+CREATE TABLE IF NOT EXISTS access_tokens (
+	token_hash             TEXT    PRIMARY KEY,
+	subject                TEXT    NOT NULL DEFAULT '',
+	audiences              TEXT    NOT NULL DEFAULT '',
+	expires_at             INTEGER NOT NULL,
+	provider_access_token  TEXT    NOT NULL DEFAULT '',
+	provider_refresh_token TEXT    NOT NULL DEFAULT '',
+	provider_access_expiry INTEGER NOT NULL DEFAULT 0,
+	rotation_failed        INTEGER NOT NULL DEFAULT 0,
+	nonce                  TEXT    NOT NULL DEFAULT '',
+	jti                    TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_at_expires ON access_tokens (expires_at);
+
 CREATE TABLE IF NOT EXISTS refresh_tokens (
 	token_hash   TEXT    PRIMARY KEY,
 	access_token TEXT    NOT NULL,
@@ -110,19 +129,21 @@ func backfillFamilyCurrentAccessToken(ex sqlExecer) error {
 	return nil
 }
 
-// NewSQLiteRefreshTokenStore returns a SQLite-backed RefreshTokenStore.
+// openSQLiteTokenDB opens (or creates) the shared token database at path,
+// initialises the full schema (access_tokens + refresh-token tables), applies
+// idempotent column migrations, and enforces owner-only file permissions.
 // path may be ":memory:" for in-process testing.
-func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
+func openSQLiteTokenDB(path string) (*sql.DB, error) {
 	// WAL mode for concurrent readers; busy_timeout avoids immediate SQLITE_BUSY.
 	dsn := path + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
-		return nil, fmt.Errorf("opening SQLite refresh token store %q: %w", path, err)
+		return nil, fmt.Errorf("opening SQLite token store %q: %w", path, err)
 	}
 	db.SetMaxOpenConns(1) // SQLite WAL allows 1 writer; serialise via the connection pool
-	if _, err := db.Exec(sqliteRTSchema); err != nil {
+	if _, err := db.Exec(sqliteTokenDBSchema); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("initialising SQLite refresh token store schema: %w", err)
+		return nil, fmt.Errorf("initialising SQLite token store schema: %w", err)
 	}
 	// Add nonce/provider_access_token columns to existing databases created before
 	// these fields were introduced. ALTER TABLE ADD COLUMN is idempotent in SQLite
@@ -136,12 +157,22 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	// the first POST /revoke after upgrading (see backfillFamilyCurrentAccessTokenSQL).
 	if err := backfillFamilyCurrentAccessToken(db); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("initialising SQLite refresh token store: %w", err)
+		return nil, fmt.Errorf("initialising SQLite token store: %w", err)
 	}
 	if path != ":memory:" {
 		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
-			slog.Warn("SQLite refresh token store chmod failed", "path", path, "err", err)
+			slog.Warn("SQLite token store chmod failed", "path", path, "err", err)
 		}
+	}
+	return db, nil
+}
+
+// NewSQLiteRefreshTokenStore returns a SQLite-backed RefreshTokenStore.
+// path may be ":memory:" for in-process testing.
+func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
+	db, err := openSQLiteTokenDB(path)
+	if err != nil {
+		return nil, err
 	}
 	s := &sqliteRefreshTokenStore{db: db}
 	swept, err := s.sweepNow()
@@ -152,6 +183,36 @@ func NewSQLiteRefreshTokenStore(path string) (RefreshTokenStore, error) {
 	_ = db.QueryRow("SELECT COUNT(*) FROM refresh_tokens").Scan(&count)
 	slog.Info("SQLite refresh token store opened", "path", path, "entries", count, "swept", swept)
 	return s, nil
+}
+
+// NewSQLiteTokenStores opens the shared token database at path and returns a
+// TokenStore and a RefreshTokenStore backed by the same *sql.DB — one file,
+// one writer lock, one transaction boundary for the gateway's whole logical
+// token state (issue #191). Closing either store closes the shared handle, so
+// callers should close exactly one of them at shutdown (Store.Close does this
+// via the RefreshTokenStore). path may be ":memory:" for in-process testing.
+func NewSQLiteTokenStores(path string) (TokenStore, RefreshTokenStore, error) {
+	db, err := openSQLiteTokenDB(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	ts := &sqliteTokenStore{db: db}
+	rts := &sqliteRefreshTokenStore{db: db}
+	sweptAT, err := ts.sweepNow()
+	if err != nil {
+		slog.Warn("SQLite token store startup sweep failed", "err", err)
+	}
+	sweptRT, err := rts.sweepNow()
+	if err != nil {
+		slog.Warn("SQLite refresh token store startup sweep failed", "err", err)
+	}
+	var countAT, countRT int
+	_ = db.QueryRow("SELECT COUNT(*) FROM access_tokens").Scan(&countAT)
+	_ = db.QueryRow("SELECT COUNT(*) FROM refresh_tokens").Scan(&countRT)
+	slog.Info("SQLite token store opened", "path", path,
+		"access_tokens", countAT, "refresh_tokens", countRT,
+		"swept_access", sweptAT, "swept_refresh", sweptRT)
+	return ts, rts, nil
 }
 
 // Save writes refreshToken's row guarded by a NOT EXISTS check against
@@ -399,5 +460,230 @@ func (s *sqliteRefreshTokenStore) sweepNow() (int64, error) {
 
 // Close releases the underlying database connection.
 func (s *sqliteRefreshTokenStore) Close() error {
+	return s.db.Close()
+}
+
+// ── SQLite TokenStore ────────────────────────────────────────────────────────
+
+// sqliteTokenStore is the SQLite-backed primary TokenStore. Field updates are
+// single UPDATE statements guarded by the expiry predicate, so the manual
+// previous-value rollback pattern of fileTokenStore is unnecessary: a failed
+// statement leaves the row untouched, and memory/disk can never diverge
+// because the database is the only state.
+type sqliteTokenStore struct {
+	db *sql.DB
+}
+
+// encodeAudiences serialises audiences for the access_tokens.audiences column.
+// An empty slice is stored as '' so decodeAudiences can round-trip it to nil.
+func encodeAudiences(audiences []string) (string, error) {
+	if len(audiences) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(audiences)
+	if err != nil {
+		return "", fmt.Errorf("encoding audiences: %w", err)
+	}
+	return string(b), nil
+}
+
+func decodeAudiences(s string) ([]string, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil, fmt.Errorf("decoding audiences: %w", err)
+	}
+	return out, nil
+}
+
+// unixOrZero maps time.Time's zero value to 0 rather than its (negative) Unix
+// representation, so "no expiry hint" round-trips through the INTEGER column.
+func unixOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
+}
+
+func timeFromUnixOrZero(v int64) time.Time {
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(v, 0)
+}
+
+// Save inserts or updates the row for token. Re-saving a non-expired token
+// merges audiences and preserves every other field (subject only when the new
+// subject is empty), matching the mem/file implementations; an expired row is
+// treated as absent and fully reset. The read-merge-write runs inside one
+// transaction, which the single DB connection serialises against all other
+// store operations.
+func (s *sqliteTokenStore) Save(token, subject string, audiences []string, expiresAt time.Time) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("saving token: %w", err)
+	}
+	key := tokenKey(token)
+	var (
+		curSubject, curAudiences, curPAT, curPRT, curNonce, curJti string
+		curPAE                                                     int64
+		curRotationFailed                                          int
+	)
+	err = tx.QueryRow(
+		`SELECT subject, audiences, provider_access_token, provider_refresh_token,
+		        provider_access_expiry, rotation_failed, nonce, jti
+		 FROM access_tokens WHERE token_hash = ? AND expires_at > ?`,
+		key, time.Now().Unix(),
+	).Scan(&curSubject, &curAudiences, &curPAT, &curPRT, &curPAE, &curRotationFailed, &curNonce, &curJti)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		_ = tx.Rollback()
+		return fmt.Errorf("saving token: reading current entry: %w", err)
+	}
+	if subject != "" {
+		curSubject = subject
+	}
+	existing, err := decodeAudiences(curAudiences)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("saving token: %w", err)
+	}
+	mergedAudiences, err := encodeAudiences(mergeAudiences(existing, audiences))
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("saving token: %w", err)
+	}
+	if _, err := tx.Exec(
+		`INSERT OR REPLACE INTO access_tokens
+		 (token_hash, subject, audiences, expires_at, provider_access_token,
+		  provider_refresh_token, provider_access_expiry, rotation_failed, nonce, jti)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		key, curSubject, mergedAudiences, expiresAt.Unix(),
+		curPAT, curPRT, curPAE, curRotationFailed, curNonce, curJti,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("saving token: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("saving token: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) SaveProviderRefresh(token, providerRefreshToken string, providerAccessExpiry time.Time) error {
+	_, err := s.db.Exec(
+		`UPDATE access_tokens SET provider_refresh_token = ?, provider_access_expiry = ?
+		 WHERE token_hash = ? AND expires_at > ?`,
+		providerRefreshToken, unixOrZero(providerAccessExpiry), tokenKey(token), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving token provider refresh metadata: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) SaveProviderAccessToken(token, providerAccessToken string) error {
+	_, err := s.db.Exec(
+		`UPDATE access_tokens SET provider_access_token = ? WHERE token_hash = ? AND expires_at > ?`,
+		providerAccessToken, tokenKey(token), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving token provider access token: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) Lookup(token string) (TokenRecord, bool) {
+	var (
+		subject, audiencesEnc, pat, prt, nonce, jti string
+		expiresUnix, paeUnix                        int64
+		rotationFailedInt                           int
+	)
+	err := s.db.QueryRow(
+		`SELECT subject, audiences, expires_at, provider_access_token, provider_refresh_token,
+		        provider_access_expiry, rotation_failed, nonce, jti
+		 FROM access_tokens WHERE token_hash = ? AND expires_at > ?`,
+		tokenKey(token), time.Now().Unix(),
+	).Scan(&subject, &audiencesEnc, &expiresUnix, &pat, &prt, &paeUnix, &rotationFailedInt, &nonce, &jti)
+	if err != nil {
+		return TokenRecord{}, false
+	}
+	audiences, err := decodeAudiences(audiencesEnc)
+	if err != nil {
+		slog.Warn("token store entry has undecodable audiences; treating as miss", "err", err)
+		return TokenRecord{}, false
+	}
+	return TokenRecord{
+		Subject:                   subject,
+		Audiences:                 audiences,
+		ExpiresAt:                 time.Unix(expiresUnix, 0),
+		ProviderAccessToken:       pat,
+		ProviderRefreshToken:      prt,
+		ProviderAccessExpiry:      timeFromUnixOrZero(paeUnix),
+		RotationPermanentlyFailed: rotationFailedInt != 0,
+		Nonce:                     nonce,
+		Jti:                       jti,
+	}, true
+}
+
+func (s *sqliteTokenStore) SaveNonce(token, nonce string) error {
+	_, err := s.db.Exec(
+		`UPDATE access_tokens SET nonce = ? WHERE token_hash = ? AND expires_at > ?`,
+		nonce, tokenKey(token), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving token nonce: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) SaveJti(token, jti string) error {
+	_, err := s.db.Exec(
+		`UPDATE access_tokens SET jti = ? WHERE token_hash = ? AND expires_at > ?`,
+		jti, tokenKey(token), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("saving token jti: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) MarkRotationFailed(token string) error {
+	_, err := s.db.Exec(
+		`UPDATE access_tokens SET rotation_failed = 1 WHERE token_hash = ? AND expires_at > ?`,
+		tokenKey(token), time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("marking token rotation failed: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) Delete(token string) error {
+	_, err := s.db.Exec(`DELETE FROM access_tokens WHERE token_hash = ?`, tokenKey(token))
+	if err != nil {
+		return fmt.Errorf("deleting token: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTokenStore) Sweep() error {
+	_, err := s.sweepNow()
+	return err
+}
+
+func (s *sqliteTokenStore) sweepNow() (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM access_tokens WHERE expires_at <= ?`, time.Now().Unix())
+	if err != nil {
+		return 0, fmt.Errorf("sweeping expired tokens: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// Close releases the shared database connection. sql.DB.Close is idempotent,
+// so closing both stores returned by NewSQLiteTokenStores is harmless.
+func (s *sqliteTokenStore) Close() error {
 	return s.db.Close()
 }

--- a/internal/auth/tokenstore_sqlite.go
+++ b/internal/auth/tokenstore_sqlite.go
@@ -160,8 +160,12 @@ func openSQLiteTokenDB(path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("initialising SQLite token store: %w", err)
 	}
 	if path != ":memory:" {
-		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
-			slog.Warn("SQLite token store chmod failed", "path", path, "err", err)
+		// WAL mode can materialise token data into -wal/-shm side files, so the
+		// same owner-only permission must apply to them, not just the main file.
+		for _, suffix := range [...]string{"", "-wal", "-shm"} {
+			if err := os.Chmod(path+suffix, 0o600); err != nil && !os.IsNotExist(err) {
+				slog.Warn("SQLite token store chmod failed", "path", path+suffix, "err", err)
+			}
 		}
 	}
 	return db, nil

--- a/internal/auth/tokenstore_sqlite_migrate.go
+++ b/internal/auth/tokenstore_sqlite_migrate.go
@@ -92,6 +92,91 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 	return nil
 }
 
+// migrateFileTokenStore reads an existing tokens.json file, inserts all
+// entries into dst inside a single transaction, then renames the file to
+// <path>.migrated so it is not re-processed on the next startup. Expired
+// entries are imported as-is and removed by the next periodic Sweep, matching
+// migrateFileRefreshTokenStore.
+//
+// If the source file does not exist the function returns nil (no-op).
+// If any step fails the source file is left untouched so the operator can
+// inspect the data; the error is returned and the caller should abort.
+func migrateFileTokenStore(path string, dst TokenStore) error {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading legacy token store %q: %w", path, err)
+	}
+	if len(data) == 0 {
+		_ = renameOverwrite(path, path+".migrated")
+		return nil
+	}
+
+	var entries map[string]fileEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("parsing legacy token store %q: %w", path, err)
+	}
+
+	sq, ok := dst.(*sqliteTokenStore)
+	if !ok {
+		return fmt.Errorf("migration destination is not a SQLite store")
+	}
+
+	// Wrap all inserts in a single transaction: atomic and significantly faster
+	// than one fsync per row when the entry count is large. INSERT OR IGNORE
+	// keeps an already-present SQLite row authoritative over the legacy file.
+	tx, err := sq.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("beginning token migration transaction: %w", err)
+	}
+	stmt, err := tx.Prepare(
+		`INSERT OR IGNORE INTO access_tokens
+		 (token_hash, subject, audiences, expires_at, provider_access_token,
+		  provider_refresh_token, provider_access_expiry, rotation_failed, nonce, jti)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("preparing token migration insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	imported := 0
+	for hash, e := range entries {
+		audiencesEnc, err := encodeAudiences(e.Audiences)
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("migrating token entry: %w", err)
+		}
+		rotationFailedInt := 0
+		if e.RotationFailed {
+			rotationFailedInt = 1
+		}
+		if _, err := stmt.Exec(
+			hash, e.Subject, audiencesEnc, e.ExpiresAt.Unix(),
+			e.ProviderAccessToken, e.ProviderRefreshToken, unixOrZero(e.ProviderAccessExpiry),
+			rotationFailedInt, e.Nonce, e.Jti,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("migrating token entry: %w", err)
+		}
+		imported++
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing token migration transaction: %w", err)
+	}
+
+	migratedPath := path + ".migrated"
+	if err := renameOverwrite(path, migratedPath); err != nil {
+		return fmt.Errorf("renaming legacy token store after migration: %w", err)
+	}
+	slog.Info("legacy token store migrated to SQLite",
+		"source", path, "renamed_to", migratedPath, "imported", imported)
+	return nil
+}
+
 // renameOverwrite renames src to dst, removing dst first if it exists.
 // This avoids os.Rename failures on Windows when dst already exists.
 func renameOverwrite(src, dst string) error {

--- a/internal/auth/tokenstore_sqlite_migrate.go
+++ b/internal/auth/tokenstore_sqlite_migrate.go
@@ -24,7 +24,9 @@ func migrateFileRefreshTokenStore(path string, dst RefreshTokenStore) error {
 		return fmt.Errorf("reading legacy refresh token store %q: %w", path, err)
 	}
 	if len(data) == 0 {
-		_ = renameOverwrite(path, path+".migrated")
+		if err := renameOverwrite(path, path+".migrated"); err != nil {
+			return fmt.Errorf("renaming empty legacy refresh token store %q: %w", path, err)
+		}
 		return nil
 	}
 
@@ -110,7 +112,9 @@ func migrateFileTokenStore(path string, dst TokenStore) error {
 		return fmt.Errorf("reading legacy token store %q: %w", path, err)
 	}
 	if len(data) == 0 {
-		_ = renameOverwrite(path, path+".migrated")
+		if err := renameOverwrite(path, path+".migrated"); err != nil {
+			return fmt.Errorf("renaming empty legacy token store %q: %w", path, err)
+		}
 		return nil
 	}
 

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -525,3 +525,312 @@ func TestSQLiteRefreshTokenStoreBackfillsFamilyPointerOnReopen(t *testing.T) {
 		t.Errorf("RevokeFamily after backfill-on-reopen: got %q, want %q", current, "at-legacy-current")
 	}
 }
+
+// ── SQLite TokenStore ────────────────────────────────────────────────────────
+
+// newTestSQLiteTokenStores opens a shared in-memory database and registers
+// cleanup for the shared handle.
+func newTestSQLiteTokenStores(t *testing.T) (TokenStore, RefreshTokenStore) {
+	t.Helper()
+	ts, rts, err := NewSQLiteTokenStores(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteTokenStores: %v", err)
+	}
+	t.Cleanup(func() { _ = ts.(*sqliteTokenStore).Close() })
+	return ts, rts
+}
+
+func TestSQLiteTokenStoreContract(t *testing.T) {
+	ts, _ := newTestSQLiteTokenStores(t)
+	testTokenStoreContract(t, ts)
+}
+
+func TestSQLiteRefreshTokenStoreContractOnSharedDB(t *testing.T) {
+	_, rts := newTestSQLiteTokenStores(t)
+	testRefreshTokenStoreContract(t, rts)
+}
+
+// TestSQLiteTokenStorePersistence verifies that every TokenRecord field
+// round-trips through a store reopen (process-restart simulation), including
+// the zero ProviderAccessExpiry ("no expiry hint") sentinel.
+func TestSQLiteTokenStorePersistence(t *testing.T) {
+	path := tempSQLitePath(t)
+	exp := time.Now().Add(time.Hour)
+	pae := time.Now().Add(8 * time.Hour).Truncate(time.Second)
+
+	ts1, _, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := ts1.Save("tok-full", "alice", []string{"https://gw.example/mcp"}, exp); err != nil {
+		t.Fatalf("Save tok-full: %v", err)
+	}
+	if err := ts1.SaveProviderAccessToken("tok-full", "gho_persist"); err != nil {
+		t.Fatalf("SaveProviderAccessToken: %v", err)
+	}
+	if err := ts1.SaveProviderRefresh("tok-full", "ghr_persist", pae); err != nil {
+		t.Fatalf("SaveProviderRefresh: %v", err)
+	}
+	if err := ts1.SaveNonce("tok-full", "nonce-persist"); err != nil {
+		t.Fatalf("SaveNonce: %v", err)
+	}
+	if err := ts1.SaveJti("tok-full", "jti-persist"); err != nil {
+		t.Fatalf("SaveJti: %v", err)
+	}
+	// Second entry: provider refresh saved without an expiry hint — must come
+	// back as the zero time, not Unix(0).
+	if err := ts1.Save("tok-nohint", "bob", nil, exp); err != nil {
+		t.Fatalf("Save tok-nohint: %v", err)
+	}
+	if err := ts1.SaveProviderRefresh("tok-nohint", "ghr_nohint", time.Time{}); err != nil {
+		t.Fatalf("SaveProviderRefresh (zero expiry): %v", err)
+	}
+	if err := ts1.(*sqliteTokenStore).Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	ts2, _, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	t.Cleanup(func() { _ = ts2.(*sqliteTokenStore).Close() })
+	rec, ok := ts2.Lookup("tok-full")
+	if !ok {
+		t.Fatal("Lookup tok-full after reopen: expected hit")
+	}
+	if rec.Subject != "alice" {
+		t.Errorf("Subject: got %q, want %q", rec.Subject, "alice")
+	}
+	if !rec.HasAudience("https://gw.example/mcp") {
+		t.Errorf("Audiences: got %#v, want https://gw.example/mcp", rec.Audiences)
+	}
+	if rec.ProviderAccessToken != "gho_persist" {
+		t.Errorf("ProviderAccessToken: got %q, want %q", rec.ProviderAccessToken, "gho_persist")
+	}
+	if rec.ProviderRefreshToken != "ghr_persist" {
+		t.Errorf("ProviderRefreshToken: got %q, want %q", rec.ProviderRefreshToken, "ghr_persist")
+	}
+	if !rec.ProviderAccessExpiry.Equal(pae) {
+		t.Errorf("ProviderAccessExpiry: got %v, want %v", rec.ProviderAccessExpiry, pae)
+	}
+	if rec.Nonce != "nonce-persist" {
+		t.Errorf("Nonce: got %q, want %q", rec.Nonce, "nonce-persist")
+	}
+	if rec.Jti != "jti-persist" {
+		t.Errorf("Jti: got %q, want %q", rec.Jti, "jti-persist")
+	}
+
+	recNoHint, ok := ts2.Lookup("tok-nohint")
+	if !ok {
+		t.Fatal("Lookup tok-nohint after reopen: expected hit")
+	}
+	if !recNoHint.ProviderAccessExpiry.IsZero() {
+		t.Errorf("ProviderAccessExpiry: got %v, want zero time", recNoHint.ProviderAccessExpiry)
+	}
+}
+
+// TestSQLiteTokenStoreMarkRotationFailedPersists verifies the restart
+// durability of RotationPermanentlyFailed — the property that keeps a dead
+// bearer out of the subject index after a gateway restart.
+func TestSQLiteTokenStoreMarkRotationFailedPersists(t *testing.T) {
+	path := tempSQLitePath(t)
+
+	ts1, _, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := ts1.Save("tok-dead", "alice", nil, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ts1.MarkRotationFailed("tok-dead"); err != nil {
+		t.Fatalf("MarkRotationFailed: %v", err)
+	}
+	if err := ts1.(*sqliteTokenStore).Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	ts2, _, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	t.Cleanup(func() { _ = ts2.(*sqliteTokenStore).Close() })
+	rec, ok := ts2.Lookup("tok-dead")
+	if !ok {
+		t.Fatal("Lookup after reopen: expected hit")
+	}
+	if !rec.RotationPermanentlyFailed {
+		t.Error("RotationPermanentlyFailed must survive a reopen")
+	}
+}
+
+// TestSQLiteTokenStoresShareDatabase verifies that the TokenStore and
+// RefreshTokenStore returned by NewSQLiteTokenStores write into the same
+// database file and both survive a reopen through it.
+func TestSQLiteTokenStoresShareDatabase(t *testing.T) {
+	path := tempSQLitePath(t)
+	exp := time.Now().Add(time.Hour)
+
+	ts1, rts1, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+	if err := ts1.Save("at-shared", "alice", nil, exp); err != nil {
+		t.Fatalf("TokenStore.Save: %v", err)
+	}
+	if err := rts1.Save("rt-shared", "at-shared", "aud", "fid-shared", exp); err != nil {
+		t.Fatalf("RefreshTokenStore.Save: %v", err)
+	}
+	if err := ts1.(*sqliteTokenStore).Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	ts2, rts2, err := NewSQLiteTokenStores(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	t.Cleanup(func() { _ = ts2.(*sqliteTokenStore).Close() })
+	if _, ok := ts2.Lookup("at-shared"); !ok {
+		t.Error("TokenStore entry must survive reopen of the shared database")
+	}
+	if _, _, _, _, ok := rts2.Lookup("rt-shared"); !ok {
+		t.Error("RefreshTokenStore entry must survive reopen of the shared database")
+	}
+}
+
+// TestMigrateFileTokenStore verifies that entries from a legacy tokens.json
+// are imported into the SQLite store with all fields intact and the source
+// file is renamed to .migrated.
+func TestMigrateFileTokenStore(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json")
+
+	exp := time.Now().Add(time.Hour)
+	pae := time.Now().Add(8 * time.Hour).Truncate(time.Second)
+	entries := map[string]fileEntry{
+		tokenKey("tok-legacy-full"): {
+			Subject:              "alice",
+			Audiences:            []string{"https://gw.example/mcp"},
+			ExpiresAt:            exp,
+			ProviderAccessToken:  "gho_legacy",
+			ProviderRefreshToken: "ghr_legacy",
+			ProviderAccessExpiry: pae,
+			RotationFailed:       true,
+			Nonce:                "nonce-legacy",
+			Jti:                  "jti-legacy",
+		},
+		tokenKey("tok-legacy-min"): {Subject: "bob", ExpiresAt: exp},
+	}
+	data, _ := json.Marshal(entries)
+	if err := os.WriteFile(legacyPath, data, 0o600); err != nil {
+		t.Fatalf("writing legacy file: %v", err)
+	}
+
+	dst, _ := newTestSQLiteTokenStores(t)
+	if err := migrateFileTokenStore(legacyPath, dst); err != nil {
+		t.Fatalf("migrateFileTokenStore: %v", err)
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Error("legacy file should have been renamed, but still exists")
+	}
+	if _, err := os.Stat(legacyPath + ".migrated"); err != nil {
+		t.Errorf(".migrated file not found: %v", err)
+	}
+
+	rec, ok := dst.Lookup("tok-legacy-full")
+	if !ok {
+		t.Fatal("Lookup tok-legacy-full: expected hit after migration")
+	}
+	if rec.Subject != "alice" {
+		t.Errorf("Subject: got %q, want %q", rec.Subject, "alice")
+	}
+	if !rec.HasAudience("https://gw.example/mcp") {
+		t.Errorf("Audiences: got %#v", rec.Audiences)
+	}
+	if rec.ProviderAccessToken != "gho_legacy" {
+		t.Errorf("ProviderAccessToken: got %q, want %q", rec.ProviderAccessToken, "gho_legacy")
+	}
+	if rec.ProviderRefreshToken != "ghr_legacy" {
+		t.Errorf("ProviderRefreshToken: got %q, want %q", rec.ProviderRefreshToken, "ghr_legacy")
+	}
+	if !rec.ProviderAccessExpiry.Equal(pae) {
+		t.Errorf("ProviderAccessExpiry: got %v, want %v", rec.ProviderAccessExpiry, pae)
+	}
+	if !rec.RotationPermanentlyFailed {
+		t.Error("RotationPermanentlyFailed must survive migration")
+	}
+	if rec.Nonce != "nonce-legacy" {
+		t.Errorf("Nonce: got %q, want %q", rec.Nonce, "nonce-legacy")
+	}
+	if rec.Jti != "jti-legacy" {
+		t.Errorf("Jti: got %q, want %q", rec.Jti, "jti-legacy")
+	}
+
+	recMin, ok := dst.Lookup("tok-legacy-min")
+	if !ok {
+		t.Fatal("Lookup tok-legacy-min: expected hit after migration")
+	}
+	if recMin.Subject != "bob" || len(recMin.Audiences) != 0 || !recMin.ProviderAccessExpiry.IsZero() {
+		t.Errorf("tok-legacy-min: got %+v, want minimal record", recMin)
+	}
+}
+
+// TestMigrateFileTokenStoreDoesNotOverwrite verifies that INSERT OR IGNORE
+// keeps an already-present SQLite row authoritative over the legacy file.
+func TestMigrateFileTokenStoreDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json")
+
+	exp := time.Now().Add(time.Hour)
+	entries := map[string]fileEntry{
+		tokenKey("tok-conflict"): {Subject: "stale-subject", ExpiresAt: exp},
+	}
+	data, _ := json.Marshal(entries)
+	if err := os.WriteFile(legacyPath, data, 0o600); err != nil {
+		t.Fatalf("writing legacy file: %v", err)
+	}
+
+	dst, _ := newTestSQLiteTokenStores(t)
+	if err := dst.Save("tok-conflict", "current-subject", nil, exp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := migrateFileTokenStore(legacyPath, dst); err != nil {
+		t.Fatalf("migrateFileTokenStore: %v", err)
+	}
+	rec, ok := dst.Lookup("tok-conflict")
+	if !ok {
+		t.Fatal("Lookup tok-conflict: expected hit")
+	}
+	if rec.Subject != "current-subject" {
+		t.Errorf("Subject: got %q, want the pre-existing SQLite row to win", rec.Subject)
+	}
+}
+
+// TestMigrateFileTokenStoreNoFile verifies that migration is a no-op when the
+// legacy file does not exist.
+func TestMigrateFileTokenStoreNoFile(t *testing.T) {
+	dst, _ := newTestSQLiteTokenStores(t)
+	if err := migrateFileTokenStore(filepath.Join(t.TempDir(), "nonexistent"), dst); err != nil {
+		t.Errorf("expected nil for missing file, got %v", err)
+	}
+}
+
+// TestMigrateFileTokenStoreEmptyFile verifies that an empty legacy file is
+// renamed to .migrated without error.
+func TestMigrateFileTokenStoreEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json")
+	if err := os.WriteFile(legacyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("writing empty file: %v", err)
+	}
+	dst, _ := newTestSQLiteTokenStores(t)
+	if err := migrateFileTokenStore(legacyPath, dst); err != nil {
+		t.Fatalf("migrateFileTokenStore: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Error("empty legacy file should have been renamed")
+	}
+	if _, err := os.Stat(legacyPath + ".migrated"); err != nil {
+		t.Errorf(".migrated file not found: %v", err)
+	}
+}

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -26,6 +26,14 @@ func tempSQLitePath(t *testing.T) string {
 // meant to provide. Skipped on Windows where permission bits are not
 // enforced (see the isWindows() pattern used by the other *FilePermissions
 // tests in this package).
+//
+// Whether -wal/-shm exist at all by the time openSQLiteTokenDB returns is a
+// SQLite-driver/platform implementation detail (observed: present on
+// Windows, absent on Linux CI for a freshly-created, otherwise-empty
+// database — thread-owl re-review, PR #196 run 28655143021), matching the
+// chmod loop's own best-effort contract (os.IsNotExist is not an error). So
+// this only asserts the permission on side files that do exist; the main
+// database file is always expected to exist and be checked unconditionally.
 func TestOpenSQLiteTokenDBChmodsWALSideFiles(t *testing.T) {
 	if isWindows() {
 		t.Skip("file permission bits not enforced on Windows")
@@ -37,10 +45,22 @@ func TestOpenSQLiteTokenDBChmodsWALSideFiles(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	for _, suffix := range []string{"", "-wal", "-shm"} {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("stat %q: %v", path, statErr)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("%s: mode = %o, want 0600", path, perm)
+	}
+
+	for _, suffix := range []string{"-wal", "-shm"} {
 		p := path + suffix
 		info, statErr := os.Stat(p)
 		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				t.Logf("%s: not materialised by this SQLite build/platform at this point; skipping permission check", p)
+				continue
+			}
 			t.Fatalf("stat %q: %v", p, statErr)
 		}
 		if perm := info.Mode().Perm(); perm != 0o600 {

--- a/internal/auth/tokenstore_sqlite_test.go
+++ b/internal/auth/tokenstore_sqlite_test.go
@@ -18,6 +18,37 @@ func tempSQLitePath(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "tokens.refresh.db")
 }
 
+// TestOpenSQLiteTokenDBChmodsWALSideFiles verifies that the -wal/-shm side
+// files WAL mode creates alongside the main database also get the owner-only
+// permission — not just the main file (thread-owl review, PR #196): those
+// side files can contain token data mid-transaction, so leaving them at the
+// process umask would defeat the confidentiality the main file's 0600 is
+// meant to provide. Skipped on Windows where permission bits are not
+// enforced (see the isWindows() pattern used by the other *FilePermissions
+// tests in this package).
+func TestOpenSQLiteTokenDBChmodsWALSideFiles(t *testing.T) {
+	if isWindows() {
+		t.Skip("file permission bits not enforced on Windows")
+	}
+	path := tempSQLitePath(t)
+	db, err := openSQLiteTokenDB(path)
+	if err != nil {
+		t.Fatalf("openSQLiteTokenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := path + suffix
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			t.Fatalf("stat %q: %v", p, statErr)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s: mode = %o, want 0600", p, perm)
+		}
+	}
+}
+
 func newTestSQLiteStore(t *testing.T) RefreshTokenStore {
 	t.Helper()
 	rts, err := NewSQLiteRefreshTokenStore(":memory:")
@@ -803,6 +834,67 @@ func TestMigrateFileTokenStoreDoesNotOverwrite(t *testing.T) {
 	}
 	if rec.Subject != "current-subject" {
 		t.Errorf("Subject: got %q, want the pre-existing SQLite row to win", rec.Subject)
+	}
+}
+
+// TestMigrateFileTokenStoreEmptyFileRenameError verifies that a rename
+// failure on an empty legacy file is surfaced as an error rather than
+// silently swallowed (thread-owl review, PR #196): swallowing it would let
+// startup proceed while leaving the empty file in place to be re-processed
+// (and potentially fail the same way again) on every subsequent restart,
+// contradicting the "renamed to .migrated" contract other callers rely on.
+func TestMigrateFileTokenStoreEmptyFileRenameError(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json")
+	if err := os.WriteFile(legacyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("writing empty file: %v", err)
+	}
+	// Pre-create the .migrated destination as a non-empty directory so
+	// renameOverwrite's os.Remove(dst) fails with something other than
+	// "not exist", forcing the rename failure down the error path instead of
+	// the normal no-op-if-absent path.
+	migratedPath := legacyPath + ".migrated"
+	if err := os.Mkdir(migratedPath, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(migratedPath, "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("writing blocker file: %v", err)
+	}
+
+	dst, _ := newTestSQLiteTokenStores(t)
+	if err := migrateFileTokenStore(legacyPath, dst); err == nil {
+		t.Fatal("expected error when the .migrated destination cannot be removed, got nil")
+	}
+	if _, statErr := os.Stat(legacyPath); statErr != nil {
+		t.Errorf("legacy empty file should remain in place after a failed rename: %v", statErr)
+	}
+}
+
+// TestMigrateFileRefreshTokenStoreEmptyFileRenameError is the
+// RefreshTokenStore counterpart of TestMigrateFileTokenStoreEmptyFileRenameError.
+func TestMigrateFileRefreshTokenStoreEmptyFileRenameError(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "tokens.json.refresh")
+	if err := os.WriteFile(legacyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("writing empty file: %v", err)
+	}
+	migratedPath := legacyPath + ".migrated"
+	if err := os.Mkdir(migratedPath, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(migratedPath, "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("writing blocker file: %v", err)
+	}
+
+	dst, err := NewSQLiteRefreshTokenStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteRefreshTokenStore: %v", err)
+	}
+	if err := migrateFileRefreshTokenStore(legacyPath, dst); err == nil {
+		t.Fatal("expected error when the .migrated destination cannot be removed, got nil")
+	}
+	if _, statErr := os.Stat(legacyPath); statErr != nil {
+		t.Errorf("legacy empty file should remain in place after a failed rename: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## 概要

#191 のプライマリ TokenStore SQLite 移行を実装する。#24 クローズ時に追跡漏れし、#134 / PR #135 で RefreshTokenStore のみ SQLite 化されて以来分裂していたストレージを統合する。

## 変更内容

### TokenStore の SQLite 実装（`sqliteTokenStore`）

- RefreshTokenStore と**同一 SQLite DB**（`<token-store-path>.refresh.db`）に `access_tokens` テーブルを追加。単一ファイル・単一 writer ロック・単一トランザクション境界
- フィールド更新（`SaveProviderRefresh` / `SaveProviderAccessToken` / `SaveNonce` / `SaveJti` / `MarkRotationFailed`）は有効期限ガード付きの単一 `UPDATE` 文。file ストアの「ファイル全体 rewrite + 手動 `previous` 退避ロールバック」パターンを置き換え、メモリ/ディスク乖離の余地を排除
- `Save` の再保存セマンティクス（audiences マージ・subject 保持）は単一トランザクション内の read-merge-write で mem/file 実装と同一に維持
- 期限切れエントリはインデックス付き `DELETE`（全走査 sweep + rewrite から置き換え）
- `NewSQLiteTokenStores(path)` が共有 `*sql.DB` で両ストアを返す。`NewSQLiteRefreshTokenStore` は既存 API のまま内部を `openSQLiteTokenDB` に共通化

### DB ファイル名について

`.refresh.db` という歴史的名称を継続使用する。rename マイグレーションは crash 時の WAL 孤児化リスクと、旧バージョンへのロールバック時に denylist（revoked_jti）・リフレッシュ状態が参照できなくなるセキュリティリグレッションを伴うため見送った（doc コメントと docs/configuration.md に経緯を明記）。

### 自動マイグレーション

- `migrateFileTokenStore`: 既存 `tokens.json` を初回起動時に単一トランザクションでインポートし `tokens.json.migrated` にリネーム（#135 のパターン踏襲）
- `INSERT OR IGNORE` により既存 SQLite 行が legacy ファイルより優先
- 失敗時は元ファイルを残したまま起動中止（fail-closed、実機検証済み）

### テスト

- 既存の TokenStore 契約テスト（`testTokenStoreContract`）を SQLite 実装に適用
- 全フィールドの reopen 往復（ゼロ `ProviderAccessExpiry` センチネル含む）、`MarkRotationFailed` の再起動耐性、共有 DB、マイグレーション（全フィールド / 上書きなし / ファイルなし / 空ファイル）
- NewHandler 経由の統合テスト（マイグレーション + `.migrated` リネーム）

### ドキュメント

- `docs/configuration.md` トークン永続化セクションを実装に合わせて全面改訂（`MCP_GATEWAY_TOKEN_STORE_PATH` のベースパス意味論、バックアップ除外対象に `-wal`/`-shm`/`*.migrated` を追記）。PR #189 の「SQLite バックエンドを指す場合は同 DB 内」というドキュメント先行記述と実装の乖離を解消
- README / README.ja / CHANGELOG / CHANGELOG.ja 更新

## 検証

実バイナリでのエンドツーエンド検証を実施:

1. legacy `tokens.json` を置いて起動 → `imported:1` ログ、`.migrated` リネーム、`.refresh.db` 作成を確認
2. 再起動 → `access_tokens:1` で SQLite 永続化を確認
3. 移行済みトークンで `GET /mcp` → 認証通過し `proxy request user=dave` でプロキシ到達（upstream 停止のため 502 = 期待どおり）
4. 不正トークン → 401（ストアミス経路）
5. 壊れた `tokens.json` で起動 → exit 1、元ファイル無傷（fail-closed）

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)