### PR TITLE
chore(release): v0.9.0 CHANGELOG

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -3,7 +3,7 @@
 すべての変更は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に従い、
 バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に従う。
 
-## [Unreleased]
+## [0.9.0] - 2026-07-10
 
 ### 追加
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -392,7 +392,8 @@
 - `auth.Handler` から GitHub 固有の HTTP 通信を排除し、`provider.Provider` への委譲に変更。
 - `middleware` のコンテキストキーを `github_login` → `authenticated_user` に rename（内部実装のみ、外部互換維持）。
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.2...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and versioning follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,7 +438,8 @@ and versioning follows [Semantic Versioning](https://semver.org/).
 - Removed GitHub-specific HTTP calls from `auth.Handler`; delegated to `provider.Provider`.
 - Renamed middleware context key `github_login` → `authenticated_user` (internal only; external compatibility maintained).
 
-[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/mcp-gateway/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scottlz0310/mcp-gateway/compare/v0.5.2...v0.6.0

--- a/tasks.md
+++ b/tasks.md
@@ -19,12 +19,20 @@
 
 ## 現在の判断基準
 
-- 対象: 2026-07-03 時点の open issue
+- 対象: 2026-07-10 時点の open issue
 - `#126` は設計決定 issue。Phase 1 (v0.6.0) + Phase 2 (v0.7.0) で実装完了。2026-06-21 にクローズ済み。
 - `#84` は upstream OAuth delegation の親 issue。実装 chain（#113〜#118, #166, #171）+ 関連修正（#162, #175, #177, #179）すべて完了。2026-06-21 にクローズ済み。
 - `#65` は Renovate Dependency Dashboard であり、通常の実装ロードマップには含めない。open 維持。
 
 ---
+
+## v0.9.0 で完了した issue（2026-07-10 リリース）
+
+| Issue | 内容 | 対応 PR |
+|---|---|---|
+| [#201](https://github.com/scottlz0310/mcp-gateway/issues/201) | ローカル HTTPS (TLS) 終端サポート（`MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH`） | #202 |
+
+※ ペアとなるホスト側自動セットアップ（`make setup-tls`・証明書マウント・health-check の `-k` トグル・register の HTTPS 追従）は `scottlz0310/Mcp-Docker` PR #203 で実装・マージ済み。実環境での結合 E2E（`make setup-tls` → HTTPS 起動 → register）は未実施のため、リリース後の運用確認として実施する。
 
 ## v0.8.0 で完了した issue（2026-07-03 リリース）
 
@@ -171,21 +179,6 @@ Cloudflare MCP など、upstream が独自 OAuth サーバーを持つケース�
 - [x] `memUpstreamTokenStore` / `fileUpstreamTokenStore` に実装を追加
 - [x] `RefreshAfter401` で `LookupForRefresh` を使用して期限切れ access token でも refresh_token を取得可能に
 - [x] 期限切れ access token + 有効 refresh_token のシナリオテストを追加
-
----
-
-## v0.8.0 以降の open issue
-
-### [#201](https://github.com/scottlz0310/mcp-gateway/issues/201) ローカル HTTPS (TLS) 接続サポート
-
-mcp-gateway 側スコープ（証明書の自動セットアップは Mcp-Docker#202 側）:
-
-- [x] `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH` を追加し、両方設定時に `ListenAndServeTLS` で起動（setup wizard も同様）
-- [x] 片方のみ設定・ファイル欠如・ディレクトリ指定は起動時エラー（フェイルファスト、自己署名フォールバックなし）
-- [x] `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルトスキームを TLS 有効時は `https` に
-- [x] `validateTLSConfig` のパラメータ化テストと TLS listener の疎通テストを追加
-- [x] `docs/configuration.md` に環境変数と「TLS 終端（ローカル HTTPS）」セクションを追記
-- [ ] Mcp-Docker 側（証明書マウント・`setup-tls`・health-check の `-k` トグル）との結合確認
 
 ---
 


### PR DESCRIPTION
## Summary

- `[Unreleased]` セクションを `[0.9.0] - 2026-07-10` として確定（CHANGELOG.md / CHANGELOG.ja.md、両版は同期済み）
- `tasks.md` に v0.9.0 で完了した issue 一覧を追記し、#201 を open issue セクションから完了テーブルへ移動

## v0.9.0 に含まれる主な変更

| Issue | 内容 |
|---|---|
| #201 | ローカル HTTPS (TLS) 終端サポート — `MCP_GATEWAY_TLS_CERT_PATH` / `MCP_GATEWAY_TLS_KEY_PATH` 両方設定時に `ListenAndServeTLS` で起動。フェイルファスト検証・TLS 有効時の `https` デフォルトスキーム導出を含む |

その他: Go module directive の v1.26.5 更新（#199）、依存 minor 更新（#200）— chore のため CHANGELOG 記載なし（従来慣行どおり）。

## 関連

- ペアとなるホスト側自動セットアップは scottlz0310/Mcp-Docker#203 で実装・マージ済み（`make setup-tls`・証明書マウント・health-check `-k` トグル・register の HTTPS 追従）
- 実環境での結合 E2E（`make setup-tls` → HTTPS 起動 → register）は未実施のため、リリース後の運用確認として tasks.md に注記済み
- リリース後のフォローアップ: Mcp-Docker のデフォルトイメージを `:main` から `:latest` へ戻す（builtin AS は v0.8.0 で、TLS は本リリースで `:latest` に揃うため）

## リリース手順（マージ後）

1. `git tag v0.9.0 && git push origin v0.9.0`
2. release.yml が test → multi-arch イメージ build/push（`v0.9.0` / `0.9` / `latest`）→ GitHub Release 作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)