### PR TITLE
feat(server): ローカル HTTPS (TLS) 終端サポートを追加 (#201)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,13 @@
 
 ## [Unreleased]
 
+### 追加
+
+- ローカル HTTPS（TLS 終端）サポート（[#201](https://github.com/scottlz0310/mcp-gateway/issues/201)）
+  - 新環境変数 `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH`: 両方に PEM 証明書・秘密鍵のパスを設定すると、ゲートウェイ（初回セットアップウィザードを含む）が `http.Server.ListenAndServeTLS` で TLS 付きで listen する。
+  - 起動時のフェイルファスト検証: 片方のみの設定、ファイル欠如、ディレクトリ指定は明示的なエラーで起動を中断する。自己署名証明書の自動生成フォールバックは行わない（ローカル証明書の準備はデプロイ側の責務。例: Mcp-Docker の `setup-tls`）。
+  - `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルト公開 URL は、TLS 有効時に `https` スキームで導出されるようになり、OAuth コールバックとディスカバリメタデータがリスナーと整合する。
+
 ## [0.8.0] - 2026-07-03
 
 ### セキュリティ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Local HTTPS (TLS termination) support ([#201](https://github.com/scottlz0310/mcp-gateway/issues/201))
+  - New env vars `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH`: when both point to a PEM cert/key pair, the gateway (including the first-run setup wizard) listens with TLS via `http.Server.ListenAndServeTLS`.
+  - Fail-fast validation at startup: setting only one of the two vars, or pointing either at a missing file or a directory, aborts startup with an explicit error — no self-signed fallback is generated (local cert provisioning is owned by the deployment side, e.g. Mcp-Docker `setup-tls`).
+  - When `MCP_GATEWAY_PUBLIC_URL` is not set, the derived default public URL now uses the `https` scheme while TLS is enabled, keeping OAuth callbacks and discovery metadata consistent with the listener.
+
 ## [0.8.0] - 2026-07-03
 
 ### Security

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,13 @@ func main() {
 
 	cfg := loadConfig()
 
+	// TLS fail-fast: an inconsistent or dangling cert/key configuration must
+	// abort startup instead of silently falling back to plain HTTP (#201).
+	if err := validateTLSConfig(cfg.tlsCertPath, cfg.tlsKeyPath); err != nil {
+		slog.Error("invalid TLS configuration", "err", err)
+		os.Exit(1)
+	}
+
 	// Load or generate the encryption key.
 	masterKey := []byte(getEnv("MCP_GATEWAY_MASTER_KEY", os.Getenv("MCP_MASTER_KEY")))
 	if len(strings.TrimSpace(string(masterKey))) == 0 {
@@ -113,11 +120,15 @@ func main() {
 		strings.TrimSpace(os.Getenv("MCP_GATEWAY_BASE_URL")) == "" &&
 		strings.TrimSpace(appCfg.Gateway.PublicURL) == "" &&
 		strings.TrimSpace(appCfg.Gateway.BaseURL) == "" {
+		scheme := "http"
+		if cfg.tlsCertPath != "" {
+			scheme = "https"
+		}
 		_, bindPort, err := net.SplitHostPort(cfg.bindAddr)
 		if err == nil && strings.TrimSpace(bindPort) != "" {
-			cfg.publicURL = "http://127.0.0.1:" + bindPort
+			cfg.publicURL = scheme + "://127.0.0.1:" + bindPort
 		} else {
-			cfg.publicURL = "http://127.0.0.1:" + cfg.port
+			cfg.publicURL = scheme + "://127.0.0.1:" + cfg.port
 		}
 	}
 	if _, ok := appconfig.ResolveOAuthEnv("OAUTH_SCOPES", "GITHUB_MCP_OAUTH_SCOPES"); !ok && strings.TrimSpace(appCfg.Gateway.OAuthScopes) != "" {
@@ -247,15 +258,15 @@ func main() {
 	}()
 
 	oauthHandler, err := auth.NewHandler(auth.Config{
-		BaseURL:              cfg.publicURL,
-		SessionTTL:           time.Duration(cfg.sessionTTLMin) * time.Minute,
-		CacheTTL:             time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
-		ExpiresIn:            time.Duration(cfg.tokenExpiresInSec) * time.Second,
-		TokenStorePath:       cfg.tokenStorePath,
-		ResourceAudienceMap:  buildResourceAudienceMap(routes, cfg.publicURL),
-		TokenAudienceStrict:  cfg.tokenAudienceStrict,
-		GitHubRefreshEnabled: cfg.githubRefreshEnabled,
-		OIDCPrivateKey:       oidcPrivateKey,
+		BaseURL:                cfg.publicURL,
+		SessionTTL:             time.Duration(cfg.sessionTTLMin) * time.Minute,
+		CacheTTL:               time.Duration(cfg.tokenCacheTTLMin) * time.Minute,
+		ExpiresIn:              time.Duration(cfg.tokenExpiresInSec) * time.Second,
+		TokenStorePath:         cfg.tokenStorePath,
+		ResourceAudienceMap:    buildResourceAudienceMap(routes, cfg.publicURL),
+		TokenAudienceStrict:    cfg.tokenAudienceStrict,
+		GitHubRefreshEnabled:   cfg.githubRefreshEnabled,
+		OIDCPrivateKey:         oidcPrivateKey,
 		AllowedRedirectHosts:   cfg.allowedRedirectHosts,
 		AllowedRedirectSchemes: cfg.allowedRedirectSchemes,
 	}, prov, auth.WithAuditRecorder(auditRecorder))
@@ -426,6 +437,7 @@ func main() {
 	slog.Info("mcp-gateway starting",
 		"bind_addr", cfg.bindAddr,
 		"public_url", cfg.publicURL,
+		"tls_enabled", cfg.tlsCertPath != "",
 		"provider", prov.Name(),
 		"routes", len(routes),
 		"trusted_proxies", len(trustedProxies),
@@ -448,10 +460,45 @@ func main() {
 	// (fail-closed) with an explicit log so misconfiguration is obvious.
 	startInternalAPI(oauthHandler, oauthHandler)
 
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath); err != nil && err != http.ErrServerClosed {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}
+}
+
+// listenAndServe starts srv with TLS termination when a cert/key pair is
+// configured, and plain HTTP otherwise. Path consistency is validated at
+// startup by validateTLSConfig.
+func listenAndServe(srv *http.Server, tlsCertPath, tlsKeyPath string) error {
+	if tlsCertPath != "" {
+		return srv.ListenAndServeTLS(tlsCertPath, tlsKeyPath)
+	}
+	return srv.ListenAndServe()
+}
+
+// validateTLSConfig rejects half-configured TLS (only one of cert/key set)
+// and dangling paths. Deliberately no self-signed fallback: local cert
+// provisioning is owned by the deployment side (Mcp-Docker setup-tls).
+func validateTLSConfig(tlsCertPath, tlsKeyPath string) error {
+	if tlsCertPath == "" && tlsKeyPath == "" {
+		return nil
+	}
+	if tlsCertPath == "" || tlsKeyPath == "" {
+		return fmt.Errorf("MCP_GATEWAY_TLS_CERT_PATH and MCP_GATEWAY_TLS_KEY_PATH must be set together (cert=%q, key=%q)", tlsCertPath, tlsKeyPath)
+	}
+	for name, path := range map[string]string{
+		"MCP_GATEWAY_TLS_CERT_PATH": tlsCertPath,
+		"MCP_GATEWAY_TLS_KEY_PATH":  tlsKeyPath,
+	} {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("%s: cannot access %q: %w", name, path, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("%s: %q is a directory, expected a PEM file", name, path)
+		}
+	}
+	return nil
 }
 
 // runSetupWizard starts an HTTP server that serves only the /setup endpoint.
@@ -493,8 +540,8 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	slog.Info("setup wizard listening", "bind_addr", cfg.bindAddr)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	slog.Info("setup wizard listening", "bind_addr", cfg.bindAddr, "tls_enabled", cfg.tlsCertPath != "")
+	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath); err != nil && err != http.ErrServerClosed {
 		slog.Error("setup server error", "err", err)
 	}
 }
@@ -510,23 +557,26 @@ type config struct {
 	// Replaces the deprecated baseURL / MCP_GATEWAY_BASE_URL.
 	publicURL string
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
-	bindAddr             string
-	oauthProvider        string
-	oauthScopes          string
-	oidcIssuerURL        string
-	oidcAudience         string
-	port                 string
-	logLevel             string
-	upstreamURL          string // deprecated; prefer ROUTE_* env vars
-	trustedProxyCIDRs    []string
-	sessionTTLMin        int
-	tokenCacheTTLMin     int
-	tokenExpiresInSec    int
-	tokenAudienceStrict  bool
-	githubRefreshEnabled bool
-	tokenStorePath       string
-	keyPath              string
-	configPath           string
+	bindAddr string
+	// tlsCertPath / tlsKeyPath enable TLS termination when both are set.
+	tlsCertPath            string
+	tlsKeyPath             string
+	oauthProvider          string
+	oauthScopes            string
+	oidcIssuerURL          string
+	oidcAudience           string
+	port                   string
+	logLevel               string
+	upstreamURL            string // deprecated; prefer ROUTE_* env vars
+	trustedProxyCIDRs      []string
+	sessionTTLMin          int
+	tokenCacheTTLMin       int
+	tokenExpiresInSec      int
+	tokenAudienceStrict    bool
+	githubRefreshEnabled   bool
+	tokenStorePath         string
+	keyPath                string
+	configPath             string
 	allowedRedirectHosts   []string
 	allowedRedirectSchemes []string
 	// upstream OAuth state paths
@@ -537,10 +587,21 @@ type config struct {
 func loadConfig() config {
 	port := getEnv("MCP_GATEWAY_PORT", "8080")
 
+	tlsCertPath := strings.TrimSpace(getEnv("MCP_GATEWAY_TLS_CERT_PATH", ""))
+	tlsKeyPath := strings.TrimSpace(getEnv("MCP_GATEWAY_TLS_KEY_PATH", ""))
+
+	// The default public URL scheme follows the listener: https when TLS
+	// termination is enabled, so OAuth callbacks and discovery metadata stay
+	// reachable without an explicit MCP_GATEWAY_PUBLIC_URL.
+	defaultScheme := "http"
+	if tlsCertPath != "" {
+		defaultScheme = "https"
+	}
+
 	// publicURL resolution: MCP_GATEWAY_PUBLIC_URL > MCP_GATEWAY_BASE_URL > default.
 	// Deprecation warning for MCP_GATEWAY_BASE_URL is emitted in main() after logger init.
 	publicURL := getEnv("MCP_GATEWAY_PUBLIC_URL",
-		getEnv("MCP_GATEWAY_BASE_URL", "http://127.0.0.1:"+port))
+		getEnv("MCP_GATEWAY_BASE_URL", defaultScheme+"://127.0.0.1:"+port))
 
 	// bindAddr defaults to loopback; Docker deployments should set MCP_GATEWAY_BIND_ADDR=0.0.0.0:<port>.
 	bindAddr := getEnv("MCP_GATEWAY_BIND_ADDR", "127.0.0.1:"+port)
@@ -559,26 +620,28 @@ func loadConfig() config {
 
 	return config{
 		// githubClientID and githubClientSecret are resolved after key/config loading in main().
-		publicURL:            publicURL,
-		bindAddr:             bindAddr,
-		port:                 port,
-		oauthProvider:        oauthProvider,
-		oauthScopes:          oauthScopes,
-		oidcIssuerURL:        getEnv("OAUTH_ISSUER_URL", ""),
-		oidcAudience:         getEnv("OAUTH_AUDIENCE", ""),
-		logLevel:             getEnv("LOG_LEVEL", "info"),
-		upstreamURL:          getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
-		trustedProxyCIDRs:    splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
-		sessionTTLMin:        getEnvInt("SESSION_TTL_MIN", 10),
-		tokenCacheTTLMin:     getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
-		tokenExpiresInSec:    getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
-		tokenAudienceStrict:  getEnvBool("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT", false),
-		githubRefreshEnabled: getEnvBool("MCP_GATEWAY_GITHUB_REFRESH_ENABLED", false),
-		tokenStorePath:       lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", filepath.Join(stateDir, "tokens.json")),
-		keyPath:              getEnv("MCP_GATEWAY_KEY_PATH", filepath.Join(stateDir, "gateway.key")),
-		configPath:           getEnv("MCP_CONFIG_FILE", filepath.Join(stateDir, "config.yaml")),
-		allowedRedirectHosts:   splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
-		allowedRedirectSchemes: splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES")),
+		publicURL:               publicURL,
+		bindAddr:                bindAddr,
+		tlsCertPath:             tlsCertPath,
+		tlsKeyPath:              tlsKeyPath,
+		port:                    port,
+		oauthProvider:           oauthProvider,
+		oauthScopes:             oauthScopes,
+		oidcIssuerURL:           getEnv("OAUTH_ISSUER_URL", ""),
+		oidcAudience:            getEnv("OAUTH_AUDIENCE", ""),
+		logLevel:                getEnv("LOG_LEVEL", "info"),
+		upstreamURL:             getEnv("GITHUB_MCP_UPSTREAM_URL", ""),
+		trustedProxyCIDRs:       splitCSV(os.Getenv("MCP_GATEWAY_TRUSTED_PROXIES")),
+		sessionTTLMin:           getEnvInt("SESSION_TTL_MIN", 10),
+		tokenCacheTTLMin:        getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
+		tokenExpiresInSec:       getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		tokenAudienceStrict:     getEnvBool("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT", false),
+		githubRefreshEnabled:    getEnvBool("MCP_GATEWAY_GITHUB_REFRESH_ENABLED", false),
+		tokenStorePath:          lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", filepath.Join(stateDir, "tokens.json")),
+		keyPath:                 getEnv("MCP_GATEWAY_KEY_PATH", filepath.Join(stateDir, "gateway.key")),
+		configPath:              getEnv("MCP_CONFIG_FILE", filepath.Join(stateDir, "config.yaml")),
+		allowedRedirectHosts:    splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_HOSTS")),
+		allowedRedirectSchemes:  splitCSV(os.Getenv("MCP_GATEWAY_ALLOWED_REDIRECT_SCHEMES")),
 		upstreamClientStorePath: filepath.Join(stateDir, "upstream_clients.json"),
 		upstreamTokenStorePath:  filepath.Join(stateDir, "upstream_tokens.json"),
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,8 +1,21 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/scottlz0310/mcp-gateway/internal/router"
 )
@@ -13,6 +26,144 @@ func mustURL(raw string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+// writeSelfSignedCert generates a self-signed certificate for 127.0.0.1 and
+// writes the PEM cert/key pair into dir, returning their paths.
+func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "mcp-gateway test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+func TestValidateTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	certPath, keyPath := writeSelfSignedCert(t, dir)
+
+	tests := []struct {
+		name    string
+		cert    string
+		key     string
+		wantErr bool
+	}{
+		{name: "both empty: TLS disabled", cert: "", key: "", wantErr: false},
+		{name: "both set and files exist", cert: certPath, key: keyPath, wantErr: false},
+		{name: "cert only", cert: certPath, key: "", wantErr: true},
+		{name: "key only", cert: "", key: keyPath, wantErr: true},
+		{name: "cert file missing", cert: filepath.Join(dir, "missing-cert.pem"), key: keyPath, wantErr: true},
+		{name: "key file missing", cert: certPath, key: filepath.Join(dir, "missing-key.pem"), wantErr: true},
+		{name: "cert path is a directory", cert: dir, key: keyPath, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateTLSConfig(tc.cert, tc.key)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateTLSConfig(%q, %q) = %v, wantErr %v", tc.cert, tc.key, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestListenAndServeTLS(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	certPath, keyPath := writeSelfSignedCert(t, dir)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &http.Server{
+		Addr: addr,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- listenAndServe(srv, certPath, keyPath) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("failed to add test certificate to pool")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+		Timeout:   5 * time.Second,
+	}
+
+	var resp *http.Response
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err = client.Get("https://" + addr + "/")
+		if err == nil || time.Now().After(deadline) {
+			break
+		}
+		select {
+		case srvErr := <-errCh:
+			t.Fatalf("server exited before accepting connections: %v", srvErr)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if err != nil {
+		t.Fatalf("HTTPS request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	if err := srv.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; !errors.Is(err, http.ErrServerClosed) {
+		t.Errorf("listenAndServe returned %v, want http.ErrServerClosed", err)
+	}
 }
 
 func TestBuildResourceAudienceMap(t *testing.T) {
@@ -39,8 +190,8 @@ func TestBuildResourceAudienceMap(t *testing.T) {
 				{Name: "cloudflare", Prefix: "/mcp/cloudflare", Upstream: mustURL("https://mcp.cloudflare.com/mcp"), RequiredAudience: "mcp-gateway"},
 			},
 			want: map[string]string{
-				"http://127.0.0.1:8080":                  "mcp-gateway",
-				"cloudflare":                             "mcp-gateway",
+				"http://127.0.0.1:8080":                "mcp-gateway",
+				"cloudflare":                           "mcp-gateway",
 				"http://127.0.0.1:8080/mcp/cloudflare": "mcp-gateway",
 			},
 		},
@@ -51,8 +202,8 @@ func TestBuildResourceAudienceMap(t *testing.T) {
 				{Name: "svc", Prefix: "/mcp/svc", Upstream: mustURL("http://svc:9000"), RequiredAudience: "custom-aud"},
 			},
 			want: map[string]string{
-				"http://127.0.0.1:8080":          "mcp-gateway",
-				"svc":                            "custom-aud",
+				"http://127.0.0.1:8080":         "mcp-gateway",
+				"svc":                           "custom-aud",
 				"http://127.0.0.1:8080/mcp/svc": "custom-aud",
 			},
 		},
@@ -84,8 +235,8 @@ func TestBuildResourceAudienceMap(t *testing.T) {
 				{Name: "svc", Prefix: "/mcp/svc", Upstream: mustURL("http://svc:8000"), RequiredAudience: "mcp-gateway"},
 			},
 			want: map[string]string{
-				"http://127.0.0.1:8080":          "mcp-gateway",
-				"svc":                            "mcp-gateway",
+				"http://127.0.0.1:8080":         "mcp-gateway",
+				"svc":                           "mcp-gateway",
 				"http://127.0.0.1:8080/mcp/svc": "mcp-gateway",
 			},
 		},
@@ -97,8 +248,8 @@ func TestBuildResourceAudienceMap(t *testing.T) {
 				{Name: "open", Prefix: "/mcp/open", Upstream: mustURL("http://open:8000"), NoAuth: true, RequiredAudience: "mcp-gateway"},
 			},
 			want: map[string]string{
-				"http://127.0.0.1:8080":             "mcp-gateway",
-				"secure":                            "mcp-gateway",
+				"http://127.0.0.1:8080":            "mcp-gateway",
+				"secure":                           "mcp-gateway",
 				"http://127.0.0.1:8080/mcp/secure": "mcp-gateway",
 			},
 		},

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -153,7 +153,7 @@ func TestListenAndServeTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HTTPS request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -104,14 +104,13 @@ func TestListenAndServeTLS(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeSelfSignedCert(t, dir)
 
+	// Hold the ephemeral port until immediately before the server starts to
+	// keep the reuse race window minimal (ListenAndServeTLS re-binds Addr).
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	addr := ln.Addr().String()
-	if err := ln.Close(); err != nil {
-		t.Fatal(err)
-	}
 
 	srv := &http.Server{
 		Addr: addr,
@@ -121,6 +120,9 @@ func TestListenAndServeTLS(t *testing.T) {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	errCh := make(chan error, 1)
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
 	go func() { errCh <- listenAndServe(srv, certPath, keyPath) }()
 	t.Cleanup(func() { _ = srv.Close() })
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,8 @@ OAuth クライアントシークレットは意図的に特別扱いです。`c
 | `MCP_MASTER_KEY` | なし | `MCP_GATEWAY_MASTER_KEY` の旧エイリアス。 |
 | `MCP_GATEWAY_PUBLIC_URL` | `http://127.0.0.1:<port>` | OAuth コールバック・ディスカバリメタデータ・Protected Resource Metadata で使用するクライアントから見える正規 URL。 |
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:<port>` | TCP リスナーアドレス。Docker でポートを公開する場合は `0.0.0.0:<port>` を使用。 |
+| `MCP_GATEWAY_TLS_CERT_PATH` | なし | TLS サーバー証明書（PEM）のパス。`MCP_GATEWAY_TLS_KEY_PATH` とペアで設定すると HTTPS で listen する。片方のみの設定やファイル欠如は起動エラー（フェイルファスト）。 |
+| `MCP_GATEWAY_TLS_KEY_PATH` | なし | TLS 秘密鍵（PEM）のパス。`MCP_GATEWAY_TLS_CERT_PATH` とペアで設定する。 |
 | `MCP_GATEWAY_PORT` | `8080` | `public_url` と `bind_addr` のデフォルト導出に使用するポート。 |
 | `MCP_GATEWAY_BASE_URL` | なし | `MCP_GATEWAY_PUBLIC_URL` の非推奨エイリアス。設定されると起動時警告を出力。 |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | なし | `X-Forwarded-*` ヘッダーを信頼する直前のリバースプロキシの CIDR リスト（カンマ区切り）。 |
@@ -349,9 +351,23 @@ MCP_GATEWAY_TOKEN_STORE_PATH=
 
 **builtin mode（`OAUTH_PROVIDER=builtin`）の追加事項:** builtin mode ではクライアントに渡すアクセストークンはゲートウェイ署名の JWT であり、GitHub アクセストークン自体ではありません。ただし Phase B delegated access（`EnsureFreshAccessTokenForSubject`、`upstream_provider_token=true` ルートおよび `/internal/v1/whoami` が使用）が upstream サービスへ GitHub トークンを引き渡せるようにするため、GitHub アクセストークンは JWT に紐付けて、アクセストークンストアとリフレッシュトークンストアの両方（同一 SQLite データベース内）に**平文で常に**保存されます（`github_refresh_enabled` 無効時でも同様）。`github_refresh_enabled` はリフレッシュトークン自体の保存有無のみを制御し、GitHub アクセストークンの保存有無は制御しません。したがって上記の「トークンデータベースの読者はログイン済みユーザーの GitHub セッションを乗っ取れる」というリスクは、`github_refresh_enabled` の設定に関わらず builtin mode にも同様に適用されます。
 
+## TLS 終端（ローカル HTTPS）
+
+mcp-gateway 自体で TLS を終端する場合、PEM 形式の証明書と秘密鍵のパスをペアで指定します:
+
+```bash
+MCP_GATEWAY_TLS_CERT_PATH=/data/certs/localhost.pem
+MCP_GATEWAY_TLS_KEY_PATH=/data/certs/localhost-key.pem
+MCP_GATEWAY_PUBLIC_URL=https://localhost:8080
+```
+
+- 両方が設定されている場合のみ HTTPS で listen します。片方のみの設定、またはファイルが存在しない場合は起動時にエラー終了します（フェイルファスト）。
+- 自己署名証明書の自動生成は行いません。ローカル開発では [mkcert](https://github.com/FiloSottile/mkcert) 等で信頼済み証明書を生成してください（Docker 運用でのセットアップ自動化は Mcp-Docker 側で提供）。
+- `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルトスキームは、TLS 有効時は自動的に `https` になります。
+
 ## リバースプロキシヘッダー
 
-mcp-gateway の前で TLS を終端する場合:
+リバースプロキシで mcp-gateway の前段で TLS を終端する場合:
 
 ```bash
 MCP_GATEWAY_PUBLIC_URL=https://mcp.example.com

--- a/tasks.md
+++ b/tasks.md
@@ -174,6 +174,21 @@ Cloudflare MCP など、upstream が独自 OAuth サーバーを持つケース�
 
 ---
 
+## v0.8.0 以降の open issue
+
+### [#201](https://github.com/scottlz0310/mcp-gateway/issues/201) ローカル HTTPS (TLS) 接続サポート
+
+mcp-gateway 側スコープ（証明書の自動セットアップは Mcp-Docker#202 側）:
+
+- [x] `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH` を追加し、両方設定時に `ListenAndServeTLS` で起動（setup wizard も同様）
+- [x] 片方のみ設定・ファイル欠如・ディレクトリ指定は起動時エラー（フェイルファスト、自己署名フォールバックなし）
+- [x] `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルトスキームを TLS 有効時は `https` に
+- [x] `validateTLSConfig` のパラメータ化テストと TLS listener の疎通テストを追加
+- [x] `docs/configuration.md` に環境変数と「TLS 終端（ローカル HTTPS）」セクションを追記
+- [ ] Mcp-Docker 側（証明書マウント・`setup-tls`・health-check の `-k` トグル）との結合確認
+
+---
+
 ## 運用枠
 
 ### [#65](https://github.com/scottlz0310/mcp-gateway/issues/65) Dependency Dashboard


### PR DESCRIPTION
## 概要

Issue #201 の mcp-gateway 側スコープを実装する。環境変数で PEM 証明書・秘密鍵のパスをペアで指定すると、ゲートウェイ（初回セットアップウィザードを含む）が TLS 終端で listen する。

## 変更内容

- `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH` を追加。両方設定時に `http.Server.ListenAndServeTLS` で起動（通常モード・setup wizard の listener 起動を `listenAndServe` ヘルパーに共通化）
- 起動時のフェイルファスト検証 `validateTLSConfig`: 片方のみの設定・ファイル欠如・ディレクトリ指定は明示的なエラーで起動中断。自己署名証明書の自動生成フォールバックは行わない（ローカル証明書の準備は Mcp-Docker#202 の `setup-tls` 側の責務）
- `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルト公開 URL を TLS 有効時は `https` スキームで導出し、OAuth コールバック・ディスカバリメタデータをリスナーと整合させる
- 起動ログに `tls_enabled` を追加

## テスト

- `validateTLSConfig` のパラメータ化テスト（7 ケース）
- 自己署名証明書を生成し、`listenAndServe` 経由で実際に HTTPS リクエストを通す listener テスト
- 実機検証: フェイルファスト 3 パターン（exit=1）、setup wizard / 通常モードの HTTPS 疎通（`curl --cacert` で証明書検証込み）、PRM メタデータの `https` 導出、TLS 無効時の平文 HTTP リグレッションを確認済み

## ドキュメント

- `docs/configuration.md`: 環境変数 2 件と「TLS 終端（ローカル HTTPS）」セクションを追加
- `CHANGELOG.md` / `CHANGELOG.ja.md`: Unreleased に追加
- `tasks.md`: #201 タスクを追加

## 関連

- Closes #201 の mcp-gateway 側スコープ（Mcp-Docker 側は scottlz0310/Mcp-Docker#202）

🤖 Generated with [Claude Code](https://claude.com/claude-code)