### PR TITLE
fix(server): TLS リスナーの HTTP/2 を既定で無効化し MCP_GATEWAY_ENABLE_HTTP2 で opt-in 化 (#204)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -3,6 +3,15 @@
 すべての変更は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に従い、
 バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に従う。
 
+## [Unreleased]
+
+### 修正
+
+- TLS リスナーはデフォルトで HTTP/1.1 のみを話すようになり、ALPN のオファーから HTTP/2 を除外した（[#204](https://github.com/scottlz0310/mcp-gateway/issues/204)）
+  - Node.js 26 以降の fetch クライアント（undici）は h2 をネゴシエートするが、他のリクエストが in-flight の間はボディ付きリクエストを多重化しないため、終わらない MCP Streamable HTTP の SSE GET が後続のすべての POST をクライアントタイムアウトまで飢餓させていた（mcp-resource-subscriber では `MCP error -32001: Request timed out`、ゲートウェイログでは副次的な 502 `Content-Length ... but only wrote 0 bytes` proxy error として観測）。ゲートウェイ自体の h2 → h1 中継は正常であることを検証済みで、キューイングは完全にクライアント内部で発生していた。
+  - 新環境変数 `MCP_GATEWAY_ENABLE_HTTP2`（デフォルト `false`）: 影響を受けないクライアントのみを想定するデプロイでは TLS リスナーの HTTP/2 を再有効化できる。
+  - ALPN ポリシーを固定する回帰テスト（`TestListenAndServeALPN`）を追加。
+
 ## [0.9.0] - 2026-07-10
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and versioning follows [Semantic Versioning](https://semver.org/).
 
-## [0.9.0] - 2026-07-10
+## [Unreleased]
+
+### Fixed
+
+- The TLS listener now speaks HTTP/1.1 only by default; HTTP/2 is removed from the ALPN offer ([#204](https://github.com/scottlz0310/mcp-gateway/issues/204))
+  - Node.js >= 26 fetch clients (undici) negotiate h2 but refuse to multiplex requests with a body while any other request is in flight, so the never-ending MCP Streamable HTTP SSE GET starved every subsequent POST until the client timed out (observed as `MCP error -32001: Request timed out` in mcp-resource-subscriber and cosmetic 502 `Content-Length ... but only wrote 0 bytes` proxy errors in the gateway log). The gateway's h2 -> h1 proxying itself was verified sound; the queueing happened entirely inside the client.
+  - New env var `MCP_GATEWAY_ENABLE_HTTP2` (default `false`) re-enables HTTP/2 on the TLS listener for deployments whose clients are known to be unaffected.
+  - Regression test pinning the ALPN policy (`TestListenAndServeALPN`).
+
+
 
 ### Added
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -438,6 +438,7 @@ func main() {
 		"bind_addr", cfg.bindAddr,
 		"public_url", cfg.publicURL,
 		"tls_enabled", cfg.tlsCertPath != "",
+		"http2_enabled", cfg.enableHTTP2,
 		"provider", prov.Name(),
 		"routes", len(routes),
 		"trusted_proxies", len(trustedProxies),
@@ -460,7 +461,7 @@ func main() {
 	// (fail-closed) with an explicit log so misconfiguration is obvious.
 	startInternalAPI(oauthHandler, oauthHandler)
 
-	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath); err != nil && err != http.ErrServerClosed {
+	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath, cfg.enableHTTP2); err != nil && err != http.ErrServerClosed {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}
@@ -469,8 +470,20 @@ func main() {
 // listenAndServe starts srv with TLS termination when a cert/key pair is
 // configured, and plain HTTP otherwise. Path consistency is validated at
 // startup by validateTLSConfig.
-func listenAndServe(srv *http.Server, tlsCertPath, tlsKeyPath string) error {
+//
+// The TLS listener speaks HTTP/1.1 only unless enableHTTP2 is set. Node.js
+// >= 26 clients (undici) negotiate h2 via ALPN but refuse to multiplex
+// requests with a body while any other request is in flight, so the
+// never-ending MCP Streamable HTTP SSE GET starves every subsequent POST
+// until the client times out (#204). HTTP/1.1 restores per-request pooled
+// connections, which those clients handle correctly.
+func listenAndServe(srv *http.Server, tlsCertPath, tlsKeyPath string, enableHTTP2 bool) error {
 	if tlsCertPath != "" {
+		if !enableHTTP2 {
+			protocols := new(http.Protocols)
+			protocols.SetHTTP1(true)
+			srv.Protocols = protocols
+		}
 		return srv.ListenAndServeTLS(tlsCertPath, tlsKeyPath)
 	}
 	return srv.ListenAndServe()
@@ -541,7 +554,7 @@ func runSetupWizard(cfg config, appCfg *appconfig.AppConfig, km *appconfig.KeyMa
 		IdleTimeout:       120 * time.Second,
 	}
 	slog.Info("setup wizard listening", "bind_addr", cfg.bindAddr, "tls_enabled", cfg.tlsCertPath != "")
-	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath); err != nil && err != http.ErrServerClosed {
+	if err := listenAndServe(server, cfg.tlsCertPath, cfg.tlsKeyPath, cfg.enableHTTP2); err != nil && err != http.ErrServerClosed {
 		slog.Error("setup server error", "err", err)
 	}
 }
@@ -559,8 +572,11 @@ type config struct {
 	// bindAddr is the TCP address the HTTP listener binds to (host:port).
 	bindAddr string
 	// tlsCertPath / tlsKeyPath enable TLS termination when both are set.
-	tlsCertPath            string
-	tlsKeyPath             string
+	tlsCertPath string
+	tlsKeyPath  string
+	// enableHTTP2 re-enables HTTP/2 on the TLS listener. Off by default;
+	// see listenAndServe for the rationale (#204).
+	enableHTTP2            bool
 	oauthProvider          string
 	oauthScopes            string
 	oidcIssuerURL          string
@@ -635,6 +651,7 @@ func loadConfig() config {
 		sessionTTLMin:           getEnvInt("SESSION_TTL_MIN", 10),
 		tokenCacheTTLMin:        getEnvInt("TOKEN_CACHE_TTL_MIN", 30),
 		tokenExpiresInSec:       getEnvInt("TOKEN_EXPIRES_IN_SEC", 7776000), // 90 days
+		enableHTTP2:             getEnvBool("MCP_GATEWAY_ENABLE_HTTP2", false),
 		tokenAudienceStrict:     getEnvBool("MCP_GATEWAY_TOKEN_AUDIENCE_STRICT", false),
 		githubRefreshEnabled:    getEnvBool("MCP_GATEWAY_GITHUB_REFRESH_ENABLED", false),
 		tokenStorePath:          lookupEnv("MCP_GATEWAY_TOKEN_STORE_PATH", filepath.Join(stateDir, "tokens.json")),

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -168,8 +168,9 @@ func TestListenAndServeTLS(t *testing.T) {
 	}
 }
 
-// TestListenAndServeALPN pins the HTTP/2 policy on the TLS listener: a client
-// offering h2 must fall back to HTTP/1.1 unless enableHTTP2 is set (#204).
+// TestListenAndServeALPN pins the HTTP/2 policy on the TLS listener when a
+// client offers both h2 and HTTP/1.1: HTTP/1.1 is selected unless enableHTTP2
+// is set (#204). A client offering only h2 has no common protocol by default.
 func TestListenAndServeALPN(t *testing.T) {
 	t.Parallel()
 
@@ -178,8 +179,8 @@ func TestListenAndServeALPN(t *testing.T) {
 		enableHTTP2 bool
 		wantProto   string
 	}{
-		{name: "default: h2 offer falls back to http/1.1", enableHTTP2: false, wantProto: "http/1.1"},
-		{name: "enableHTTP2: h2 negotiated", enableHTTP2: true, wantProto: "h2"},
+		{name: "default: http/1.1 selected from h2 and http/1.1", enableHTTP2: false, wantProto: "http/1.1"},
+		{name: "enableHTTP2: h2 selected from h2 and http/1.1", enableHTTP2: true, wantProto: "h2"},
 	}
 
 	for _, tc := range tests {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -123,7 +123,7 @@ func TestListenAndServeTLS(t *testing.T) {
 	if err := ln.Close(); err != nil {
 		t.Fatal(err)
 	}
-	go func() { errCh <- listenAndServe(srv, certPath, keyPath) }()
+	go func() { errCh <- listenAndServe(srv, certPath, keyPath, false) }()
 	t.Cleanup(func() { _ = srv.Close() })
 
 	certPEM, err := os.ReadFile(certPath)
@@ -165,6 +165,87 @@ func TestListenAndServeTLS(t *testing.T) {
 	}
 	if err := <-errCh; !errors.Is(err, http.ErrServerClosed) {
 		t.Errorf("listenAndServe returned %v, want http.ErrServerClosed", err)
+	}
+}
+
+// TestListenAndServeALPN pins the HTTP/2 policy on the TLS listener: a client
+// offering h2 must fall back to HTTP/1.1 unless enableHTTP2 is set (#204).
+func TestListenAndServeALPN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		enableHTTP2 bool
+		wantProto   string
+	}{
+		{name: "default: h2 offer falls back to http/1.1", enableHTTP2: false, wantProto: "http/1.1"},
+		{name: "enableHTTP2: h2 negotiated", enableHTTP2: true, wantProto: "h2"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			certPath, keyPath := writeSelfSignedCert(t, dir)
+
+			// Hold the ephemeral port until immediately before the server starts to
+			// keep the reuse race window minimal (ListenAndServeTLS re-binds Addr).
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := ln.Addr().String()
+
+			srv := &http.Server{
+				Addr: addr,
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}),
+				ReadHeaderTimeout: 5 * time.Second,
+			}
+			if err := ln.Close(); err != nil {
+				t.Fatal(err)
+			}
+			errCh := make(chan error, 1)
+			go func() { errCh <- listenAndServe(srv, certPath, keyPath, tc.enableHTTP2) }()
+			t.Cleanup(func() { _ = srv.Close() })
+
+			certPEM, err := os.ReadFile(certPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(certPEM) {
+				t.Fatal("failed to add test certificate to pool")
+			}
+			tlsCfg := &tls.Config{
+				RootCAs:    pool,
+				NextProtos: []string{"h2", "http/1.1"},
+			}
+
+			var conn *tls.Conn
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				conn, err = tls.Dial("tcp", addr, tlsCfg)
+				if err == nil || time.Now().After(deadline) {
+					break
+				}
+				select {
+				case srvErr := <-errCh:
+					t.Fatalf("server exited before accepting connections: %v", srvErr)
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
+			if err != nil {
+				t.Fatalf("TLS dial failed: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			if got := conn.ConnectionState().NegotiatedProtocol; got != tc.wantProto {
+				t.Errorf("negotiated ALPN protocol: got %q, want %q", got, tc.wantProto)
+			}
+		})
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,7 @@ OAuth クライアントシークレットは意図的に特別扱いです。`c
 | `MCP_GATEWAY_BIND_ADDR` | `127.0.0.1:<port>` | TCP リスナーアドレス。Docker でポートを公開する場合は `0.0.0.0:<port>` を使用。 |
 | `MCP_GATEWAY_TLS_CERT_PATH` | なし | TLS サーバー証明書（PEM）のパス。`MCP_GATEWAY_TLS_KEY_PATH` とペアで設定すると HTTPS で listen する。片方のみの設定やファイル欠如は起動エラー（フェイルファスト）。 |
 | `MCP_GATEWAY_TLS_KEY_PATH` | なし | TLS 秘密鍵（PEM）のパス。`MCP_GATEWAY_TLS_CERT_PATH` とペアで設定する。 |
+| `MCP_GATEWAY_ENABLE_HTTP2` | `false` | TLS リスナーで HTTP/2（ALPN `h2`）を有効化する。デフォルトは HTTP/1.1 のみ（[TLS 終端](#tls-終端ローカル-https)参照）。 |
 | `MCP_GATEWAY_PORT` | `8080` | `public_url` と `bind_addr` のデフォルト導出に使用するポート。 |
 | `MCP_GATEWAY_BASE_URL` | なし | `MCP_GATEWAY_PUBLIC_URL` の非推奨エイリアス。設定されると起動時警告を出力。 |
 | `MCP_GATEWAY_TRUSTED_PROXIES` | なし | `X-Forwarded-*` ヘッダーを信頼する直前のリバースプロキシの CIDR リスト（カンマ区切り）。 |
@@ -364,6 +365,7 @@ MCP_GATEWAY_PUBLIC_URL=https://localhost:8080
 - 両方が設定されている場合のみ HTTPS で listen します。片方のみの設定、またはファイルが存在しない場合は起動時にエラー終了します（フェイルファスト）。
 - 自己署名証明書の自動生成は行いません。ローカル開発では [mkcert](https://github.com/FiloSottile/mkcert) 等で信頼済み証明書を生成してください（Docker 運用でのセットアップ自動化は Mcp-Docker 側で提供）。
 - `MCP_GATEWAY_PUBLIC_URL` 未設定時のデフォルトスキームは、TLS 有効時は自動的に `https` になります。
+- TLS リスナーは**デフォルトで HTTP/1.1 のみ**を話します（HTTP/2 は ALPN から除外）。Node.js 26 以降の fetch クライアント（undici）は h2 をネゴシエートしますが、他のリクエストが in-flight の間はボディ付きリクエストを多重化しないため、MCP Streamable HTTP の長寿命 SSE GET が後続の POST を飢餓させます（[#204](https://github.com/scottlz0310/mcp-gateway/issues/204)）。この問題の影響を受けないクライアントのみを想定する場合は `MCP_GATEWAY_ENABLE_HTTP2=true` で HTTP/2 を再有効化できます。
 
 ## リバースプロキシヘッダー
 

--- a/tasks.md
+++ b/tasks.md
@@ -26,6 +26,14 @@
 
 ---
 
+## 対応中の issue
+
+| Issue | 内容 | 対応 PR |
+|---|---|---|
+| [#204](https://github.com/scottlz0310/mcp-gateway/issues/204) | thread-owl の Streamable HTTP 購読が reverse proxy 経由で 502 / timeout。原因は Node 26（undici）の h2 クライアント側キューイング → TLS リスナーの HTTP/2 を既定無効化（`MCP_GATEWAY_ENABLE_HTTP2` で opt-in） | #205 |
+
+※ #204 のクローズは、リリース後に subscriber / Squirrel Notifier での実環境 E2E（受け入れ条件の `enqueue_review` 通知受信まで）を確認してから行う。
+
 ## v0.9.0 で完了した issue（2026-07-10 リリース）
 
 | Issue | 内容 | 対応 PR |


### PR DESCRIPTION
## 概要

TLS リスナーを既定で HTTP/1.1 のみとし、ALPN のオファーから `h2` を除外する。新環境変数 `MCP_GATEWAY_ENABLE_HTTP2`（デフォルト `false`）で HTTP/2 を再有効化できる。

Refs #204（調査記録: [調査結果コメント](https://github.com/scottlz0310/mcp-gateway/issues/204#issuecomment-4949068726)）

## 根本原因（#204 調査結果の要約）

- v0.9.0 の TLS 終端で ALPN により HTTP/2 が自動有効化（Go `ListenAndServeTLS` のデフォルト）
- Node.js ≥ 26 の fetch（undici 8.x）はデフォルトで h2 をネゴシエートするが、`client-h2.js` の `busy()` が「stream ボディのリクエストは他が in-flight の間 dispatch しない」ため、終わらない MCP Streamable HTTP の SSE GET が後続のすべての POST をクライアント内部で飢餓させる（60 秒 = MCP TS SDK のデフォルト request timeout）
- ゲートウェイの h2 → h1 中継自体は正常（`node:http2` 生クライアントによる対照テストで実証済み）。ログの 502 は teardown の残骸で、原因ではなく結果

## 変更内容

- `cmd/server/main.go`
  - `listenAndServe`: TLS 時、`enableHTTP2` が false なら `http.Protocols` で HTTP/1.1 のみに制限（Go 1.24+ API）
  - `MCP_GATEWAY_ENABLE_HTTP2`（デフォルト `false`）を config に追加、起動ログに `http2_enabled` を出力
- `cmd/server/main_test.go`: ALPN ポリシーを固定するパラメータ化回帰テスト `TestListenAndServeALPN`（h2 オファー → 既定で `http/1.1` にフォールバック / opt-in で `h2`）
- `docs/configuration.md` / `CHANGELOG.md` / `CHANGELOG.ja.md` 更新

## 検証（実バイナリ + 実クライアント）

修正版バイナリをローカルで TLS 起動し、モック Streamable HTTP upstream への `auth=none` ルートに対して、故障を起こした実クライアント（Node v26.4.0 の素の fetch）で initialize → initialized → GET(SSE) → tools/list POST を実行:

**既定（`http2_enabled=false`）— 修正後の挙動:**

```
+0.02s [conn] alpn=http/1.1
+0.04s GET status 200 (SSE open)
+2.04s sending tools/list POST ...
+2.06s tools/list status 200   ← GET を開いたまま 20ms で応答
```

**`MCP_GATEWAY_ENABLE_HTTP2=true`（opt-in）— #204 の故障が再現（= フラグが実際に効いている）:**

```
+0.03s [conn] alpn=h2
+0.04s GET status 200 (SSE open)
+2.04s sending tools/list POST ...
+22.06s tools/list ERROR: TimeoutError   ← undici 内部で飢餓
```

**プローブ:**

- `MCP_GATEWAY_ENABLE_HTTP2=banana`（不正値）→ 安全側の `http2_enabled=false` で正常起動
- h2 を offer しない curl（http/1.1 のみ）→ 従来どおり 200
- 非 TLS パスは変更なし（`tlsCertPath == ""` の分岐は未変更）

## 受け入れ条件との対応

- Gateway 経由の initialize → tool call → long-lived GET が 60 秒制約なく動作（上記ログ）
- `Content-Length ... but only wrote 0 bytes` / 502 は発生原因（クライアント内キューイング）ごと解消
- subscriber / Squirrel Notifier での実環境 E2E は、本 PR のリリース後（または local build の差し替え後）に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
